### PR TITLE
Transfer Elsa.jl

### DIFF
--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -1,0 +1,358 @@
+#######################################################################
+# Kernel Polynomial Method : momenta
+#######################################################################
+struct MomentaKPM{T,B<:Tuple}
+    μlist::Vector{T}
+    bandbracket::B
+end
+struct KPMBuilder{A,H<:AbstractMatrix,T,K,B}
+    A::A
+    h::H
+    bandbracket::Tuple{B,B}
+    order::Int
+    missingket::Bool
+    μlist::Vector{T}
+    ket::K
+    ket0::K
+    ket1::K
+end
+
+function KPMBuilder(h::AbstractMatrix{Tv}, A = _defaultA(Tv); ket = missing, order = 10, bandrange = missing) where {Tv}
+    eh = eltype(eltype(h))
+    aA = eltype(eltype(A))
+    μlist = zeros(promote_type(eh, aA), order + 1)
+    bandbracket = bandbracketKPM(h, bandrange)
+    missingket = ket === missing
+    ket´ = missingket ? ketundef(h) : ket
+    iscompatibleket(h, ket´) || throw(ArgumentError("ket is incompatible with Hamiltonian"))
+    builder = KPMBuilder(A, h, bandbracket, order, missingket,
+        μlist, ket´, similar(ket´), similar(ket´))
+    return builder
+end
+
+ketundef(h::AbstractMatrix{T}) where {T<:Number} =
+    Vector{T}(undef, size(h, 2))
+ketundef(h::AbstractMatrix{S}) where {N,T,S<:SMatrix{N,N,T}} =
+    Vector{SVector{N,T}}(undef, size(h, 2))
+
+iscompatibleket(h::AbstractMatrix{T1}, ket::AbstractArray{T2}) where {T1,T2} =
+    _iscompatibleket(T1, T2)
+_iscompatibleket(::Type{T1}, ::Type{T2}) where {T1<:Real, T2<:Real} = true
+_iscompatibleket(::Type{T1}, ::Type{T2}) where {T1<:Number, T2<:Complex} = true
+_iscompatibleket(::Type{S1}, ::Type{S2}) where {N, S1<:SMatrix{N,N}, S2<:SVector{N}} =
+    _iscompatibleket(eltype(S1), eltype(S2))
+_iscompatibleket(::Type{S1}, ::Type{S2}) where {N, S1<:SMatrix{N,N}, S2<:SMatrix{N}} =
+    _iscompatibleket(eltype(S1), eltype(S2))
+_iscompatibleket(t1, t2) = false
+
+function matrixKPM(h::Hamiltonian{<:Lattice,L}) where {L}
+    iszero(L) ||
+        throw(ArgumentError("Hamiltonian is defined on an infinite lattice. Convert it to a matrix first using `bloch(h, φs...)`"))
+    return bloch(h)
+end
+
+matrixKPM(h::AbstractMatrix) = h
+matrixKPM(A::UniformScaling) = A
+
+"""
+    momentaKPM(h::AbstractMatrix, A = I; ket = missing, order = 10, randomkets = 1, bandrange = missing)
+
+Compute the Kernel Polynomial Method (KPM) momenta `μ_n = ⟨ket|T_n(h) A|ket⟩/⟨ket|ket⟩` where `T_n(x)`
+is the Chebyshev polynomial of order `n`, for a given `ket::AbstractVector`, hamiltonian `h`, and
+observable `A`. If `ket` is `missing`, momenta are computed by means of a stochastic trace
+`μ_n = Tr[A T_n(h)] ≈ ∑ₐ⟨a|A T_n(h)|a⟩/N` over `N = randomkets` normalized random `|a⟩`.
+Furthermore, the trace over a specific set of kets can also be computed; in this case
+`ket::AbstractMatrix` must be a matrix where the columns are the kets involved in the calculation.
+
+The order of the Chebyshev expansion is `order`. The `bandbrange = (ϵmin, ϵmax)` should completely encompass
+the full bandwidth of `hamiltonian`. If `missing` it is computed automatically using `ArnoldiMethods` (must be loaded).
+
+# Example
+```
+julia> h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(region = RegionPresets.sphere(10));
+
+julia> momentaKPM(bloch(h), bandrange = (-6,6))
+Quantica.MomentaKPM{Float64}([0.9594929736144973, -0.005881595972403821, -0.4933354572913581, 0.00359537502632597, 0.09759451291347333, -0.0008081453185250322, -0.00896262538765363, 0.00048205637037715177, -0.0003705198310034668, 9.64901673962623e-20, 9.110915988898614e-18], (0.0, 6.030150753768845))
+```
+"""
+momentaKPM(h::Hamiltonian, A = _defaultA(eltype(h)); kw...) = momentaKPM(matrixKPM(h), matrixKPM(A); kw...)
+
+function momentaKPM(h::AbstractMatrix, A = _defaultA(eltype(h)); randomkets = 1, kw...)
+   b = KPMBuilder(h, A; kw...)
+    if b.missingket
+        pmeter = Progress(b.order * randomkets, "Averaging moments: ")
+        for n in 1:randomkets
+            randomize!(b.ket)
+            addmomentaKPM!(b, pmeter)
+        end
+        b.μlist ./= randomkets
+    else
+        pmeter = Progress(b.order, "Computing moments: ")
+        addmomentaKPM!(b, pmeter)
+    end
+    return MomentaKPM(jackson!(b.μlist), b.bandbracket)
+end
+
+_defaultA(::Type{T}) where {T<:Number} = one(T) * I
+_defaultA(::Type{S}) where {N,T,S<:SMatrix{N,N,T}} = one(T) * I
+
+# This iterates bras <psi_n| = <psi_0|AT_n(h) instead of kets (faster CSC multiplication)
+# In practice we iterate their conjugate |psi_n> = T_n(h') A'|psi_0>, and do the projection
+# onto the start ket, |psi_0>
+function addmomentaKPM!(b::KPMBuilder{<:AbstractMatrix,<:AbstractSparseMatrix}, pmeter)
+    μlist, ket, ket0, ket1 = b.μlist, b.ket, b.ket0, b.ket1
+    h´, A´, bandbracket = b.h', b.A', b.bandbracket
+    order = length(μlist) - 1
+    fill!(ket0, zero(eltype(ket0)))
+    mul!(ket1, A´, ket)
+    μlist[1] += proj(ket1, ket)
+    ProgressMeter.next!(pmeter; showvalues = ())
+    for n in 2:(order+1)
+        ProgressMeter.next!(pmeter; showvalues = ())
+        μ = iterateKPM!(ket0, ket1, ket, h´, bandbracket)
+        μlist[n] += μ
+        n + 1 > order + 1 && break
+        ket0, ket1 = ket1, ket0
+    end
+    return μlist
+end
+
+function iterateKPM!(ket0::A, ket1::A, kini::A, adjh::Adjoint, (center, halfwidth)) where {S,A<:AbstractArray{S}}
+    h = adjh.parent
+    nzv = nonzeros(h)
+    rv = rowvals(h)
+    T = eltype(S)
+    μ = zero(T)
+    α = T(-2 * center / halfwidth)
+    β = T(2 / halfwidth)
+    for k in 1:size(ket0, 2)
+        for col in 1:size(h, 2)
+            @inbounds begin
+                tmp = α * ket1[col, k] - ket0[col, k]
+                for ptr in nzrange(h, col)
+                    tmp += β * adjoint(nzv[ptr]) * ket1[rv[ptr],k]
+                end
+                ket0[col, k] = tmp
+                μ += dot(tmp, kini[col, k])
+            end
+        end
+    end
+    return μ
+end
+
+function addmomentaKPM!(b::KPMBuilder{<:UniformScaling, <:AbstractSparseMatrix}, pmeter)
+    μlist, ket, ket0, ket1 = b.μlist, b.ket, b.ket0, b.ket1
+    h´, A, bandbracket = b.h', b.A, b.bandbracket
+    order = length(μlist) - 1
+    fill!(ket0, zero(eltype(ket0)))
+    ket1 .= ket
+    for n in 1:2:(order+1)
+        ProgressMeter.next!(pmeter; showvalues = ())
+        ProgressMeter.next!(pmeter; showvalues = ()) # twice because of 2-step
+        μ, μ´ = iterateKPM!(ket0, ket1, h´, bandbracket)
+        μlist[n] += μ
+        n + 1 > order + 1 && break
+        μlist[n + 1] += μ´
+        ket0, ket1 = ket1, ket0
+    end
+    A.λ ≈ 1 || (μlist .*= A.λ)
+    return μlist
+end
+
+function iterateKPM!(ket0::A, ket1::A, adjh::Adjoint, (center, halfwidth)) where {S,A<:AbstractArray{S}}
+    h = adjh.parent
+    nzv = nonzeros(h)
+    rv = rowvals(h)
+    T = eltype(S)
+    μ = μ´ = zero(T)
+    α = T(-2 * center / halfwidth)
+    β = T(2 / halfwidth)
+    for k in 1:size(ket0, 2)
+        for col in 1:size(h, 2)
+            @inbounds begin
+                k1 = ket1[col, k]
+                tmp = α * k1 - ket0[col, k]
+                for ptr in nzrange(h, col)
+                    tmp += β * adjoint(nzv[ptr]) * ket1[rv[ptr],k]
+                end
+                ket0[col, k] = tmp
+                μ  += dot(k1, k1)
+                μ´ += dot(tmp, k1)
+            end
+        end
+    end
+    return μ, μ´
+end
+
+# This is equivalent to tr(ket1'*ket2) for matrices, and ket1'*ket2 for vectors
+proj(ket1, ket2) = dot(vec(ket1), vec(ket2))
+
+function randomize!(v::AbstractVector{T}) where {T}
+    v .= _randomize.(v)
+    normalize!(v)
+    return v
+end
+@inline _randomize(v::T) where {T<:Real} = randn(R)
+@inline _randomize(v::T) where {R,T<:Complex{R}} = randn(R) + im * randn(R)
+@inline _randomize(v::T) where {T<:SArray} = _randomize.(v)
+
+function jackson!(μ::AbstractVector)
+    order = length(μ) - 1
+    @inbounds for n in eachindex(μ)
+        μ[n] *= ((order - n + 1) * cos(π * n / (order + 1)) +
+                sin(π * n / (order + 1)) * cot(π / (order + 1))) / (order + 1)
+    end
+    return μ
+end
+
+function bandbracketKPM(h, ::Missing)
+    @warn "Computing spectrum bounds... Consider using the `bandrange` kwargs for faster performance."
+    bandbracketKPM(h, bandrangeKPM(h))
+end
+bandbracketKPM(h, (ϵmin, ϵmax)::Tuple{T,T}, pad = float(T)(0.01)) where {T} = ((ϵmax + ϵmin) / 2, (ϵmax - ϵmin) / (2 - pad))
+
+function bandrangeKPM(h::AbstractMatrix{T}) where {T}
+    checkloaded(:ArnoldiMethod)
+    R = real(T)
+    decompl, _ = Main.ArnoldiMethod.partialschur(h, nev=1, tol=1e-4, which = Main.ArnoldiMethod.LR());
+    decomps, _ = Main.ArnoldiMethod.partialschur(h, nev=1, tol=1e-4, which = Main.ArnoldiMethod.SR());
+    ϵmax = R(real(decompl.eigenvalues[1]))
+    ϵmin = R(real(decomps.eigenvalues[1]))
+    @warn  "Computed bandrange = ($ϵmin, $ϵmax)"
+    return (ϵmin, ϵmax)
+end
+
+#######################################################################
+# Kernel Polynomial Method : observables
+#######################################################################
+"""
+    dosKPM(h::AbstractMatrix; resolution = 2, kw...)
+
+Compute, using the Kernel Polynomial Method (KPM), the local density of states `ρ(ϵ) =
+⟨ket|δ(ϵ-h)|ket⟩/⟨ket|ket⟩` for a given `ket::AbstractVector` and hamiltonian `h`, or the
+global density of states `ρ(ϵ) = Tr[δ(ϵ-h)]` if `ket` is `missing`.
+
+If `ket` is an `AbstractMatrix` it evaluates the trace over the set of kets in `ket` (see
+`momentaKPM` and its options `kw` for further details). The result is a tuple of energy
+points `xk::Vector` and real `ρ::Vector` values (any imaginary part in ρ is dropped), where
+the number of energy points `xk` is `order * resolution`, rounded to the closest integer.
+
+    dosKPM(μ::MomentaKPM; resolution = 2)
+
+Same as above with momenta `μ` as input.
+
+    dosKPM(h::Hamiltonian; kw...)
+
+Equivalent to `dosKPM(bloch(h); kw...)` for finite hamiltonians (zero dimensional).
+"""
+dosKPM(h::AbstractMatrix; resolution = 2, kw...) =
+    dosKPM(momentaKPM(h; kw...), resolution = resolution)
+
+dosKPM(μ::MomentaKPM; resolution = 2) = real.(densityKPM(μ; resolution = resolution))
+
+dosKPM(h::Hamiltonian; kw...) = dosKPM(matrixKPM(h); kw...)
+
+"""
+    densityKPM(h::AbstractMatrix, A; resolution = 2, kw...)
+
+Compute, using the Kernel Polynomial Method (KPM), the local spectral density of an operator
+`A` `ρ_A(ϵ) = ⟨ket|A δ(ϵ-h)|ket⟩/⟨ket|ket⟩` for a given `ket::AbstractVector` and
+hamiltonian `h`, or the global spectral density `ρ_A(ϵ) = Tr[A δ(ϵ-h)]` if `ket` is
+`missing`. If `ket` is an `AbstractMatrix` it evaluates the trace over the set of kets in
+`ket` (see `momentaKPM` and its options `kw` for further details). A tuple of energy points
+`xk` and `ρ_A` values is returned where the number of energy points `xk` is `order *
+resolution`, rounded to the closest integer.
+
+    densityKPM(momenta::MomentaKPM; resolution = 2)
+
+Same as above with the KPM momenta as input (see `momentaKPM`).
+
+    densityKPM(h::Hamiltonian, A::Hamiltonian; kw...)
+
+Equivalent to `densityKPM(bloch(h), bloch(A); kw...)` for finite Hamiltonians (zero dimensional).
+"""
+densityKPM(h::AbstractMatrix, A; resolution = 2, kw...) =
+    densityKPM(momentaKPM(h, A; kw...); resolution = resolution)
+
+densityKPM(h::Hamiltonian, A::Hamiltonian; kw...) = densityKPM(matrixKPM(h), matrixKPM(A); kw...)
+
+function densityKPM(momenta::MomentaKPM{T}; resolution = 2) where {T}
+    checkloaded(:FFTW)
+    (center, halfwidth) = momenta.bandbracket
+    numpoints = round(Int, length(momenta.μlist) * resolution)
+    ρlist = zeros(T, numpoints)
+    copyto!(ρlist, momenta.μlist)
+    Main.FFTW.r2r!(ρlist, Main.FFTW.REDFT01, 1)  # DCT-III in FFTW
+    xk = [cos(π * (k + 0.5) / numpoints) for k in 0:numpoints - 1]
+    @. ρlist = center + halfwidth * ρlist / (π * sqrt(1.0 - xk^2))
+    @. xk = center + halfwidth * xk
+    return xk, ρlist
+end
+
+"""
+    averageKPM(h::AbstractMatrix, A; kBT = 0, Ef = 0, kw...)
+
+Compute, using the Kernel Polynomial Method (KPM), the thermal expectation value `<A> = Σ_k
+f(E_k) <k|A|k> =  ∫dE f(E) Tr [A δ(E-H)] = Tr [A f(H)]` for a given hermitian operator `A`
+and a hamiltonian `h` (see `momentaKPM` and its options `kw` for further details).
+`f(E)` is the Fermi-Dirac distribution function, `kBT` is the temperature in energy
+units and `Ef` the Fermi energy.
+
+    averageKPM(μ::MomentaKPM, A; kBT = 0, Ef = 0)
+
+Same as above with the KPM momenta as input (see `momentaKPM`).
+
+    averageKPM(h::Hamiltonian, A::Hamiltonian; kw...)
+
+Equivalent to `averageKPM(bloch(h), bloch(A); kw...)` for finite Hamiltonians (zero
+dimensional).
+"""
+averageKPM(h::AbstractMatrix, A; kBT = 0, Ef = 0, kw...) = averageKPM(momentaKPM(h, A; kw...); kBT = kBT, Ef = Ef)
+
+averageKPM(h::Hamiltonian, A::Hamiltonian; kw...) = averageKPM(matrixKPM(h), matrixKPM(A); kw...)
+
+function averageKPM(momenta::MomentaKPM{T}; kBT = 0.0, Ef = 0.0) where {T}
+    (center, halfwidth) = momenta.bandbracket
+    order = length(momenta.μlist) - 1
+    # if !iszero(kBT)
+    #     @warn "Finite temperature requires numerical evaluation of the integrals"
+    #     checkloaded(:QuadGK)
+    # end
+    average = sum(n -> momenta.μlist[n + 1] * fermicheby(n, Ef, kBT, center, halfwidth), 0:order)
+    return average
+end
+
+# Pending issue: Unexpected behaviour with center != 0.
+function fermicheby(n, Ef, kBT, center, halfwidth)
+    kBT´ = kBT / halfwidth;
+    Ef´ = (Ef - center) / halfwidth;
+    T = typeof(Ef´)
+    if kBT´ == 0
+        int = n == 0 ? 0.5+asin(Ef´)/π : -2.0*sin(n*acos(Ef´))/(n*π)
+    else
+        throw(error("Finite temperature not yet implemented"))
+        # η = 1e-10
+        # int = Main.QuadGK.quadgk(E´ -> _intfermi(n, E´, Ef´, kBT´), -1.0+η, 1.0-η, atol= 1e-10, rtol=1e-10)[1]
+    end
+    return T(int)
+end
+
+_intfermi(n, E´, Ef´, kBT´) = fermifun(E´, Ef´, kBT´) * 2/(π*(1-E´^2)^(1/2)) * chebypol(n, E´) / (1+(n == 0 ? 1 : 0))
+
+fermifun(E´, Ef´, kBT´) = kBT´ == 0 ? (E´<Ef´ ? 1.0 : 0.0) : (1/(1+exp((E´-Ef´)/(kBT´))))
+
+function chebypol(m::Int, x::T) where {T<:Number}
+    cheby0 = one(T)
+    cheby1 = x
+    if m == 0
+        chebym = cheby0
+    elseif m == 1
+        chebym = cheby1
+    else
+        for i in 2:m
+            chebym = 2x * cheby1 - cheby0
+            cheby0, cheby1 = cheby1, chebym
+        end
+    end
+    return chebym
+end

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -1,5 +1,42 @@
 module Quantica
 
-# Write your package code here.
+using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
+      ProgressMeter, LinearMaps, Random
+
+using SparseArrays: getcolptr, AbstractSparseMatrix
+
+export sublat, bravais, lattice, dims, sites, supercell, unitcell,
+       hopping, onsite, onsiteselector, hoppingselector, onsite!, hopping!,
+       hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
+       flatten, wrap, transform!, combine,
+       spectrum, bandstructure, marchingmesh, defaultmethod, bands, vertices,
+       energies, states,
+       momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM
+
+export LatticePresets, RegionPresets, HamiltonianPresets
+
+export LinearAlgebraPackage, ArpackPackage, KrylovKitPackage
+
+export @SMatrix, @SVector, SMatrix, SVector
+
+export ishermitian, I
+
+const NameType = Symbol
+const nametype = Symbol
+
+const TOOMANYITERS = 10^8
+
+include("iterators.jl")
+include("presets.jl")
+include("lattice.jl")
+include("model.jl")
+include("hamiltonian.jl")
+include("parametric.jl")
+include("mesh.jl")
+include("diagonalizer.jl")
+include("bandstructure.jl")
+include("KPM.jl")
+include("convert.jl")
+include("tools.jl")
 
 end

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -1,0 +1,273 @@
+#######################################################################
+# Spectrum
+#######################################################################
+struct Spectrum{E,T,A<:AbstractMatrix{T}}
+    energies::E
+    states::A
+end
+
+"""
+    spectrum(h; method = defaultmethod(h))
+
+Compute the spectrum of a 0D Hamiltonian `h` (or alternatively of the bounded unit cell of a
+finite dimensional `h`) using one of the following `method`s
+
+    method                    diagonalization function
+    --------------------------------------------------------------
+    LinearAlgebraPackage()     LinearAlgebra.eigen!
+    ArpackPackage()            Arpack.eigs (must be `using Arpack`)
+
+The energies and eigenstates in the resulting `s::Spectrum` object can be accessed with
+`energies(s)` and `states(s)`
+
+# See also
+    `energies`, `states`, `bandstructure`
+
+"""
+function spectrum(h; method = defaultmethod(h))
+    matrix = similarmatrix(h, method)
+    bloch!(matrix, h)
+    (ϵk, ψk) = diagonalize(matrix, method)
+    return Spectrum(ϵk, ψk)
+end
+
+"""
+    energies(s::Spectrum)
+
+Return the energies of `s` as a `Vector`
+
+# See also
+    `spectrum`, `states`
+"""
+energies(s::Spectrum) = s.energies
+
+"""
+    states(s::Spectrum)
+
+Return the states of `s` as the columns of a `Matrix`
+
+# See also
+    `spectrum`, `energies`
+"""
+states(s::Spectrum) = s.states
+
+#######################################################################
+# Bandstructure
+#######################################################################
+struct Band{M,A<:AbstractVector{M},MD<:Mesh,S<:AbstractArray}
+    mesh::MD        # Mesh with missing vertices removed
+    simplices::S    # Tuples of indices of mesh vertices that define mesh simplices
+    states::A       # Must be resizeable container to build & refine band
+    dimstates::Int  # Needed to extract the state at a given vertex from vector `states`
+end
+
+function Band(mesh::Mesh{D}, states::AbstractVector{M}, dimstates::Int) where {M,D}
+    simps = simplices(mesh, Val(D))
+    return Band(mesh, simps, states, dimstates)
+end
+
+struct Bandstructure{D,M,B<:Band{M},MD<:Mesh{D}}   # D is dimension of parameter space
+    bands::Vector{B}
+    kmesh::MD
+end
+
+function Base.show(io::IO, b::Bandstructure{D,M}) where {D,M}
+    ioindent = IOContext(io, :indent => string("  "))
+    print(io,
+"Bandstructure: bands for a $(D)D hamiltonian
+  Bands        : $(length(b.bands))
+  Element type : $(displayelements(M))")
+    print(ioindent, "\n", b.kmesh)
+end
+
+# API #
+"""
+    bands(bs::Bandstructure)
+
+Return a vector of all the `Band`s in `bs`.
+"""
+bands(bs::Bandstructure) = bs.bands
+
+"""
+    vertices(bs::Bandstructure, i)
+
+Return the vertices `(k..., ϵ)` of the i-th band in `bs`, in the form of a
+`Vector{SVector{L+1}}`, where `L` is the lattice dimension.
+"""
+vertices(bs::Bandstructure, i) = vertices(bands(bs)[i])
+
+vertices(b::Band) = vertices(b.mesh)
+
+"""
+    states(bs::Bandstructure, i)
+
+Return the states of each vertex of the i-th band in `bs`, in the form of a `Matrix` of size
+`(nψ, nk)`, where `nψ` is the length of each state vector, and `nk` the number of vertices.
+"""
+states(bs::Bandstructure, i) = states(bands(bs)[i])
+
+states(b::Band) = reshape(b.states, b.dimstates)
+
+#######################################################################
+# bandstructure
+#######################################################################
+"""
+    bandstructure(h::Hamiltonian, mesh::Mesh; minprojection = 0.5, method = defaultmethod(h))
+
+Compute the bandstructure of Bloch Hamiltonian `bloch(h, ϕs...)` with `ϕs` evaluated on the
+vertices of `mesh`. It is assumed that `h` is hermitian.
+
+The option `minprojection` determines the minimum projection between eigenstates to connect
+them into a common subband. The option `method` is chosen automatically if unspecified, and
+can be one of the following
+
+    method                    diagonalization function
+    --------------------------------------------------------------
+    LinearAlgebraPackage()     LinearAlgebra.eigen!
+    ArpackPackage()            Arpack.eigs (must be `using Arpack`)
+
+Options passed to the `method` will be forwarded to the diagonalization function. For example,
+`method = ArpackPackage(nev = 8, sigma = 1im)` will use `Arpack.eigs(matrix; nev = 8,
+sigma = 1im)` to compute the bandstructure.
+
+    bandstructure(h::Hamiltonian; resolution = 13, shift = missing, kw...)
+
+Same as above with a  uniform `mesh = marchingmesh(h; npoints = resolution, shift = shift)`
+of marching tetrahedra (generalized to the lattice dimensions of the Hamiltonian). Note that
+`resolution` denotes the number of points along each Bloch axis, including endpoints (can be
+a tuple for axis-dependent points).
+
+# Example
+```
+julia> h = LatticePresets.honeycomb() |> unitcell(3) |> hamiltonian(hopping(-1, range = 1/√3));
+
+julia> bandstructure(h; resolution = 25, method = LinearAlgebraPackage())
+Bandstructure: bands for a 2D hamiltonian
+  Bands        : 8
+  Element type : scalar (Complex{Float64})
+  Mesh{2}: mesh of a 2-dimensional manifold
+    Vertices   : 625
+    Edges      : 3552
+```
+
+# See also
+    marchingmesh
+"""
+function bandstructure(h::Hamiltonian{<:Any,L,M}; resolution = 13, shift = missing, kw...) where {L,M}
+    checkfinitedim(h)
+    mesh = marchingmesh(h; npoints = resolution, shift = shift)
+    return bandstructure(h,  mesh; kw...)
+end
+
+function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
+    checkfinitedim(h)
+    ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
+    d = diagonalizer(h, mesh, method, minprojection)
+    matrix = similarmatrix(h, method)
+    return bandstructure!(matrix, h, mesh, d)
+end
+
+function bandstructure!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,<:Any,M}, mesh::MD, d::Diagonalizer) where {M,D,T,MD<:Mesh{D,T}}
+    nϵ = 0                           # Temporary, to be reassigned
+    ϵks = Matrix{T}(undef, 0, 0)     # Temporary, to be reassigned
+    ψks = Array{M,3}(undef, 0, 0, 0) # Temporary, to be reassigned
+
+    dimh = size(h, 1)
+    nk = nvertices(mesh)
+    # function to apply to eigenvalues when building bands (depends on momenta type)
+    by = _maybereal(T)
+
+    p = Progress(nk, "Step 1/2 - Diagonalising: ")
+    for (n, ϕs) in enumerate(vertices(mesh))
+        bloch!(matrix, h, ϕs)
+        # (ϵk, ψk) = diagonalize(Hermitian(matrix), d)  ## This is faster (!)
+        (ϵk, ψk) = diagonalize(matrix, d.method)
+        resolve_degeneracies!(ϵk, ψk, ϕs, matrix, d.codiag)
+        if n == 1  # With first vertex can now know the number of eigenvalues... Reassign
+            nϵ = size(ϵk, 1)
+            ϵks = Matrix{T}(undef, nϵ, nk)
+            ψks = Array{M,3}(undef, dimh, nϵ, nk)
+        end
+        copyslice!(ϵks, CartesianIndices((1:nϵ, n:n)),
+                   ϵk,  CartesianIndices((1:nϵ,)), by)
+        copyslice!(ψks, CartesianIndices((1:dimh, 1:nϵ, n:n)),
+                   ψk,  CartesianIndices((1:dimh, 1:nϵ)), identity)
+        ProgressMeter.next!(p; showvalues = ())
+    end
+
+    p = Progress(nϵ * nk, "Step 2/2 - Connecting bands: ")
+    pcounter = 0
+    bands = Band{M,Vector{M},Mesh{D+1,T,Vector{SVector{D+1,T}}},Vector{NTuple{D+1,Int}}}[]
+    vertindices = zeros(Int, nϵ, nk) # 0 == unclassified, -1 == different band, > 0 vertex index
+    pending = CartesianIndex{2}[]
+    sizehint!(pending, nk)
+    while true
+        src = findfirst(iszero, vertindices)
+        src === nothing && break
+        resize!(pending, 1)
+        pending[1] = src # source CartesianIndex for band search
+        band = extractband(mesh, pending, ϵks, ψks, vertindices, d.minprojection)
+        nverts = nvertices(band.mesh)
+        nverts > D && push!(bands, band) # avoid bands with no simplices
+        pcounter += nverts
+        ProgressMeter.update!(p, pcounter; showvalues = ())
+    end
+    return Bandstructure(bands, mesh)
+end
+
+_maybereal(::Type{<:Complex}) = identity
+_maybereal(::Type{<:Real}) = real
+
+function extractband(kmesh::Mesh{D,T}, pending, ϵks::AbstractArray{T}, ψks::AbstractArray{M}, vertindices, minprojection) where {D,T,M}
+    dimh, nϵ, nk = size(ψks)
+    kverts = vertices(kmesh)
+    states = eltype(ψks)[]
+    sizehint!(states, nk * dimh)
+    verts = SVector{D+1,T}[]
+    sizehint!(verts, nk)
+    adjmat = SparseMatrixBuilder{Bool}()
+    vertindices[first(pending)] = 1 # pending starts with a single vertex
+    for c in pending
+        ϵ, k = Tuple(c) # c == CartesianIndex(ϵ::Int, k::Int)
+        vertex = vcat(kverts[k], SVector(ϵks[c]))
+        push!(verts, vertex)
+        appendslice!(states, ψks, CartesianIndices((1:dimh, ϵ:ϵ, k:k)))
+        for edgek in edges(kmesh, k)
+            k´ = edgedest(kmesh, edgek)
+            proj, ϵ´ = findmostparallel(ψks, k´, ϵ, k)
+            if proj >= minprojection
+                if iszero(vertindices[ϵ´, k´]) # unclassified
+                    push!(pending, CartesianIndex(ϵ´, k´))
+                    vertindices[ϵ´, k´] = length(pending) # this is clever!
+                end
+                indexk´ = vertindices[ϵ´, k´]
+                indexk´ > 0 && pushtocolumn!(adjmat, indexk´, true)
+            end
+        end
+        finalizecolumn!(adjmat)
+    end
+    for (i, vi) in enumerate(vertindices)
+        @inbounds vi > 0 && (vertindices[i] = -1) # mark as classified in a different band
+    end
+    mesh = Mesh(verts, sparse(adjmat))
+    return Band(mesh, states, dimh)
+end
+
+function findmostparallel(ψks::Array{M,3}, destk, srcb, srck) where {M}
+    T = real(eltype(M))
+    dimh, nϵ, nk = size(ψks)
+    maxproj = zero(T)
+    destb = 0
+    @inbounds for nb in 1:nϵ
+        proj = zero(M)
+        for i in 1:dimh
+            proj += ψks[i, nb, destk]' * ψks[i, srcb, srck]
+        end
+        absproj = T(abs(tr(proj)))
+        if maxproj <= absproj  # must happen at least once
+            destb = nb
+            maxproj = absproj
+        end
+    end
+    return maxproj, destb
+end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,0 +1,33 @@
+# In v0.7+ the idea is that `convert`` is a shortcut to a "safe" subset of the constructors
+# for a type, that guarantees the resulting type. The constructor is the central machinery
+# to instantiate types and convert between instances. (For parametric types, unless overridden,
+# you get an implicit internal constructor without parameters, so no need to define that externally)
+
+Base.convert(::Type{T}, l::T) where T<:Tuple{Vararg{Sublat}} = l
+Base.convert(::Type{Tuple{Vararg{Sublat{E,T}}}}, l::Tuple{Vararg{Sublat}}) where {E,T} = Sublat{E,T}.(l)
+
+Base.convert(::Type{T}, l::T) where T<:Sublat = l
+Base.convert(::Type{T}, l::Sublat) where T<:Sublat = T(l)
+
+Base.convert(::Type{T}, l::T) where T<:Bravais = l
+Base.convert(::Type{T}, l::Bravais) where T<:Bravais = T(l)
+
+# Constructors for conversion
+
+Sublat{E,T}(s::Sublat, name = s.name) where {E,T} =
+    Sublat([padright(site, zero(T), Val(E)) for site in s.sites], name)
+
+# We need this to promote different sublats into common dimensionality and type to combine
+# into a lattice, while neglecting orbital dimension
+Base.promote(ss::Sublat{E,T}...) where {E,T} = ss
+Base.promote_rule(::Type{Sublat{E1,T1}}, ::Type{Sublat{E2,T2}}) where {E1,E2,T1,T2} =
+    Sublat{max(E1, E2), promote_type(T1, T2)}
+
+Bravais{E,L,T}(b::Bravais) where {E,L,T} =
+    Bravais(padtotype(b.matrix, SMatrix{E,L,T}), padright(b.semibounded, Val(L)))
+
+# Promotion
+
+# promote_model(model::Model, sys::System{E,L,T,Tv}, systems...) where {E,L,T,Tv} = promote_model(Tv, model, systems...)
+# promote_model(::Type{Tv}, model::Model, sys::System{E,L,T,Tv2}, systems...) where {Tv,E,L,T,Tv2} = promote_model(promote_type(Tv, Tv2), model, systems...)
+# promote_model(::Type{Tv}, model::Model) where {Tv} = convert(Model{Tv}, model)

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -1,0 +1,227 @@
+#######################################################################
+# Diagonalize methods
+#   (All but LinearAlgebraPackage `@require` some package to be loaded)
+#######################################################################
+abstract type AbstractDiagonalizeMethod end
+
+struct Diagonalizer{S<:AbstractDiagonalizeMethod,C}
+    method::S
+    codiag::C
+    minprojection::Float64
+end
+
+diagonalizer(h::Hamiltonian, mesh::Mesh, method, minprojection) =
+    Diagonalizer(method, codiagonalizer(h, mesh), minprojection)
+
+## Diagonalize methods ##
+
+function defaultmethod(h::Hamiltonian)
+    if eltype(h) <: Number
+        # method = issparse(h) ? ArpackPackage() : LinearAlgebraPackage()
+        method = LinearAlgebraPackage()
+    else
+        # method = KrylovKitPackage()
+        throw(ArgumentError("Methods for generic Hamiltonian eltypes not yet implemented. Consider using `flatten` on your Hamiltonian."))
+    end
+    return method
+end
+
+checkloaded(package::Symbol) = isdefined(Main, package) ||
+    throw(ArgumentError("Package $package not loaded, need to be `using $package`."))
+
+## LinearAlgebra ##
+struct LinearAlgebraPackage{K<:NamedTuple} <: AbstractDiagonalizeMethod
+    kw::K
+end
+
+LinearAlgebraPackage(; kw...) = LinearAlgebraPackage(values(kw))
+
+function diagonalize(matrix, method::LinearAlgebraPackage)
+    ϵ, ψ = eigen!(matrix; (method.kw)...)
+    return ϵ, ψ
+end
+
+similarmatrix(h, ::LinearAlgebraPackage) = Matrix(similarmatrix(h))
+
+## Arpack ##
+struct ArpackPackage{K<:NamedTuple} <: AbstractDiagonalizeMethod
+    kw::K
+end
+
+ArpackPackage(; kw...) = (checkloaded(:Arpack); ArpackPackage(values(kw)))
+
+function diagonalize(matrix, method::ArpackPackage)
+    ϵ, ψ = Main.Arpack.eigs(matrix; (method.kw)...)
+    return ϵ, ψ
+end
+
+similarmatrix(h, ::ArpackPackage) = similarmatrix(h)
+
+## IterativeSolvers ##
+
+struct KrylovKitPackage{K<:NamedTuple} <: AbstractDiagonalizeMethod
+    kw::K
+end
+
+KrylovKitPackage(; kw...) = (checkloaded(:KrylovKit); KrylovKitPackage(values(kw)))
+
+function diagonalize(matrix::AbstractMatrix{M}, method::KrylovKitPackage) where {M}
+    ishermitian(matrix) || throw(ArgumentError("Only Hermitian matrices supported with KrylovKitPackage for the moment"))
+    origin = get(method.kw, :origin, 0.0)
+    howmany = get(method.kw, :howmany, 1)
+    kw´ = Base.structdiff(method.kw, NamedTuple{(:origin,:howmany)}) # Remove origin option
+    lmap = shiftandinvert(matrix, origin)
+    T = eltypevec(matrix)
+    n = size(matrix, 2)
+    x0 = rand(T, n)
+    ϵ, ψ, _ = Main.KrylovKit.eigsolve(x -> lmap * x, x0, howmany, :LM; kw´...)
+
+    ϵ´ = invertandshift(ϵ, origin)
+    resize!(ϵ´, howmany)
+
+    dimh = size(matrix, 2)
+    ψ´ = Matrix{T}(undef, dimh, howmany)
+    for i in 1:howmany
+        copyslice!(ψ´, CartesianIndices((1:dimh, i:i)), ψ[i], CartesianIndices((1:dimh,)))
+    end
+
+    return ϵ´, ψ´
+end
+
+similarmatrix(h, ::KrylovKitPackage) = similarmatrix(h)
+
+#######################################################################
+# shift and invert methods
+#######################################################################
+
+function shiftandinvert(matrix::AbstractMatrix{Tv}, origin) where {Tv}
+    cols, rows = size(matrix)
+    # Shift away from real axis to avoid pivot point error in factorize
+    matrix´ = diagshift!(parent(matrix), origin + im)
+    F = factorize(matrix´)
+    lmap = LinearMap{Tv}((x, y) -> ldiv!(x, F, y), cols, rows,
+                         ismutating = true, ishermitian = false)
+    return lmap
+end
+
+function diagshift!(matrix::AbstractMatrix, origin)
+    matrix´ = parent(matrix)
+    vals = nonzeros(matrix´)
+    rowval = rowvals(matrix´)
+    for col in 1:size(matrix, 2)
+        found_diagonal = false
+        for ptr in nzrange(matrix´, col)
+            if col == rowval[ptr]
+                found_diagonal = true
+                vals[ptr] -= origin * I  # To respect non-scalar eltypes
+                break
+            end
+        end
+        found_diagonal || throw(error("Sparse work matrix must include the diagonal. Possible bug in `similarmatrix`."))
+    end
+    return matrix
+end
+
+function invertandshift(ϵ::Vector{T}, origin) where {T}
+    ϵ´ = similar(ϵ, real(T))
+    ϵ´ .= real(inv.(ϵ) .+ (origin + im))  # Caution: we assume a real spectrum
+    return ϵ´
+end
+
+#######################################################################
+# resolve_degeneracies
+#######################################################################
+# Tries to make states continuous at crossings. Here, ϵ needs to be sorted
+function resolve_degeneracies!(ϵ, ψ, ϕs, matrix, codiag)
+    issorted(ϵ, by = real) || sorteigs!(codiag.perm, ϵ, ψ)
+    hasapproxruns(ϵ, codiag.degtol) || return ϵ, ψ
+    ranges, ranges´ = codiag.rangesA, codiag.rangesB
+    resize!(ranges, 0)
+    pushapproxruns!(ranges, ϵ, 0, codiag.degtol) # 0 is an offset
+    for n in 1:num_codiag_matrices(codiag)
+        v = codiag_matrix!(matrix, n, codiag, ϕs)
+        resize!(ranges´, 0)
+        for (i, r) in enumerate(ranges)
+            subspace = view(ψ, :, r)
+            vsubspace = subspace' * v * subspace
+            veigen = eigen!(Hermitian(vsubspace))
+            if hasapproxruns(veigen.values, codiag.degtol)
+                roffset = minimum(r) - 1 # Range offset within the ϵ vector
+                pushapproxruns!(ranges´, veigen.values, roffset, codiag.degtol)
+            end
+            subspace .= subspace * veigen.vectors
+        end
+        ranges, ranges´ = ranges´, ranges
+        isempty(ranges) && break
+    end
+    return ψ
+end
+
+# Could perhaps be better/faster using a generalized CoSort
+function sorteigs!(perm, ϵ::Vector, ψ::Matrix)
+    resize!(perm, length(ϵ))
+    p = sortperm!(perm, ϵ, by = real)
+    # permute!(ϵ, p)
+    sort!(ϵ, by = real)
+    Base.permutecols!!(ψ, p)
+    return ϵ, ψ
+end
+
+#######################################################################
+# Codiagonalizer
+#######################################################################
+codiagonalizer(h, mesh) = VelocityCodiagonalizer(h, meshdelta(mesh))
+
+meshdelta(mesh::Mesh{<:Any,T}) where {T} = T(0.1) * first(minmax_edge_length(mesh))
+
+## VelocityCodiagonalizer
+## Uses velocity operators along different directions. If not enough, use finite differences
+struct VelocityCodiagonalizer{S,T,H<:Hamiltonian}
+    h::H
+    directions::Vector{S}
+    degtol::T
+    delta::T                        # Finite differences
+    rangesA::Vector{UnitRange{Int}} # Prealloc buffer for degeneray ranges
+    rangesB::Vector{UnitRange{Int}} # Prealloc buffer for degeneray ranges
+    perm::Vector{Int}               # Prealloc for sortperm!
+end
+
+function VelocityCodiagonalizer(h::Hamiltonian{<:Any,L}, delta;
+                                direlements = -0:1, onlypositive = true, kw...) where {L}
+    directions = vec(SVector{L,Int}.(Iterators.product(ntuple(_ -> direlements, Val(L))...)))
+    onlypositive && filter!(ispositive, directions)
+    unique!(normalize, directions)
+    sort!(directions, by = norm, rev = false)
+    degtol = sqrt(eps(realtype(h)))
+    delta´ = delta === missing ? degtol : delta
+    VelocityCodiagonalizer(h, directions, degtol, delta´, UnitRange{Int}[], UnitRange{Int}[], Int[])
+end
+
+num_codiag_matrices(codiag) = 2 * length(codiag.directions) + 1
+function codiag_matrix!(matrix, n, codiag, ϕs)
+    ndirs = length(codiag.directions)
+    if n <= ndirs
+        bloch!(matrix, codiag.h, ϕs, dn -> im * codiag.directions[n]' * dn)
+    elseif n <= 2ndirs # resort to finite differences
+        bloch!(matrix, codiag.h, ϕs + codiag.delta * codiag.directions[n - ndirs])
+    else # use a fixed random matrix
+        randomfill!(matrix)
+    end
+    return matrix
+end
+
+function randomfill!(matrix::SparseMatrixCSC, seed = 1234)
+    Random.seed!(seed)
+    rand!(nonzeros(matrix))  ## CAREFUL: this will be non-hermitian
+    return matrix
+end
+
+function randomfill!(matrix::AbstractArray{T}, seed = 1234) where {T}
+    Random.seed!(seed)
+    fill!(matrix, zero(T))
+    for i in 1:minimum(size(matrix))
+        r = rand(T)
+        @inbounds matrix[i, i] = r + r'
+    end
+    return matrix
+end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1,0 +1,1151 @@
+#######################################################################
+# Hamiltonian
+#######################################################################
+struct HamiltonianHarmonic{L,M,A<:Union{AbstractMatrix{M},SparseMatrixBuilder{M}}}
+    dn::SVector{L,Int}
+    h::A
+end
+
+HamiltonianHarmonic{L,M,A}(dn::SVector{L,Int}, n::Int, m::Int) where {L,M,A<:SparseMatrixCSC{M}} =
+    HamiltonianHarmonic(dn, sparse(Int[], Int[], M[], n, m))
+
+HamiltonianHarmonic{L,M,A}(dn::SVector{L,Int}, n::Int, m::Int) where {L,M,A<:Matrix{M}} =
+    HamiltonianHarmonic(dn, zeros(M, n, m))
+
+struct Hamiltonian{LA<:AbstractLattice,L,M,A<:AbstractMatrix,
+                   H<:HamiltonianHarmonic{L,M,A},
+                   O<:Tuple{Vararg{Tuple{Vararg{NameType}}}}} <: AbstractMatrix{M}
+    lattice::LA
+    harmonics::Vector{H}
+    orbitals::O
+end
+
+function Hamiltonian(lat, hs::Vector{H}, orbs, n::Int, m::Int) where {L,M,H<:HamiltonianHarmonic{L,M}}
+    sort!(hs, by = h -> abs.(h.dn))
+    if isempty(hs) || !iszero(first(hs).dn)
+        pushfirst!(hs, H(zero(SVector{L,Int}), empty_sparse(M, n, m)))
+    end
+    return Hamiltonian(lat, hs, orbs)
+end
+
+Base.show(io::IO, ham::Hamiltonian) = show(io, MIME("text/plain"), ham)
+function Base.show(io::IO, ::MIME"text/plain", ham::Hamiltonian)
+    i = get(io, :indent, "")
+    print(io, i, summary(ham), "\n",
+"$i  Bloch harmonics  : $(length(ham.harmonics)) ($(displaymatrixtype(ham)))
+$i  Harmonic size    : $((n -> "$n × $n")(nsites(ham)))
+$i  Orbitals         : $(displayorbitals(ham))
+$i  Element type     : $(displayelements(ham))
+$i  Onsites          : $(nonsites(ham))
+$i  Hoppings         : $(nhoppings(ham))
+$i  Coordination     : $(nhoppings(ham) / nsites(ham))")
+    ioindent = IOContext(io, :indent => string("  "))
+    issuperlattice(ham.lattice) && print(ioindent, "\n", ham.lattice.supercell)
+end
+
+Base.summary(h::Hamiltonian{LA}) where {E,L,LA<:Lattice{E,L}} =
+    "Hamiltonian{<:Lattice} : Hamiltonian on a $(L)D Lattice in $(E)D space"
+
+Base.summary(::Hamiltonian{LA}) where {E,L,T,L´,LA<:Superlattice{E,L,T,L´}} =
+    "Hamiltonian{<:Superlattice} : $(L)D Hamiltonian on a $(L´)D Superlattice in $(E)D space"
+
+Base.eltype(::Hamiltonian{<:Any,<:Any,M}) where {M} = M
+
+displaymatrixtype(h::Hamiltonian) = displaymatrixtype(matrixtype(h))
+displaymatrixtype(::Type{<:SparseMatrixCSC}) = "SparseMatrixCSC, sparse"
+displaymatrixtype(::Type{<:Array}) = "Matrix, dense"
+displaymatrixtype(A::Type{<:AbstractArray}) = string(A)
+displayelements(h::Hamiltonian) = displayelements(blocktype(h))
+displayelements(::Type{S}) where {N,T,S<:SMatrix{N,N,T}} = "$N × $N blocks ($T)"
+displayelements(::Type{T}) where {T} = "scalar ($T)"
+displayorbitals(h::Hamiltonian) =
+    replace(replace(string(h.orbitals), "Symbol(\"" => ":"), "\")" => "")
+
+SparseArrays.issparse(h::Hamiltonian{LA,L,M,A}) where {LA,L,M,A<:AbstractSparseMatrix} = true
+SparseArrays.issparse(h::Hamiltonian{LA,L,M,A}) where {LA,L,M,A} = false
+
+# Internal API #
+
+latdim(h::Hamiltonian{LA}) where {E,L,LA<:AbstractLattice{E,L}} = L
+
+matrixtype(::Hamiltonian{LA,L,M,A}) where {LA,L,M,A} = A
+realtype(::Hamiltonian{<:Any,<:Any,M}) where {M} = real(eltype(M))
+
+# find SVector type that can hold all orbital amplitudes in any lattice sites
+orbitaltype(orbs, type::Type{Tv} = Complex{T}) where {T,Tv} =
+    _orbitaltype(SVector{1,Tv}, orbs...)
+_orbitaltype(::Type{S}, ::NTuple{D,NameType}, os...) where {N,Tv,D,S<:SVector{N,Tv}} =
+    (M = max(N,D); _orbitaltype(SVector{M,Tv}, os...))
+_orbitaltype(t::Type{SVector{N,Tv}}) where {N,Tv} = t
+_orbitaltype(t::Type{SVector{1,Tv}}) where {Tv} = Tv
+
+# find SMatrix type that can hold all matrix elements between lattice sites
+blocktype(orbs, type::Type{Tv}) where {Tv} =
+    _blocktype(orbitaltype(orbs, Tv))
+_blocktype(::Type{S}) where {N,Tv,S<:SVector{N,Tv}} = SMatrix{N,N,Tv,N*N}
+_blocktype(::Type{S}) where {S<:Number} = S
+
+blocktype(h::Hamiltonian{LA,L,M}) where {LA,L,M} = M
+
+promote_blocktype(hs::Hamiltonian...) = promote_blocktype(blocktype.(hs)...)
+promote_blocktype(s1::Type, s2::Type, ss::Type...) =
+    promote_blocktype(promote_blocktype(s1, s2), ss...)
+promote_blocktype(::Type{SMatrix{N1,N1,T1,NN1}}, ::Type{SMatrix{N2,N2,T2,NN2}}) where {N1,NN1,T1,N2,NN2,T2} =
+    SMatrix{max(N1, N2), max(N1, N2), promote_type(T1, T2), max(NN1,NN2)}
+promote_blocktype(T1::Type{<:Number}, T2::Type{<:Number}) = promote_type(T1, T2)
+promote_blocktype(T::Type) = T
+
+blockdim(h::Hamiltonian) = blockdim(blocktype(h))
+blockdim(::Type{S}) where {N,S<:SMatrix{N,N}} = N
+blockdim(::Type{T}) where {T<:Number} = 1
+
+checkfinitedim(h::Hamiltonian{LA,L}) where {LA,L} =
+    L == 0 && throw(ArgumentError("A finite-dimensional Hamiltonian is required, not zero-dimensional"))
+
+function nhoppings(ham::Hamiltonian)
+    count = 0
+    for h in ham.harmonics
+        count += iszero(h.dn) ? (_nnz(h.h) - _nnzdiag(h.h)) : _nnz(h.h)
+    end
+    return count
+end
+
+function nonsites(ham::Hamiltonian)
+    count = 0
+    for h in ham.harmonics
+        iszero(h.dn) && (count += _nnzdiag(h.h))
+    end
+    return count
+end
+
+_nnz(h::AbstractSparseMatrix) = nnz(h)
+_nnz(h::DenseMatrix) = count(!iszero, h)
+
+function _nnzdiag(s::SparseMatrixCSC)
+    count = 0
+    rowptrs = rowvals(s)
+    for col in 1:size(s,2)
+        for ptr in nzrange(s, col)
+            rowptrs[ptr] == col && (count += 1; break)
+        end
+    end
+    return count
+end
+_nnzdiag(s::Matrix) = count(!iszero, s[i,i] for i in 1:minimum(size(s)))
+
+# Iteration tools #
+
+struct EachIndexNonzeros{H}
+    h::H
+    rowrange::UnitRange{Int}
+    colrange::UnitRange{Int}
+end
+
+eachindex_nz(h, rowrange = 1:size(h, 1), colrange = 1:size(h, 2)) =
+    EachIndexNonzeros(h, rclamp(rowrange, 1:size(h, 1)), rclamp(colrange, 1:size(h, 2)))
+
+function firststate(itr::EachIndexNonzeros{<:Hamiltonian}, nhar)
+    m = itr.h.harmonics[nhar].h
+    row, col = nextnonzero_row_col(m, itr)
+    return (row, col, nhar)
+end
+
+function nextnonzero_row_col(m::DenseMatrix, itr, col = first(itr.colrange))
+    for col´ in col:last(itr.colrange), row in itr.rowrange
+        iszero(m[row, col´]) || return (row, col´)
+    end
+    # (0, 0) is sentinel for "no non-zero row for col´ >= col
+    return (0, 0)
+end
+
+function nextnonzero_row_col(m::AbstractSparseMatrix, itr, col = first(itr.colrange))
+    rows = rowvals(m)
+    for col´ in col:last(itr.colrange)
+        ptridx = findfirst(p -> isvalidrowcol(rows[p], col´, m, itr), nzrange(m, col´))
+        ptridx === nothing || return (ptridx, col´)
+    end
+    # (0, 0) is sentinel for "no non-zero row for col´ >= col
+    return (0, 0)
+end
+
+isvalidrowcol(row, col, m, itr) = row in itr.rowrange && !iszero(m[row, col])
+
+function Base.iterate(itr::EachIndexNonzeros{<:Hamiltonian}, (ptridx, col, nhar) = firststate(itr, 1))
+    nhar > length(itr.h.harmonics) && return nothing
+    har = itr.h.harmonics[nhar]
+    i = _iterate(har.h, itr, ptridx, col)
+    if i === nothing
+        nhar´ = nhar + 1
+        return nhar´ > length(itr.h.harmonics) ? nothing : iterate(itr, firststate(itr, nhar´))
+    else
+        ((row, col), (ptridx, col)) = i
+        return (row, col, har.dn), (ptridx, col, nhar)
+    end
+end
+
+firststate(itr::EachIndexNonzeros{<:HamiltonianHarmonic}) = nextnonzero_row_col(itr.h.h, itr)
+
+function Base.iterate(itr::EachIndexNonzeros{<:HamiltonianHarmonic}, (row, col) = firststate(itr))
+    _iterate(itr.h.h, itr, row, col)
+end
+
+# Returns nothing or ((row, col), (nextrow, nextcol)), where row and nextrow can be a ptridx
+function _iterate(m::AbstractSparseMatrix, itr, ptridx, col)
+    col in itr.colrange || return nothing  # will also return nothing if col == 0 (sentinel)
+    ptrs = nzrange(m, col)
+    rows = rowvals(m)
+    if ptridx <= length(ptrs)
+        row = rows[ptrs[ptridx]]
+        row in itr.rowrange && return (row, col), (ptridx + 1, col)
+    end
+    ptridx´, col´ = nextnonzero_row_col(m, itr, col + 1)
+    return _iterate(m, itr, ptridx´, col´)
+end
+
+function _iterate(m::DenseMatrix, itr, row, col)
+    col in itr.colrange || return nothing
+    for row´ in row:last(itr.rowrange)
+        iszero(m[row´, col]) || return (row´, col), (row´ + 1, col)
+    end
+    row´, col´ = nextnonzero_row_col(m, itr, col + 1)
+    return _iterate(m, itr, row´, col´)
+end
+
+Base.IteratorSize(::EachIndexNonzeros) = Base.SizeUnknown()
+Base.IteratorEltype(::EachIndexNonzeros) = Base.HasEltype()
+Base.eltype(s::EachIndexNonzeros{<:Hamiltonian}) = Tuple{Int, Int, typeof(first(s.h.harmonics).dn)}
+Base.eltype(s::EachIndexNonzeros{<:HamiltonianHarmonic}) = Tuple{Int, Int}
+
+# stored_indices(h::Hamiltonian) = ((har.dn, rowvals(har.h)[ptr], col) for har in h.harmonics
+#                                   for col in 1:size(har.h, 2) for ptr in nzrange(har.h, col))
+
+# External API #
+"""
+    hamiltonian(lat[, model]; orbitals, type)
+
+Create a `Hamiltonian` by additively applying `model::TighbindingModel` to the lattice `lat`
+(see `hopping` and `onsite` for details on building tightbinding models).
+
+The number of orbitals on each sublattice can be specified by the keyword `orbitals`
+(otherwise all sublattices have one orbital by default). The following, and obvious
+combinations, are possible formats for the `orbitals` keyword:
+
+    orbitals = :a                # all sublattices have 1 orbital named :a
+    orbitals = (:a,)             # same as above
+    orbitals = (:a, :b, 3)       # all sublattices have 3 orbitals named :a and :b and :3
+    orbitals = ((:a, :b), (:c,)) # first sublattice has 2 orbitals, second has one
+    orbitals = ((:a, :b), :c)    # same as above
+    orbitals = (Val(2), Val(1))  # same as above, with automatic names
+    orbitals = (:A => (:a, :b), :D => :c) # sublattice :A has two orbitals, :D and rest have one
+    orbitals = :D => Val(4)      # sublattice :D has four orbitals, rest have one
+
+The matrix sizes of tightbinding `model` must match the orbitals specified. Internally, we
+define a block size `N = max(num_orbitals)`. If `N = 1` (all sublattices with one orbital)
+the the Hamiltonian element type is `type`. Otherwise it is `SMatrix{N,N,type}` blocks,
+padded with the necessary zeros as required. Keyword `type` is `Complex{T}` by default,
+where `T` is the number type of `lat`.
+
+    h(ϕ₁, ϕ₂, ...)
+    h((ϕ₁, ϕ₂, ...))
+
+Build the Bloch Hamiltonian matrix `bloch(h, (ϕ₁, ϕ₂, ...))` of a `h::Hamiltonian` on an
+`L`D lattice. (See also `bloch!` for a non-allocating version of `bloch`.)
+
+    lat |> hamiltonian(model[, funcmodel]; kw...)
+
+Functional `hamiltonian` form equivalent to `hamiltonian(lat, model[, funcmodel]; kw...)`.
+
+# Indexing
+
+Indexing into a Hamiltonian `h` works as follows. Access the `HamiltonianHarmonic` matrix at
+a given `dn::NTuple{L,Int}` with `h[dn]`. Assign `v` into element `(i,j)` of said matrix
+with `h[dn][i,j] = v` or `h[dn, i, j] = v`. Broadcasting with vectors of indices `is` and
+`js` is supported, `h[dn][is, js] = v_matrix`.
+
+To add an empty harmonic with a given `dn::NTuple{L,Int}`, do `push!(h, dn)`. To delete it,
+do `deleteat!(h, dn)`.
+
+# Examples
+```jldoctest
+julia> h = hamiltonian(LatticePresets.honeycomb(), hopping(@SMatrix[1 2; 3 4], range = 1/√3), orbitals = Val(2))
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a, :a), (:a, :a))
+  Element type     : 2 × 2 blocks (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 6
+  Coordination     : 3.0
+
+julia> push!(h, (3,3)) # Adding a new Hamiltonian harmonic (if not already present)
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 6 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a, :a), (:a, :a))
+  Element type     : 2 × 2 blocks (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 6
+  Coordination     : 3.0
+
+julia> h[3,3][1,1] = @SMatrix[1 2; 2 1]; h[3,3] # element assignment
+2×2 SparseArrays.SparseMatrixCSC{StaticArrays.SArray{Tuple{2,2},Complex{Float64},2,4},Int64} with 1 stored entry:
+  [1, 1]  =  [1.0+0.0im 2.0+0.0im; 2.0+0.0im 1.0+0.0im]
+
+julia> h[3,3][[1,2],[1,2]] .= rand(SMatrix{2,2,Float64}, 2, 2) # Broadcast assignment
+2×2 view(::SparseArrays.SparseMatrixCSC{StaticArrays.SArray{Tuple{2,2},Complex{Float64},2,4},Int64}, [1, 2], [1, 2]) with eltype StaticArrays.SArray{Tuple{2,2},Complex{Float64},2,4}:
+ [0.271152+0.0im 0.921417+0.0im; 0.138212+0.0im 0.525911+0.0im]  [0.444284+0.0im 0.280035+0.0im; 0.565106+0.0im 0.121869+0.0im]
+ [0.201126+0.0im 0.912446+0.0im; 0.372099+0.0im 0.931358+0.0im]  [0.883422+0.0im 0.874016+0.0im; 0.296095+0.0im 0.995861+0.0im]
+
+julia> hopfunc(;k = 0) = hopping(k); hamiltonian(LatticePresets.square(), onsite(1) + hopping(2), hopfunc) # Parametric Hamiltonian
+Parametric Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 1 × 1
+  Orbitals         : ((:a,),)
+  Elements         : scalars (Complex{Float64})
+  Onsites          : 1
+  Hoppings         : 4
+  Coordination     : 4.0
+
+```
+"""
+hamiltonian(lat, ts...; orbitals = missing, kw...) =
+    _hamiltonian(lat, sanitize_orbs(orbitals, lat.unitcell.names), ts...; kw...)
+_hamiltonian(lat::AbstractLattice, orbs; kw...) = _hamiltonian(lat, orbs, TightbindingModel(); kw...)
+_hamiltonian(lat::AbstractLattice, orbs, f::Function; kw...) = _hamiltonian(lat, orbs, TightbindingModel(), f; kw...)
+_hamiltonian(lat::AbstractLattice, orbs, m::TightbindingModel; type::Type = Complex{numbertype(lat)}, kw...) =
+    hamiltonian_sparse(blocktype(orbs, type), lat, orbs, m; kw...)
+
+hamiltonian(t::TightbindingModel...; kw...) =
+    z -> hamiltonian(z, t...; kw...)
+hamiltonian(f::Function, t::TightbindingModel...; kw...) =
+    z -> hamiltonian(z, f, t...; kw...)
+hamiltonian(h::Hamiltonian) =
+    z -> hamiltonian(z, h)
+
+(h::Hamiltonian)(phases...) = bloch(h, phases...)
+
+sanitize_orbs(o::Union{Val,NameType,Integer}, names::NTuple{N}) where {N} =
+    ntuple(n -> sanitize_orbs(o), Val(N))
+sanitize_orbs(o::NTuple{M,Union{NameType,Integer}}, names::NTuple{N}) where {M,N} =
+    (ont = nametype.(o); ntuple(n -> ont, Val(N)))
+sanitize_orbs(o::Missing, names) = sanitize_orbs((:a,), names)
+sanitize_orbs(o::Pair, names) = sanitize_orbs((o,), names)
+sanitize_orbs(os::NTuple{M,Pair}, names::NTuple{N}) where {N,M} =
+    ntuple(Val(N)) do n
+        for m in 1:M
+            first(os[m]) == names[n] && return sanitize_orbs(os[m])
+        end
+        return (:a,)
+    end
+sanitize_orbs(os::NTuple{M,Any}, names::NTuple{N}) where {N,M} =
+    ntuple(n -> n > M ? (:a,) : sanitize_orbs(os[n]), Val(N))
+
+sanitize_orbs(p::Pair) = sanitize_orbs(last(p))
+sanitize_orbs(o::Integer) = (nametype(o),)
+sanitize_orbs(o::NameType) = (o,)
+sanitize_orbs(o::Val{N}) where {N} = ntuple(_ -> :a, Val(N))
+sanitize_orbs(o::NTuple{N,Union{Integer,NameType}}) where {N} = nametype.(o)
+sanitize_orbs(p) = throw(ArgumentError("Wrong format for orbitals, see `hamiltonian`"))
+
+Base.Matrix(h::Hamiltonian) = Hamiltonian(h.lattice, Matrix.(h.harmonics), h.orbitals)
+Base.Matrix(h::HamiltonianHarmonic) = HamiltonianHarmonic(h.dn, Matrix(h.h))
+
+Base.copy(h::Hamiltonian) = Hamiltonian(copy(h.lattice), copy.(h.harmonics), h.orbitals)
+Base.copy(h::HamiltonianHarmonic) = HamiltonianHarmonic(h.dn, copy(h.h))
+
+Base.size(h::Hamiltonian, n) = size(first(h.harmonics).h, n)
+Base.size(h::Hamiltonian) = size(first(h.harmonics).h)
+Base.size(h::HamiltonianHarmonic, n) = size(h.h, n)
+Base.size(h::HamiltonianHarmonic) = size(h.h)
+
+function LinearAlgebra.ishermitian(h::Hamiltonian)
+    for hh in h.harmonics
+        isnonnegative(hh.dn) || continue
+        isassigned(h, -hh.dn) || return false
+        hh.h == h[-hh.dn]' || return false
+    end
+    return true
+end
+
+bravais(h::Hamiltonian) = bravais(h.lattice)
+
+issemibounded(h::Hamiltonian) = issemibounded(h.lattice)
+
+nsites(h::Hamiltonian) = isempty(h.harmonics) ? 0 : nsites(first(h.harmonics))
+nsites(h::HamiltonianHarmonic) = size(h.h, 1)
+
+nsublats(h::Hamiltonian) = nsublats(h.lattice)
+
+norbitals(h::Hamiltonian) = length.(h.orbitals)
+
+# External API #
+
+"""
+    transform!(h::Hamiltonian, f::Function)
+
+Transform the site positions of the Hamiltonian's lattice in place without modifying the
+Hamiltonian harmonics.
+"""
+function transform!(h::Hamiltonian, f::Function)
+    transform!(h.lattice, f)
+    return h
+end
+
+# Indexing #
+
+Base.push!(h::Hamiltonian{<:Any,L}, dn::NTuple{L,Int}) where {L} = push!(h, SVector(dn...))
+Base.push!(h::Hamiltonian{<:Any,L}, dn::Vararg{Int,L}) where {L} = push!(h, SVector(dn...))
+function Base.push!(h::Hamiltonian{<:Any,L,M,A}, dn::SVector{L,Int}) where {L,M,A}
+    for hh in h.harmonics
+        hh.dn == dn && return hh
+    end
+    hh = HamiltonianHarmonic{L,M,A}(dn, size(h)...)
+    push!(h.harmonics, hh)
+    return h
+end
+
+Base.getindex(h::Hamiltonian, dn::NTuple) = getindex(h, SVector(dn))
+@inline function Base.getindex(h::Hamiltonian{<:Any,L}, dn::SVector{L,Int}) where {L}
+    nh = findfirst(hh -> hh.dn == dn, h.harmonics)
+    nh === nothing && throw(BoundsError(h, dn))
+    return h.harmonics[nh].h
+end
+Base.getindex(h::Hamiltonian, dn::NTuple, i::Vararg{Int}) = h[dn][i...]
+Base.getindex(h::Hamiltonian{LA, L}, i::Vararg{Int}) where {LA,L} = h[zero(SVector{L,Int})][i...]
+
+Base.deleteat!(h::Hamiltonian{<:Any,L}, dn::Vararg{Int,L}) where {L} =
+    deleteat!(h, toSVector(dn))
+Base.deleteat!(h::Hamiltonian{<:Any,L}, dn::NTuple{L,Int}) where {L} =
+    deleteat!(h, toSVector(dn))
+function Base.deleteat!(h::Hamiltonian{<:Any,L}, dn::SVector{L,Int}) where {L}
+    nh = findfirst(hh -> hh.dn == SVector(dn...), h.harmonics)
+    nh === nothing || deleteat!(h.harmonics, nh)
+    return h
+end
+
+Base.isassigned(h::Hamiltonian, dn::Vararg{Int}) = isassigned(h, SVector(dn))
+Base.isassigned(h::Hamiltonian, dn::NTuple) = isassigned(h, SVector(dn))
+Base.isassigned(h::Hamiltonian{<:Any,L}, dn::SVector{L,Int}) where {L} =
+    findfirst(hh -> hh.dn == dn, h.harmonics) != nothing
+
+#######################################################################
+# auxiliary types
+#######################################################################
+struct IJV{L,M}
+    dn::SVector{L,Int}
+    i::Vector{Int}
+    j::Vector{Int}
+    v::Vector{M}
+end
+
+struct IJVBuilder{L,M,E,T,O,LA<:AbstractLattice{E,L,T}}
+    lat::LA
+    orbs::O
+    ijvs::Vector{IJV{L,M}}
+    kdtrees::Vector{KDTree{SVector{E,T},Euclidean,T}}
+end
+
+IJV{L,M}(dn::SVector{L} = zero(SVector{L,Int})) where {L,M} =
+    IJV(dn, Int[], Int[], M[])
+
+function IJVBuilder(lat::AbstractLattice{E,L,T}, orbs, ijvs::Vector{IJV{L,M}}) where {E,L,T,M}
+    kdtrees = Vector{KDTree{SVector{E,T},Euclidean,T}}(undef, nsublats(lat))
+    return IJVBuilder(lat, orbs, ijvs, kdtrees)
+end
+
+IJVBuilder(lat::AbstractLattice{E,L}, orbs, ::Type{M}) where {E,L,M} =
+    IJVBuilder(lat, orbs, IJV{L,M}[])
+
+function IJVBuilder(lat::AbstractLattice{E,L}, orbs, hs::Hamiltonian...) where {E,L}
+    M = promote_blocktype(hs...)
+    ijvs = IJV{L,M}[]
+    builder = IJVBuilder(lat, orbs, ijvs)
+    offset = 0
+    for h in hs
+        for har in h.harmonics
+            ijv = builder[har.dn]
+            push_block!(ijv, har, offset)
+        end
+        offset += size(h, 1)
+    end
+    return builder
+end
+
+function Base.getindex(b::IJVBuilder{L,M}, dn::SVector{L2,Int}) where {L,L2,M}
+    L == L2 || throw(error("Tried to apply an $L2-dimensional model to an $L-dimensional lattice"))
+    for e in b.ijvs
+        e.dn == dn && return e
+    end
+    e = IJV{L,M}(dn)
+    push!(b.ijvs, e)
+    return e
+end
+
+Base.length(h::IJV) = length(h.i)
+Base.isempty(h::IJV) = length(h) == 0
+Base.copy(h::IJV) = IJV(h.dn, copy(h.i), copy(h.j), copy(h.v))
+
+function Base.resize!(h::IJV, n)
+    resize!(h.i, n)
+    resize!(h.j, n)
+    resize!(h.v, n)
+    return h
+end
+
+Base.push!(ijv::IJV, (i, j, v)::Tuple) = (push!(ijv.i, i); push!(ijv.j, j); push!(ijv.v, v))
+
+function push_block!(ijv::IJV{L,M}, h::HamiltonianHarmonic, offset) where {L,M}
+    I, J, V = findnz(h.h)
+    for (i, j, v) in zip(I, J, V)
+        push!(ijv, (i + offset, j + offset, padtotype(v, M)))
+    end
+    return ijv
+end
+
+#######################################################################
+# hamiltonian_sparse
+#######################################################################
+function hamiltonian_sparse(Mtype, lat, orbs, model)
+    builder = IJVBuilder(lat, orbs, Mtype)
+    return hamiltonian_sparse!(builder, lat, orbs, model)
+end
+
+function hamiltonian_sparse!(builder::IJVBuilder{L,M}, lat::AbstractLattice{E,L}, orbs, model) where {E,L,M}
+    checkmodelorbs(model, orbs, lat)
+    applyterms!(builder, terms(model)...)
+    n = nsites(lat)
+    HT = HamiltonianHarmonic{L,M,SparseMatrixCSC{M,Int}}
+    harmonics = HT[HT(e.dn, sparse(e.i, e.j, e.v, n, n)) for e in builder.ijvs if !isempty(e)]
+    return Hamiltonian(lat, harmonics, orbs, n, n)
+end
+
+
+applyterms!(builder, terms...) = foreach(term -> applyterm!(builder, term), terms)
+
+applyterm!(builder::IJVBuilder, term::Union{OnsiteTerm, HoppingTerm}) =
+    applyterm!(builder, term, sublats(term, builder.lat))
+
+function applyterm!(builder::IJVBuilder{L,M}, term::OnsiteTerm, termsublats) where {L,M}
+    selector = term.selector
+    lat = builder.lat
+    for s in termsublats
+        is = siterange(lat, s)
+        dn0 = zero(SVector{L,Int})
+        ijv = builder[dn0]
+        offset = lat.unitcell.offsets[s]
+        for i in is
+            isinregion(i, dn0, selector.region, lat) || continue
+            r = lat.unitcell.sites[i]
+            vs = orbsized(term(r,r), builder.orbs[s])
+            v = padtotype(vs, M)
+            term.forcehermitian ? push!(ijv, (i, i, 0.5 * (v + v'))) : push!(ijv, (i, i, v))
+        end
+    end
+    return nothing
+end
+
+function applyterm!(builder::IJVBuilder{L,M}, term::HoppingTerm, termsublats) where {L,M}
+    selector = term.selector
+    checkinfinite(selector)
+    lat = builder.lat
+    for (s1, s2) in termsublats
+        is, js = siterange(lat, s1), siterange(lat, s2)
+        dns = dniter(selector.dns, Val(L))
+        for dn in dns
+            addadjoint = term.forcehermitian
+            foundlink = false
+            ijv = builder[dn]
+            addadjoint && (ijvc = builder[negative(dn)])
+            for j in js
+                sitej = lat.unitcell.sites[j]
+                rsource = sitej - lat.bravais.matrix * dn
+                itargets = targets(builder, selector.range, rsource, s1)
+                for i in itargets
+                    isselfhopping((i, j), (s1, s2), dn) && continue
+                    isinregion((i, j), (dn, zero(dn)), selector.region, lat) || continue
+                    foundlink = true
+                    rtarget = lat.unitcell.sites[i]
+                    r, dr = _rdr(rsource, rtarget)
+                    vs = orbsized(term(r, dr), builder.orbs[s1], builder.orbs[s2])
+                    v = padtotype(vs, M)
+                    if addadjoint
+                        v *= redundancyfactor(dn, (s1, s2), selector)
+                        push!(ijv, (i, j, v))
+                        push!(ijvc, (j, i, v'))
+                    else
+                        push!(ijv, (i, j, v))
+                    end
+                end
+            end
+            foundlink && acceptcell!(dns, dn)
+        end
+    end
+    return nothing
+end
+
+orbsized(m, orbs) = orbsized(m, orbs, orbs)
+orbsized(m, o1::NTuple{D1}, o2::NTuple{D2}) where {D1,D2} = padtotype(m, SMatrix{D1,D2})
+
+dniter(dns::Missing, ::Val{L}) where {L} = BoxIterator(zero(SVector{L,Int}))
+dniter(dns, ::Val) = dns
+
+function targets(builder, range::Real, rsource, s1)
+    if !isassigned(builder.kdtrees, s1)
+        sites = view(builder.lat.unitcell.sites, siterange(builder.lat, s1))
+        (builder.kdtrees[s1] = KDTree(sites))
+    end
+    targets = inrange(builder.kdtrees[s1], rsource, range)
+    targets .+= builder.lat.unitcell.offsets[s1]
+    return targets
+end
+
+targets(builder, range::Missing, rsource, s1) = eachindex(builder.lat.sublats[s1].sites)
+
+checkinfinite(selector) =
+    selector.dns === missing && (selector.range === missing || !isfinite(selector.range)) &&
+    throw(ErrorException("Tried to implement an infinite-range hopping on an unbounded lattice"))
+
+isselfhopping((i, j), (s1, s2), dn) = i == j && s1 == s2 && iszero(dn)
+
+# Avoid double-counting hoppings when adding adjoint
+redundancyfactor(dn, ss, selector) =
+    isnotredundant(dn, selector) || isnotredundant(ss, selector) ? 1.0 : 0.5
+isnotredundant(dn::SVector, selector) = selector.dns !== missing && !iszero(dn)
+isnotredundant((s1, s2)::Tuple{Int,Int}, selector) = selector.sublats !== missing && s1 != s2
+
+#######################################################################
+# unitcell/supercell for Hamiltonians
+#######################################################################
+function supercell(ham::Hamiltonian, args...; kw...)
+    slat = supercell(ham.lattice, args...; kw...)
+    return Hamiltonian(slat, ham.harmonics, ham.orbitals)
+end
+
+function unitcell(ham::Hamiltonian{<:Lattice}, args...; modifiers = (), kw...)
+    sham = supercell(ham, args...; kw...)
+    return unitcell(sham; modifiers = modifiers)
+end
+
+function unitcell(ham::Hamiltonian{LA,L}; modifiers = ()) where {E,L,T,L´,LA<:Superlattice{E,L,T,L´}}
+    lat = ham.lattice
+    sc = lat.supercell
+    modifiers´ = resolve.(ensuretuple(modifiers), Ref(lat))
+    mapping = OffsetArray{Int}(undef, sc.sites, sc.cells.indices...) # store supersite indices newi
+    mapping .= 0
+    foreach_supersite((s, oldi, olddn, newi) -> mapping[oldi, Tuple(olddn)...] = newi, lat)
+    dim = nsites(sc)
+    B = blocktype(ham)
+    S = typeof(SparseMatrixBuilder{B}(dim, dim))
+    harmonic_builders = HamiltonianHarmonic{L´,B,S}[]
+    pinvint = pinvmultiple(sc.matrix)
+    foreach_supersite(lat) do s, source_i, source_dn, newcol
+        for oldh in ham.harmonics
+            rows = rowvals(oldh.h)
+            vals = nonzeros(oldh.h)
+            target_dn = source_dn + oldh.dn
+            super_dn = new_dn(target_dn, pinvint)
+            wrapped_dn = wrap_dn(target_dn, super_dn, sc.matrix)
+            newh = get_or_push!(harmonic_builders, super_dn, dim, newcol)
+            for p in nzrange(oldh.h, source_i)
+                target_i = rows[p]
+                # check: wrapped_dn could exit bounding box along non-periodic direction
+                checkbounds(Bool, mapping, target_i, Tuple(wrapped_dn)...) || continue
+                newrow = mapping[target_i, Tuple(wrapped_dn)...]
+                val = applymodifiers(vals[p], lat, (source_i, target_i), (source_dn, target_dn), modifiers´...)
+                iszero(newrow) || pushtocolumn!(newh.h, newrow, val)
+            end
+        end
+        foreach(h -> finalizecolumn!(h.h), harmonic_builders)
+    end
+    harmonics = [HamiltonianHarmonic(h.dn, sparse(h.h)) for h in harmonic_builders]
+    unitlat = unitcell(lat)
+    orbs = ham.orbitals
+    return Hamiltonian(unitlat, harmonics, orbs)
+end
+
+function get_or_push!(hs::Vector{<:HamiltonianHarmonic{L,B,<:SparseMatrixBuilder}}, dn, dim, currentcol) where {L,B}
+    for h in hs
+        h.dn == dn && return h
+    end
+    newh = HamiltonianHarmonic(dn, SparseMatrixBuilder{B}(dim, dim))
+    currentcol > 1 && finalizecolumn!(newh.h, currentcol - 1) # for columns that have been already processed
+    push!(hs, newh)
+    return newh
+end
+
+wrap_dn(olddn::SVector, newdn::SVector, supercell::SMatrix) = olddn - supercell * newdn
+
+applymodifiers(val, lat, inds, dns) = val
+
+function applymodifiers(val, lat, inds, dns, m::ElementModifier{Val{false}}, ms...)
+    selected = m.selector(lat, inds, dns)
+    val´ = selected ? m.f(val) : val
+    return applymodifiers(val´, lat, inds, dns, ms...)
+end
+
+function applymodifiers(val, lat, (row, col), (dnrow, dncol), m::Onsite!{Val{true}}, ms...)
+    selected = m.selector(lat, (row, col), (dnrow, dncol))
+    if selected
+        r = sites(lat)[col] + bravais(lat) * dncol
+        val´ = selected ? m.f(val, r) : val
+    else
+        val´ = val
+    end
+    return applymodifiers(val´, lat, (row, col), (dnrow, dncol), ms...)
+end
+
+function applymodifiers(val, lat, (row, col), (dnrow, dncol), m::Hopping!{Val{true}}, ms...)
+    selected = m.selector(lat, (row, col), (dnrow, dncol))
+    if selected
+        br = bravais(lat)
+        r, dr = _rdr(sites(lat)[col] + br * dncol, sites(lat)[row] + br * dnrow)
+        val´ = selected ? m.f(val, r, dr) : val
+    else
+        val´ = val
+    end
+    return applymodifiers(val´, lat, (row, col), (dnrow, dncol), ms...)
+end
+
+#######################################################################
+# wrap
+#######################################################################
+"""
+    wrap(h::Hamiltonian, axis::Int; factor = 1)
+
+Build a new Hamiltonian wherein the Bravais `axis` is wrapped into a loop. If a `factor` is
+given, the wrapped hoppings will be multiplied by said factor. This is useful to represent a
+flux Φ through the loop, if `factor = exp(im * 2π * Φ/Φ₀)`.
+
+    h |> wrap(axis; kw...)
+
+Functional form equivalent to `wrap(h, axis; kw...)`.
+
+# Examples
+```
+julia> LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = 1/√3)) |> unitcell((1,-1), (10, 10)) |> wrap(2)
+Hamiltonian{<:Lattice} : 1D Hamiltonian on a 1D Lattice in 2D space
+  Bloch harmonics  : 3 (SparseMatrixCSC, sparse)
+  Harmonic size    : 40 × 40
+  Orbitals         : ((:a,), (:a,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 120
+  Coordination     : 3.0
+```
+"""
+function wrap(h::Hamiltonian{<:Lattice,L}, axis; factor = 1) where {L}
+    1 <= axis <= L || throw(ArgumentError("wrap axis should be between 1 and the lattice dimension $L"))
+    lattice´ = _wrap(h.lattice, axis)
+    harmonics´ = _wrap(h.harmonics, axis, factor)
+    return Hamiltonian(lattice´, harmonics´, h.orbitals)
+end
+
+wrap(axis; kw...) = h -> wrap(h, axis; kw...)
+
+_wrap(lat::Lattice, axis) = Lattice(_wrap(lat.bravais, axis), lat.unitcell)
+
+function _wrap(br::Bravais{E,L}, axis) where {E,L}
+    mask = deleteat(SVector{L}(1:L), axis)
+    return Bravais(br.matrix[:, mask], br.semibounded[mask])
+end
+
+function _wrap(harmonics::Vector{HamiltonianHarmonic{L,M,A}}, axis, factor) where {L,M,A}
+    harmonics´ = HamiltonianHarmonic{L-1,M,A}[]
+    for har in harmonics
+        dn = har.dn
+        dn´ = deleteat(dn, axis)
+        factor´ = iszero(dn[axis]) ? 1 : factor
+        add_or_push!(harmonics´, dn´, har.h, factor´)
+    end
+    return harmonics´
+end
+
+function add_or_push!(hs::Vector{<:HamiltonianHarmonic}, dn, matrix::AbstractMatrix, factor)
+    for h in hs
+        if h.dn == dn
+            h.h .+= factor .* matrix
+            return h
+        end
+    end
+    newh = HamiltonianHarmonic(dn, matrix)
+    push!(hs, newh)
+    return newh
+end
+
+#######################################################################
+# combine
+#######################################################################
+"""
+    combine(hams::Hamiltonian...; coupling = missing)
+
+Build a new Hamiltonian `h` that combines all `hams` as diagonal blocks, and applies
+`coupling::Model`, if provided, to build the off-diagonal couplings. Note that the diagonal
+blocks are not modified by the coupling model.
+"""
+combine(hams::Hamiltonian...; coupling = missing) = _combine(coupling, hams...)
+
+_combine(::Missing, hams...) = _combine(TightbindingModel(), hams...)
+
+function _combine(model::TightbindingModel, hams::Hamiltonian...)
+    lat = combine((h -> h.lattice).(hams)...)
+    orbs = tuplejoin((h -> h.orbitals).(hams)...)
+    builder = IJVBuilder(lat, orbs, hams...)
+    model´ = offdiagonal(model, lat, nsublats.(hams))
+    ham = hamiltonian_sparse!(builder, lat, orbs, model´)
+    return ham
+end
+
+#######################################################################
+# Bloch routines
+#######################################################################
+struct SupercellBloch{L,T,H<:Hamiltonian{<:Superlattice}}
+    hamiltonian::H
+    phases::SVector{L,T}
+    axis::Int
+end
+SupercellBloch(h, ϕs) = SupercellBloch(h, ϕs, 0)
+
+Base.summary(h::SupercellBloch{L,T}) where {L,T} =
+    "SupercellBloch{$L)}: Bloch Hamiltonian matrix lazily defined on an $(L)D supercell"
+
+function Base.show(io::IO, sb::SupercellBloch)
+    ioindent = IOContext(io, :indent => string("  "))
+    print(io, summary(sb), "
+  Phases          : $(Tuple(sb.phases))
+  Axis            : $(iszero(sb.axis) ? "none" : sb.axis)\n")
+    print(ioindent, sb.hamiltonian.lattice.supercell)
+end
+
+"""
+    bloch!(matrix, h::Hamiltonian, ...)
+
+In-place version of `bloch`. Overwrite `matrix` with the Bloch Hamiltonian matrix of `h` for
+the specified Bloch phases `ϕs` (see `bloch` for definition and API).  A conventient way to
+obtain a `matrix` is to use `similarmatrix(h)`, which will return an `AbstractMatrix` of the
+same type as the Hamiltonian's. Note, however, that matrix need not be of the same type
+(e.g. it can be dense, while `h` is sparse).
+
+# Examples
+```
+julia> h = LatticePresets.honeycomb() |> hamiltonian(onsite(1), hopping(2));
+
+julia> bloch!(similarmatrix(h), h, (.2,.3), 2)  # velocity operator along `bravais(h)[2]`
+2×2 SparseArrays.SparseMatrixCSC{Complex{Float64},Int64} with 4 stored entries:
+  [1, 1]  =  1.99001-0.199667im
+  [2, 1]  =  1.96013-0.397339im
+  [1, 2]  =  1.96013+0.397339im
+  [2, 2]  =  1.99001-0.199667im
+```
+
+# See also:
+    bloch, optimize!, similarmatrix
+"""
+bloch!(matrix, h, ϕs::Number...) = _bloch!(matrix, h, toSVector(ϕs), 0)
+bloch!(matrix, h, ϕs::Tuple, axis = 0) = _bloch!(matrix, h, toSVector(ϕs), axis)
+bloch!(matrix, h, ϕs::SVector, axis = 0) = _bloch!(matrix, h, ϕs, axis)
+bloch!(matrix, ϕs::Number...) = h -> bloch!(matrix, h, ϕs...)
+bloch!(matrix, ϕs::Tuple, axis = 0) = h -> bloch!(matrix, h, ϕs, axis)
+
+function _bloch!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,L,M}, ϕs, axis::Number) where {L,M}
+    rawmatrix = parent(matrix)
+    if iszero(axis)
+        _copy!(rawmatrix, first(h.harmonics).h) # faster copy!(dense, sparse) specialization
+        add_harmonics!(rawmatrix, h, ϕs, dn -> 1)
+    else
+        fill!(rawmatrix, zero(M)) # There is no guarantee of same structure
+        add_harmonics!(rawmatrix, h, ϕs, dn -> -im * dn[axis])
+    end
+    return matrix
+end
+
+function _bloch!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,L,M}, ϕs, dnfunc::Function) where {L,M}
+    prefactor0 = dnfunc(zero(ϕs))
+    rawmatrix = parent(matrix)
+    if iszero(prefactor0)
+        fill!(rawmatrix, zero(M))
+    else
+        _copy!(rawmatrix, first(h.harmonics).h)
+        rmul!(rawmatrix, prefactor0)
+    end
+    add_harmonics!(rawmatrix, h, ϕs, dnfunc)
+    return matrix
+end
+
+add_harmonics!(zerobloch, h::Hamiltonian{<:Lattice}, ϕs::SVector{0}, _) = zerobloch
+
+function add_harmonics!(zerobloch, h::Hamiltonian{<:Lattice,L}, ϕs::SVector{L}, dnfunc) where {L}
+    ϕs´ = ϕs'
+    for ns in 2:length(h.harmonics)
+        hh = h.harmonics[ns]
+        hhmatrix = hh.h
+        prefactor = dnfunc(hh.dn)
+        iszero(prefactor) && continue
+        ephi = prefactor * cis(-ϕs´ * hh.dn)
+        _add!(zerobloch, hhmatrix, ephi)
+    end
+    return zerobloch
+end
+
+
+"""
+    bloch(h::Hamiltonian{<:Lattice}, ϕs::Real...)
+
+Build the Bloch Hamiltonian matrix of `h`, for the specified Bloch phases `ϕs`. In terms of
+Bloch wavevector `k`, `ϕs = k * bravais(h)`, it is defined as Overwrite `matrix` with the
+Bloch Hamiltonian matrix of `h`, for the specified Bloch phases `ϕs`, defined as
+`H(ϕs) = ∑exp(-im * ϕs' * dn) h_dn` where `h_dn` are Bloch harmonics connecting unit cells
+at a distance `dR = bravais(h) * dn`.
+
+    bloch(h::Hamiltonian{<:Lattice})
+
+Build the intra-cell Hamiltonian matrix of `h`, without adding any Bloch harmonics.
+
+    bloch(h::Hamiltonian{<:Lattice}, ϕs::NTuple{L,Real}[, axis::Int = 0])
+
+A nonzero `axis` produces the derivative of the Bloch matrix respect to `ϕs[axis]` (i.e. the
+velocity operator along this axis), `∂H(ϕs) = ∑ -im * dn[axis] * exp(-im * ϕs' * dn) h_dn`
+
+    bloch(matrix, h::Hamiltonian{<:Lattice}, ϕs::NTuple{L,Real}, dnfunc::Function)
+
+Generalization that applies a prefactor `dnfunc(dn) * exp(im * ϕs' * dn)` to the `dn`
+harmonic.
+
+    h |> bloch(ϕs...)
+    h(ϕs...)
+
+Functional forms of `bloch`, equivalent to `bloch(h, ϕs...)`
+
+    bloch(h::Hamiltonian{<:Superlattice}, ϕs::Number...)
+    bloch(h::Hamiltonian{<:Superlattice}, ϕs::Tuple[, axis = 0])
+
+Build a `SupercellBloch` object that lazily implements the Bloch Hamiltonian in the
+`Superlattice` without actually building the matrix (e.g. for matrix-free diagonalization).
+
+# Notes
+
+`bloch` allocates a new matrix on each call. For a non-allocating version of `bloch`, see
+`bloch!`.
+
+# Examples
+```
+julia> h = LatticePresets.honeycomb() |> hamiltonian(onsite(1), hopping(2)) |> bloch(.2,.3)
+2×2 SparseArrays.SparseMatrixCSC{Complex{Float64},Int64} with 4 stored entries:
+  [1, 1]  =  1.99001-0.199667im
+  [2, 1]  =  1.96013-0.397339im
+  [1, 2]  =  1.96013+0.397339im
+  [2, 2]  =  1.99001-0.199667im
+```
+
+# See also:
+    bloch!, optimize!, similarmatrix
+"""
+bloch(ϕs::Number...) = h -> bloch(h, ϕs...)
+bloch(ϕs::Tuple, axis = 0) = h -> bloch(h, ϕs, axis)
+bloch(h::Hamiltonian{<:Lattice}, args...) = bloch!(similarmatrix(h), h, args...)
+bloch(h::Hamiltonian{<:Superlattice}, ϕs::Number...) =
+    SupercellBloch(h, toSVector(ϕs))
+bloch(h::Hamiltonian{<:Superlattice}, ϕs::Tuple, axis = 0) =
+    SupercellBloch(h, toSVector(ϕs), axis)
+
+"""
+    similarmatrix(h::Hamiltonian; optimize = true)
+
+Create an uninitialized matrix of the same type of the Hamiltonian's matrix, calling
+`optimize!(h)` first if `optimize = true` to produce an optimal work matrix in the sparse
+case.
+"""
+function similarmatrix(h::Hamiltonian; optimize = true)
+    optimize && optimize!(h)
+    sm = size(h)
+    T = eltype(h)
+    matrix = similar(h.harmonics[1].h, T, sm[1], sm[2])
+    return matrix
+end
+
+"""
+    optimize!(h::Hamiltonian)
+
+Prepare a sparse Hamiltonian `h` to increase the performance of subsequent calls to
+`bloch(h, ϕs...)` and `bloch!(matrix, h, ϕs...)` by minimizing memory reshufflings. It also
+adds missing structural zeros to the diagonal to enable shifts by `α*I` (for
+shift-and-invert methods).
+
+No optimization will be performed on non-sparse Hamiltonians, or those defined on
+`Superlattice`s, for which Bloch Hamiltonians are lazily evaluated.
+
+Note that when calling `similarmatrix(h)` on a sparse `h`, `optimize!` is called first.
+
+# See also:
+    bloch, bloch!
+"""
+function optimize!(ham::Hamiltonian{<:Lattice,L,M,A}) where {L,M,A<:SparseMatrixCSC}
+    h0 = first(ham.harmonics)
+    n, m = size(h0.h)
+    iszero(h0.dn) || throw(ArgumentError("First Hamiltonian harmonic is not the fundamental"))
+    nh = length(ham.harmonics)
+    builder = SparseMatrixBuilder{M}(n, m)
+    for col in 1:m
+        for i in eachindex(ham.harmonics)
+            h = ham.harmonics[i].h
+            for p in nzrange(h, col)
+                v = i == 1 ? nonzeros(h)[p] : zero(M)
+                row = rowvals(h)[p]
+                pushtocolumn!(builder, row, v, false) # skips repeated rows
+            end
+        end
+        pushtocolumn!(builder, col, zero(M), false) # if not present already, add structural zeros to diagonal
+        finalizecolumn!(builder)
+    end
+    ho = sparse(builder)
+    copy!(h0.h, ho) # Inject new structural zeros into zero harmonics
+    return ham
+end
+# IDEA: could sum and subtract all harmonics instead
+# Tested, it is slower
+
+function optimize!(ham::Hamiltonian{<:Lattice,L,M,A}) where {L,M,A<:AbstractMatrix}
+    # @warn "Hamiltonian is not sparse. Nothing changed."
+    return ham
+end
+
+function optimize!(ham::Hamiltonian{<:Superlattice})
+    # @warn "Hamiltonian is defined on a Superlattice. Nothing changed."
+    return ham
+end
+
+
+"""
+    flatten(h::Hamiltonian)
+
+Flatten a multiorbital Hamiltonian `h` into one with a single orbital per site. The
+associated lattice is flattened also, so that there is one site per orbital for each initial
+site (all at the same position). Note that in the case of sparse Hamiltonians, zeros in
+hopping/onsite matrices are preserved as structural zeros upon flattening.
+
+    h |> flatten()
+
+Functional form equivalent to `flatten(h)` of `h |> flatten` (included for consistency with
+the rest of the API).
+
+# Examples
+```
+julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(@SMatrix[1 2], range = 1/√3, sublats = (:A,:B)), orbitals = (Val(1), Val(2)))
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a,), (:a, :a))
+  Element type     : 2 × 2 blocks (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 6
+  Coordination     : 3.0
+
+julia> flatten(h)
+Hamiltonian{<:Lattice} : 2D Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 3 × 3
+  Orbitals         : ((:flat,), (:flat,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 12
+  Coordination     : 4.0
+```
+"""
+flatten() = h -> flatten(h)
+
+function flatten(h::Hamiltonian)
+    all(isequal(1), norbitals(h)) && return copy(h)
+    harmonics´ = [flatten(har, h.orbitals, h.lattice) for har in h.harmonics]
+    lattice´ = flatten(h.lattice, h.orbitals)
+    orbitals´ = (_ -> (:flat, )).(h.orbitals)
+    return Hamiltonian(lattice´, harmonics´, orbitals´)
+end
+
+flatten(h::HamiltonianHarmonic, orbs, lat) =
+    HamiltonianHarmonic(h.dn, _flatten(h.h, length.(orbs), lat))
+
+function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, norbs::NTuple{S,<:Any}, lat) where {N,T,S}
+    offsets´ = flattenoffsets(lat.unitcell.offsets, norbs)
+    dim´ = last(offsets´)
+
+    builder = SparseMatrixBuilder{T}(dim´, dim´, nnz(src) * N * N)
+
+    for col in 1:size(src, 2)
+        scol = sublat(lat, col)
+        for j in 1:norbs[scol]
+            for p in nzrange(src, col)
+                row = rowvals(src)[p]
+                srow = sublat(lat, row)
+                rowoffset´ = flattenind(row, lat, norbs, offsets´) - 1
+                val = nonzeros(src)[p]
+                for i in 1:norbs[srow]
+                    pushtocolumn!(builder, rowoffset´ + i, val[i, j])
+                end
+            end
+            finalizecolumn!(builder, false)
+        end
+    end
+    matrix = sparse(builder)
+    return matrix
+end
+
+function _flatten(src::DenseMatrix{<:SMatrix{N,N,T}}, norbs::NTuple{S,<:Any}, lat) where {N,T,S}
+    offsets´ = flattenoffsets(lat.unitcell.offsets, norbs)
+    dim´ = last(offsets´)
+    matrix = similar(src, T, dim´, dim´)
+
+    for col in 1:size(src, 2), row in 1:size(src, 1)
+        srow, scol = sublat(lat, row), sublat(lat, col)
+        nrow, ncol = norbs[srow], norbs[scol]
+        val = src[row, col]
+        rowoffset´ = flattenind(row, lat, norbs, offsets´) - 1
+        coloffset´ = flattenind(col, lat, norbs, offsets´) - 1
+        for j in 1:ncol, i in 1:nrow
+            matrix[rowoffset´ + i, coloffset´ + j] = val[i, j]
+        end
+    end
+    return matrix
+end
+
+# sublat offsets after flattening (without padding zeros)
+function flattenoffsets(offsets, norbs)
+    offsets´ = similar(offsets)
+    i = 0
+    for s in eachindex(norbs)
+        offsets´[s] = i
+        ns = offsets[s + 1] - offsets[s]
+        no = norbs[s]
+        i += ns * no
+    end
+    offsets´[end] = i
+    return offsets´
+end
+
+# index of first orbital of site i after flattening
+function flattenind(i, lat, norbs, offsets´)
+    s = sublat(lat, i)
+    offset = lat.unitcell.offsets[s]
+    Δi = i - offset
+    i´ = offsets´[s] + (Δi - 1) * norbs[s] + 1
+    return i´
+end
+
+function flatten(lat::Lattice, orbs)
+    length(orbs) == nsublats(lat) || throw(ArgumentError("Msmatch between sublattices and orbitals"))
+    unitcell´ = flatten(lat.unitcell, length.(orbs))
+    bravais´ = lat.bravais
+    lat´ = Lattice(bravais´, unitcell´)
+end
+
+function flatten(unitcell::Unitcell, norbs::NTuple{S,Int}) where {S}
+    offsets´ = flattenoffsets(unitcell.offsets, norbs)
+    ns´ = last(offsets´)
+    sites´ = similar(unitcell.sites, ns´)
+    i = 1
+    for sl in 1:S, site in sites(unitcell, sl), rep in 1:norbs[sl]
+        sites´[i] = site
+        i += 1
+    end
+    names´ = unitcell.names
+    unitcell´ = Unitcell(sites´, names´, offsets´)
+    return unitcell´
+end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,0 +1,341 @@
+#######################################################################
+# BoxIterator
+#######################################################################
+
+"""
+    BoxIterator(seed::SVector{N,Int}; maxiterations = missing)
+
+Cartesian iterator `iter` over `SVector{N,Int}`s (`cell`s) that starts at `seed` and
+grows outwards in the form of a box of increasing sides (not necesarily equal) until
+it encompasses a certain N-dimensional region. To signal that a cell is in the desired
+region the user calls `acceptcell!(iter, cell)`.
+"""
+struct BoxIterator{N,MI<:Union{Int,Missing}}
+    seed::SVector{N,Int}
+    maxiter::MI
+    dimdir::MVector{2,Int}
+    nmoves::MVector{N,Bool}
+    pmoves::MVector{N,Bool}
+    npos::MVector{N,Int}
+    ppos::MVector{N,Int}
+end
+
+Base.IteratorSize(::BoxIterator) = Base.SizeUnknown()
+
+Base.IteratorEltype(::BoxIterator) = Base.HasEltype()
+
+Base.eltype(::BoxIterator{N}) where {N} = SVector{N,Int}
+
+Base.CartesianIndices(b::BoxIterator) =
+    CartesianIndices(UnitRange.(Tuple(b.npos), Tuple(b.ppos)))
+
+function BoxIterator(seed::SVector{N}; maxiterations = missing) where {N}
+    BoxIterator(seed, maxiterations, MVector(1, 2),
+        ones(MVector{N,Bool}), ones(MVector{N,Bool}), MVector{N,Int}(seed), MVector{N,Int}(seed))
+end
+
+function iteratorreset!(b::BoxIterator{N}) where {N}
+    b.dimdir[1] = 1
+    b.dimdir[2] = 2
+    b.nmoves .= ones(MVector{N,Bool})
+    b.pmoves .= ones(MVector{N,Bool})
+    b.npos   .= MVector(b.seed)
+    b.ppos   .= MVector(b.seed)
+    return nothing
+end
+
+struct BoxIteratorState{N}
+    range::CartesianIndices{N, NTuple{N,UnitRange{Int}}}
+    rangestate::CartesianIndex{N}
+    iteration::Int
+end
+
+Base.iterate(b::BoxIterator{0}) = (SVector{0,Int}(), nothing)
+Base.iterate(b::BoxIterator{0}, state) = nothing
+
+function Base.iterate(b::BoxIterator{N}) where {N}
+    range = CartesianIndices(ntuple(i -> b.seed[i]:b.seed[i], Val(N)))
+    itrange = iterate(range)
+    if itrange === nothing
+        return nothing
+    else
+        (cell, rangestate) = itrange
+        return (SVector(Tuple(cell)), BoxIteratorState(range, rangestate, 1))
+    end
+end
+
+function Base.iterate(b::BoxIterator{N}, s::BoxIteratorState{N}) where {N}
+    itrange = iterate(s.range, s.rangestate)
+    facedone = itrange === nothing
+    if facedone
+        alldone = !any(b.pmoves) && !any(b.nmoves) || isless(b.maxiter, s.iteration)
+        if alldone  # Last shells in all directions were empty, trim from boundingboxcorners
+            b.npos .+= 1
+            b.ppos .-= 1
+            return nothing
+        else
+            newrange = nextface!(b)
+            # newrange === nothing && return nothing
+            itrange = iterate(newrange)
+            # itrange === nothing && return nothing
+            (cell, rangestate) = itrange
+            return (SVector(Tuple(cell)), BoxIteratorState(newrange, rangestate, s.iteration + 1))
+        end
+    else
+        (cell, rangestate) = itrange
+        return (SVector(Tuple(cell)), BoxIteratorState(s.range, rangestate, s.iteration + 1))
+    end
+end
+
+function nextface!(b::BoxIterator{N}) where {N}
+    @inbounds for i in 1:2N
+        nextdimdir!(b)
+        newdim, newdir = Tuple(b.dimdir)
+        if newdir == 1
+            if b.nmoves[newdim]
+                b.npos[newdim] -= 1
+                b.nmoves[newdim] = false
+                return newrangeneg(b, newdim)
+            end
+        else
+            if b.pmoves[newdim]
+                b.ppos[newdim] += 1
+                b.pmoves[newdim] = false
+                return newrangepos(b, newdim)
+            end
+        end
+    end
+    return nothing
+end
+
+function nextdimdir!(b::BoxIterator{N}) where {N}
+    dim, dir = Tuple(b.dimdir)
+    if dim < N
+        dim += 1
+    else
+        dim = 1
+        dir = ifelse(dir == 1, 2, 1)
+    end
+    b.dimdir[1] = dim
+    b.dimdir[2] = dir
+    return nothing
+end
+
+@inline function newrangeneg(b::BoxIterator{N}, dim) where {N}
+    return CartesianIndices(ntuple(
+        i -> b.npos[i]:(i == dim ? b.npos[i] : b.ppos[i]),
+        Val(N)))
+end
+
+@inline function newrangepos(b::BoxIterator{N}, dim) where {N}
+    return CartesianIndices(ntuple(
+        i -> (i == dim ? b.ppos[i] : b.npos[i]):b.ppos[i],
+        Val(N)))
+end
+
+function acceptcell!(b::BoxIterator{N}, cell) where {N}
+    dim, dir = Tuple(b.dimdir)
+    if dir == 1
+        @inbounds for i in 1:N
+            (cell[i] == b.ppos[i]) && (b.pmoves[i] = true)
+            (i == dim || cell[i] == b.npos[i]) && (b.nmoves[i] = true)
+        end
+    else
+        @inbounds for i in 1:N
+            (i == dim || cell[i] == b.ppos[i]) && (b.pmoves[i] = true)
+            (cell[i] == b.npos[i]) && (b.nmoves[i] = true)
+        end
+    end
+    return nothing
+end
+
+# Fallback for non-BoxIterators
+acceptcell!(b, cell) = nothing
+
+#######################################################################
+# CoSort
+#######################################################################
+
+struct CoSortTup{T,Tv}
+    x::T
+    y::Tv
+end
+
+mutable struct CoSort{T,Tv,S<:AbstractVector{T},C<:AbstractVector{Tv}} <: AbstractVector{CoSortTup{T,Tv}}
+    sortvector::S
+    covector::C
+    offset::Int
+    function CoSort{T,Tv,S,C}(sortvector, covector, offset) where {T,Tv,S,C}
+        length(covector) >= length(sortvector) ? new(sortvector, covector, offset) :
+            throw(DimensionMismatch("Coarray length should exceed sorting array"))
+    end
+end
+
+CoSort(sortvector::S, covector::C) where {T,Tv,S<:AbstractVector{T},C<:AbstractVector{Tv}} =
+    CoSort{T,Tv,S,C}(sortvector, covector, 0)
+
+Base.size(c::CoSort) = (size(c.sortvector, 1) - c.offset,)
+
+Base.getindex(c::CoSort, i) =
+    CoSortTup(getindex(c.sortvector, i + c.offset), getindex(c.covector, i + c.offset))
+
+Base.setindex!(c::CoSort, t::CoSortTup, i) =
+    (setindex!(c.sortvector, t.x, i + c.offset); setindex!(c.covector, t.y, i + c.offset); c)
+
+Base.isless(a::CoSortTup, b::CoSortTup) = isless(a.x, b.x)
+
+Base.Sort.defalg(v::C) where {T<:Union{Number, Missing}, C<:CoSort{T}} = Base.DEFAULT_UNSTABLE
+
+isgrowing(c::CoSort) = isgrowing(c.sortvector, c.offset + 1)
+
+#######################################################################
+# SparseMatrixBuilder
+#######################################################################
+
+mutable struct SparseMatrixBuilder{T,S<:AbstractSparseMatrix{T}}
+    matrix::S
+    colcounter::Int
+    rowvalcounter::Int
+    cosorter::CoSort{Int,T,Vector{Int},Vector{T}}
+end
+
+struct UnfinalizedSparseMatrixCSC{Tv,Ti} <: AbstractSparseMatrix{Tv,Ti}
+    m::Int
+    n::Int
+    colptr::Vector{Ti}
+    rowval::Vector{Ti}
+    nzval::Vector{Tv}
+end
+
+function SparseMatrixBuilder{Tv}(m, n, nnzguess = missing) where {Tv}
+    colptr = [1]
+    rowval = Int[]
+    nzval = Tv[]
+    matrix = UnfinalizedSparseMatrixCSC(m, n, colptr, rowval, nzval)
+    builder = SparseMatrixBuilder(matrix, 1, 0, CoSort(rowval, nzval))
+    nnzguess === missing || sizehint!(builder, nnzguess)
+    return builder
+end
+
+# Unspecified size constructor
+SparseMatrixBuilder{Tv}() where Tv = SparseMatrixBuilder{Tv}(0, 0)
+
+function SparseMatrixBuilder(s::SparseMatrixCSC{Tv,Int}) where {Tv}
+    colptr = getcolptr(s)
+    rowval = rowvals(s)
+    nzval = nonzeros(s)
+    nnzguess = length(nzval)
+    resize!(rowval, 0)
+    resize!(nzval, 0)
+    resize!(colptr, 1)
+    colptr[1] = 1
+    builder = SparseMatrixBuilder(s, 1, 0, CoSort(rowval, nzval))
+    sizehint!(builder, nnzguess)
+    return builder
+end
+
+SparseArrays.getcolptr(s::UnfinalizedSparseMatrixCSC) = s.colptr
+SparseArrays.nonzeros(s::UnfinalizedSparseMatrixCSC) = s.nzval
+SparseArrays.rowvals(s::UnfinalizedSparseMatrixCSC) = s.rowval
+Base.size(s::UnfinalizedSparseMatrixCSC) = (s.m, s.n)
+Base.size(s::UnfinalizedSparseMatrixCSC, k) = size(s)[k]
+
+function Base.sizehint!(s::SparseMatrixBuilder, n)
+    sizehint!(getcolptr(s.matrix), n + 1)
+    sizehint!(nonzeros(s.matrix), n)
+    sizehint!(rowvals(s.matrix), n)
+    return s
+end
+
+function pushtocolumn!(s::SparseMatrixBuilder, row::Int, x, skipdupcheck::Bool = true)
+    nrows = size(s.matrix, 1)
+    nrows == 0 || 1 <= row <= size(s.matrix, 1) || throw(ArgumentError("tried adding a row $row out of bounds ($(size(s.matrix, 1)))"))
+    if skipdupcheck || !isintail(row, rowvals(s.matrix), getcolptr(s.matrix)[s.colcounter])
+        push!(rowvals(s.matrix), row)
+        push!(nonzeros(s.matrix), x)
+        s.rowvalcounter += 1
+    end
+    return s
+end
+
+function isintail(element, container, start::Int)
+    for i in start:length(container)
+        container[i] == element && return true
+    end
+    return false
+end
+
+function finalizecolumn!(s::SparseMatrixBuilder, sortcol::Bool = true)
+    size(s.matrix, 2) > 0 && s.colcounter > size(s.matrix, 2) && throw(DimensionMismatch("Pushed too many columns to matrix"))
+    if sortcol
+        s.cosorter.offset = getcolptr(s.matrix)[s.colcounter] - 1
+        sort!(s.cosorter)
+        isgrowing(s.cosorter) || throw(error("Internal error: repeated rows"))
+    end
+    s.colcounter += 1
+    push!(getcolptr(s.matrix), s.rowvalcounter + 1)
+    return nothing
+end
+
+function finalizecolumn!(s::SparseMatrixBuilder, ncols::Int)
+    for _ in 1:ncols
+        finalizecolumn!(s)
+    end
+    return nothing
+end
+
+function SparseArrays.sparse(s::SparseMatrixBuilder{<:Any,<:SparseMatrixCSC})
+    completecolptr!(getcolptr(s.matrix), size(s.matrix, 2), s.rowvalcounter)
+    return s.matrix
+end
+
+function completecolptr!(colptr, cols, lastrowptr)
+    colcounter = length(colptr)
+    if colcounter < cols + 1
+        resize!(colptr, cols + 1)
+        for col in (colcounter + 1):(cols + 1)
+            colptr[col] = lastrowptr + 1
+        end
+    end
+    return colptr
+end
+
+function SparseArrays.sparse(s::SparseMatrixBuilder{<:Any,<:UnfinalizedSparseMatrixCSC})
+    m, n = size(s.matrix)
+    rowval = rowvals(s.matrix)
+    colptr = getcolptr(s.matrix)
+    nzval = nonzeros(s.matrix)
+    if m != 0 && n != 0
+        completecolptr!(colptr, n, s.rowvalcounter)
+    else # determine size of matrix after the fact
+        m, n = isempty(rowval) ? 0 : maximum(rowval), s.colcounter - 1
+    end
+    return SparseMatrixCSC(m, n, colptr, rowval, nzval)
+end
+
+#######################################################################
+# SparseMatrixReader
+#######################################################################
+
+struct SparseMatrixReader{Tv,Ti}
+    matrix::SparseMatrixCSC{Tv,Ti}
+end
+
+Base.IteratorSize(::SparseMatrixReader) = Base.HasLength()
+
+Base.IteratorEltype(::SparseMatrixReader) = Base.HasEltype()
+
+Base.eltype(::SparseMatrixReader{Tv,Ti}) where {Tv,Ti} = Tuple{Ti,Ti,Tv}
+
+Base.length(s::SparseMatrixReader) = nnz(s.matrix)
+
+function Base.iterate(s::SparseMatrixReader, state = (1, 1))
+    (ptr, col) = state
+    ptr > length(s) && return nothing
+    @inbounds while ptr > s.matrix.colptr[col + 1] - 1
+         col += 1
+    end
+    return (s.matrix.rowval[ptr], col, s.matrix.nzval[ptr], ptr), (ptr + 1, col)
+end
+
+enumerate_sparse(s::SparseMatrixCSC) = SparseMatrixReader(s)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -1,0 +1,828 @@
+abstract type AbstractLattice{E,L,T} end
+
+#######################################################################
+# Sublat (sublattice)
+#######################################################################
+struct Sublat{E,T}
+    sites::Vector{SVector{E,T}}
+    name::NameType
+end
+
+Base.empty(s::Sublat) = Sublat(empty(s.sites), s.name)
+
+Base.copy(s::Sublat) = Sublat(copy(s.sites), s.name)
+
+Base.show(io::IO, s::Sublat{E,T}) where {E,T} = print(io,
+"Sublat{$E,$T} : sublattice of $T-typed sites in $(E)D space
+  Sites    : $(length(s.sites))
+  Name     : $(displayname(s))")
+
+displayname(s::Sublat) = s.name == nametype(:_) ? "pending" : string(":", s.name)
+# displayorbitals(s::Sublat) = string("(", join(string.(":", s.orbitals), ", "), ")")
+nsites(s::Sublat) = length(s.sites)
+
+# External API #
+
+"""
+    sublat(sites...; name::$(NameType), orbitals = (:noname,))
+    sublat(sites::Vector{<:SVector}; name::$(NameType), orbitals = (:noname,))
+
+Create a `Sublat{E,T,D}` that adds a sublattice, of name `name`, with sites at positions
+`sites` in `E` dimensional space, each of which hosts `D` different orbitals, with orbital
+names specified by `orbitals`. Sites can be entered as tuples or `SVectors`.
+
+# Examples
+```jldoctest
+julia> sublat((0.0, 0), (1, 1), (1, -1), name = :A, orbitals = (:upspin, :downspin))
+Sublat{2,Float64,2} : sublattice in 2D space with 2 orbitals per site
+  Sites    : 3
+  Name     : :A
+  Orbitals : (:upspin, :downspin)
+```
+"""
+sublat(sites::Vector{<:SVector}; name = :_, kw...) =
+    Sublat(sites, nametype(name))
+sublat(vs::Union{Tuple,AbstractVector{<:Number}}...; kw...) = sublat(toSVectors(vs...); kw...)
+
+# transform!(s::S, f::F) where {S <: Sublat,F <: Function} = (s.sites .= f.(s.sites); s)
+
+#######################################################################
+# Bravais
+#######################################################################
+struct Bravais{E,L,T,EL}
+    matrix::SMatrix{E,L,T,EL}
+    semibounded::SVector{L,Bool}
+end
+
+Bravais{E,T}() where {E,T} = Bravais(SMatrix{E,0,T,0}(), SVector{0,Bool}())
+
+displayvectors(br::Bravais) = displayvectors(br.matrix)
+
+Base.show(io::IO, b::Bravais{E,L,T}) where {E,L,T} = print(io,
+"Bravais{$E,$L,$T} : set of $L Bravais vectors in $(E)D space.
+  Vectors     : $(displayvectors(b))
+  Matrix      : $(b.matrix),
+  Semibounded : $(issemibounded(b) ? display_as_tuple(findall(b.semibounded)) : "none")")
+
+# External API #
+
+"""
+    bravais(vecs...; semibounded = false)
+    bravais(matrix; semibounded = false)
+
+Create a `Bravais{E,L}` that adds `L` Bravais vectors `vecs` in `E` dimensional space,
+alternatively given as the columns of matrix `mat`. For higher instantiation efficiency
+enter `vecs` as `Tuple`s or `SVector`s and `mat` as `SMatrix`.
+
+To create semibounded lattices along some or all Bravais vectors, use `semibounded`. A
+`semibounded = true` makes all axes semibounded. A `semibounded = (axes::Int...)` indicates
+the indices of axes to be made semibounded. A tuple of Booleans, one per Bravais axes,
+`semibounded = issemi::NTuple{L,Bool}` is also allowed. Note that semibounded lattices
+always extend toward positive multiples of Bravais vectors. To invert the direction, invert
+the vectors.
+
+We can scale a `b::Bravais` simply by multiplying it with a factor `a`, like `a * b`.
+
+    bravais(lat::Lattice)
+    bravais(h::Hamiltonian)
+
+Obtain the Bravais matrix of lattice `lat` or Hamiltonian `h`
+
+# Examples
+```jldoctest
+julia> bravais((1.0, 2), (3, 4))
+Bravais{2,2,Float64} : set of 2 Bravais vectors in 2D space.
+  Vectors : ((1.0, 2.0), (3.0, 4.0))
+  Matrix  : [1.0 3.0; 2.0 4.0]
+```
+
+# See also:
+    semibounded
+"""
+bravais(vs::Union{Tuple,AbstractVector,AbstractMatrix}...; semibounded = false, kw...) =
+    (s = toSMatrix(vs...); Bravais(s, sanitize_semibounded(semibounded, s)))
+
+bravais(lat::AbstractLattice) = lat.bravais.matrix
+
+sanitize_semibounded(sb::Bool, ::SMatrix{E,L}) where {E,L} =
+    SVector{L,Bool}(filltuple(sb, Val(L))) # need to specify type becaus of L=0 case
+sanitize_semibounded(sb::Int, s::SMatrix{E,L}) where {E,L} =
+    sanitize_semibounded((sb,), s)
+sanitize_semibounded(sb::NTuple{L,Bool}, ::SMatrix{E,L}) where {E,L} = SVector{L,Bool}(sb)
+sanitize_semibounded(sb, ::SMatrix{E,L}) where {E,L} =
+    SVector{L,Bool}(ntuple(i -> i in sb, Val(L)))
+
+transform(b::Bravais{E,0}, f::F) where {E,F<:Function} = b
+
+function transform(b::Bravais{E,L,T}, f::F) where {E,L,T,F<:Function}
+    svecs = let z = zero(SVector{E,T})
+        ntuple(i -> f(b.matrix[:, i]) - f(z), Val(L))
+    end
+    matrix = hcat(svecs...)
+    return Bravais(matrix, b.semibounded)
+end
+
+Base.:*(factor::Number, b::Bravais) = Bravais(factor * b.matrix, b.semibounded)
+Base.:*(b::Bravais, factor::Number) = Bravais(b.matrix * factor, b.semibounded)
+
+issemibounded(b::Bravais) = !iszero(b.semibounded)
+
+#######################################################################
+# Unitcell
+#######################################################################
+struct Unitcell{E,T,N}
+    sites::Vector{SVector{E,T}}
+    names::NTuple{N,NameType}
+    offsets::Vector{Int}        # Linear site number offsets for each sublat
+end                             # so that diff(offset) == sublatsites
+
+
+Unitcell(sublats::Sublat...; kw...) = Unitcell(promote(sublats...); kw...)
+Unitcell(sublats::NTuple{N,Sublat{E,T}};
+    dim = Val(E), type = float(T), names = [s.name for s in sublats], kw...) where {N,E,T} =
+    _Unitcell(sublats, dim, type, names)
+
+# Dynamic dispatch
+_Unitcell(sublats, dim::Integer, type, names) = _Unitcell(sublats, Val(dim), type, names)
+
+function _Unitcell(sublats::NTuple{N,Sublat}, dim::Val{E}, type::Type{T}, names) where {N,E,T}
+    sites = SVector{E,T}[]
+    offsets = [0]  # length(offsets) == length(sublats) + 1
+    for s in eachindex(sublats)
+        for site in sublats[s].sites
+            push!(sites, padright(site, Val(E)))
+        end
+        push!(offsets, length(sites))
+    end
+    names´ = uniquenames(sanitize_names(names, Val(N)))
+    return Unitcell(sites, names´, offsets)
+end
+
+sanitize_names(name::Union{NameType,Int}, ::Val{N}) where {N} = ntuple(_ -> NameType(name), Val(N))
+sanitize_names(names::AbstractVector, ::Val{N}) where {N} = ntuple(i -> NameType(names[i]), Val(N))
+sanitize_names(names::NTuple{N,Union{NameType,Int}}, ::Val{N}) where {N} = NameType.(names)
+
+function uniquenames(names::NTuple{N,NameType}) where {N}
+    namesvec = [names...]
+    allnames = NameType[:_]
+    for i in eachindex(names)
+        namesvec[i] in allnames && (namesvec[i] = uniquename(allnames, namesvec[i], i))
+        push!(allnames, namesvec[i])
+    end
+    names´ = ntuple(i -> namesvec[i], Val(N))
+    return names´
+end
+
+function uniquename(allnames, name, i)
+    newname = nametype(Char(64+i)) # Lexicographic, starting from Char(65) = 'A'
+    return newname in allnames ? uniquename(allnames, name, i + 1) : newname
+end
+
+sites(u::Unitcell) = u.sites
+sites(u::Unitcell, s::Int) = view(u.sites, siterange(u, s))
+
+siteindex(u::Unitcell, sublat, idx) = idx + u.offsets[sublat]
+
+siterange(u::Unitcell, sublat) = (1+u.offsets[sublat]):u.offsets[sublat+1]
+
+nsites(u::Unitcell) = length(u.sites)
+nsites(u::Unitcell, sublat) = sublatsites(u)[sublat]
+
+offsets(u::Unitcell) = u.offsets
+
+sublat(u::Unitcell, siteidx) = Int(findlast(o -> o < siteidx, u.offsets))
+
+sublatsites(u::Unitcell) = diff(u.offsets)
+
+nsublats(u::Unitcell) = length(u.names)
+
+sublats(u::Unitcell) = 1:nsublats(u)
+
+transform!(u::Unitcell, f::Function) = (u.sites .= f.(u.sites); u)
+
+Base.copy(u::Unitcell) = Unitcell(copy(u.sites), u.names, copy(u.offsets))
+
+#######################################################################
+# Lattice
+#######################################################################
+struct Lattice{E,L,T<:AbstractFloat,B<:Bravais{E,L,T},U<:Unitcell{E,T}} <: AbstractLattice{E,L,T}
+    bravais::B
+    unitcell::U
+end
+
+displaynames(l::AbstractLattice) = display_as_tuple(l.unitcell.names, ":")
+
+function Base.show(io::IO, lat::Lattice)
+    i = get(io, :indent, "")
+    hassemi = issemibounded(lat.bravais)
+    print(io, i, summary(lat), "\n",
+"$i  Bravais vectors : $(displayvectors(lat.bravais.matrix; digits = 6))", hassemi ? "
+$i    Semibounded   : $(display_as_tuple(findall(lat.bravais.semibounded)))" : "", "
+$i  Sublattices     : $(nsublats(lat))
+$i    Names         : $(displaynames(lat))
+$i    Sites         : $(display_as_tuple(sublatsites(lat))) --> $(nsites(lat)) total per unit cell")
+end
+
+Base.summary(::Lattice{E,L,T}) where {E,L,T} =
+    "Lattice{$E,$L,$T} : $(L)D lattice in $(E)D space"
+
+# External API #
+
+"""
+    lattice([bravais::Bravais,] sublats::Sublat...; dim::Val{E}, type::T, names)
+
+Create a `Lattice{E,L,T}` with Bravais matrix `bravais` and sublattices `sublats`
+converted to a common  `E`-dimensional embedding space and type `T`. To override the
+embedding  dimension `E`, use keyword `dim = Val(E)`. Similarly, override type `T` with
+`type = T`.
+
+The keywords `names` can be used to rename `sublats`. Given names can be replaced to ensure
+that all sublattice names are unique.
+
+See also `LatticePresets` for built-in lattices.
+
+# Examples
+```jldoctest
+julia> lattice(bravais((1, 0)), sublat((0, 0)), sublat((0, Float32(1))); dim = Val(3))
+Lattice{3,1,Float32} : 1D lattice in 3D space
+  Bravais vectors : ((1.0, 0.0, 0.0),)
+  Sublattices     : 2
+    Names         : (:A, :B)
+    Sites         : (1, 1) --> 2 total per unit cell
+
+julia> LatticePresets.honeycomb(semibounded = 1, names = (:C, :D))
+Lattice{2,2,Float64} : 2D lattice in 2D space
+  Bravais vectors : ((0.5, 0.866025), (-0.5, 0.866025))
+    Semibounded   : (1)
+  Sublattices     : 2
+    Names         : (:C, :D)
+    Sites         : (1, 1) --> 2 total per unit cell
+```
+
+# See also:
+    LatticePresets, bravais, sublat, supercell, intracell
+"""
+lattice(s::Sublat, ss::Sublat...; kw...) = _lattice(Unitcell(s, ss...; kw...))
+_lattice(u::Unitcell{E,T}) where {E,T} = Lattice(Bravais{E,T}(), u)
+lattice(br::Bravais, s::Sublat, ss::Sublat...; kw...) = lattice(br, Unitcell(s, ss...; kw...))
+
+function lattice(bravais::Bravais{E2,L2}, unitcell::Unitcell{E,T}) where {E2,L2,E,T}
+    L = min(E,L2) # L should not exceed E
+    Lattice(convert(Bravais{E,L,T}, bravais), unitcell)
+end
+
+issemibounded(lat::Lattice) = issemibounded(lat.bravais)
+
+"""
+    dims(lat::Lattice{E,L}) -> (E, L)
+
+Return a tuple `(E, L)` of the embedding and lattice dimensions of `lat`
+"""
+dims(lat::Lattice{E,L}) where {E,L} = E, L
+
+#######################################################################
+# Supercell
+#######################################################################
+struct Supercell{L,L´,M<:Union{Missing,OffsetArray{Bool}},S<:SMatrix{L,L´}} # L´ is supercell dim
+    matrix::S
+    sites::UnitRange{Int}
+    cells::CartesianIndices{L,NTuple{L,UnitRange{Int}}}
+    mask::M
+    semibounded::SVector{L´,Bool}
+end
+
+# Supercell{L}(ns::Integer) where {L} =
+#     Supercell(SMatrix{L,L,Int,L*L}(I), 1:ns, CartesianIndices(ntuple(_->0:0, Val(L))),
+#               missing, filltuple(false, Val(L)))
+
+dim(::Supercell{L,L´}) where {L,L´} = L´
+
+nsites(s::Supercell{L,L´,<:OffsetArray}) where {L,L´} = sum(s.mask)
+nsites(s::Supercell{L,L´,Missing}) where {L,L´} = length(s.sites) * length(s.cells)
+
+Base.CartesianIndices(s::Supercell) = s.cells
+
+function Base.show(io::IO, s::Supercell{L,L´}) where {L,L´}
+    hassemi = issemibounded(s)
+    i = get(io, :indent, "")
+    print(io, i,
+"Supercell{$L,$(L´)} for $(L´)D superlattice of the base $(L)D lattice
+$i  Supervectors  : $(displayvectors(s.matrix))
+$i  Supersites    : $(nsites(s))", hassemi ? "
+$i  Semibounded   : $(display_as_tuple(findall(s.semibounded)))" : "")
+end
+
+ismasked(s::Supercell{L,L´,<:OffsetArray})  where {L,L´} = true
+ismasked(s::Supercell{L,L´,Missing})  where {L,L´} = false
+
+isinmask(s::Supercell{L,L´,<:OffsetArray}, site, dn) where {L,L´} = s.mask[site, Tuple(dn)...]
+isinmask(s::Supercell{L,L´,Missing}, site, dn) where {L,L´} = true
+isinmask(s::Supercell{L,L´,<:OffsetArray}, site) where {L,L´} = s.mask[site]
+isinmask(s::Supercell{L,L´,Missing}, site) where {L,L´} = true
+
+issemibounded(sc::Supercell) = !iszero(sc.semibounded)
+
+Base.copy(s::Supercell{<:Any,<:Any,Missing}) =
+    Supercell(copy(s.matrix), s.sites, s.cells, s.mask, s.semibounded)
+
+Base.copy(s::Supercell{<:Any,<:Any,<:AbstractArray}) =
+    Supercell(copy(s.matrix), s.sites, s.cells, copy(s.mask), s.semibounded)
+
+#######################################################################
+# Superlattice
+#######################################################################
+struct Superlattice{E,L,T<:AbstractFloat,L´,S<:Supercell{L,L´},B<:Bravais{E,L,T},U<:Unitcell{E,T}} <: AbstractLattice{E,L,T}
+    bravais::B
+    unitcell::U
+    supercell::S
+end
+
+function Base.show(io::IO, lat::Superlattice)
+    i = get(io, :indent, "")
+    hassemi = issemibounded(lat.bravais)
+    ioindent = IOContext(io, :indent => string(i, "  "))
+    print(io, i, summary(lat), "\n",
+"$i  Bravais vectors : $(displayvectors(lat.bravais.matrix; digits = 6))", hassemi ? "
+$i    Semibounded   : $(display_as_tuple(findall(lat.bravais.semibounded)))" : "", "
+$i  Sublattices     : $(nsublats(lat))
+$i    Names         : $(displaynames(lat))
+$i    Sites         : $(display_as_tuple(sublatsites(lat))) --> $(nsites(lat)) total per unit cell\n")
+    print(ioindent, lat.supercell)
+end
+
+Base.summary(::Superlattice{E,L,T,L´}) where {E,L,T,L´} =
+    "Superlattice{$E,$L,$T,$L´} : $(L)D lattice in $(E)D space, filling a $(L´)D supercell"
+
+# apply f to trues in mask. Arguments are s = sublat, oldi = old site, dn, newi = new site
+function foreach_supersite(f::F, lat::Superlattice) where {F<:Function}
+    newi = 0
+    for s in 1:nsublats(lat), oldi in siterange(lat, s)
+        for dn in CartesianIndices(lat.supercell)
+            if isinmask(lat.supercell, oldi, dn)
+                newi += 1
+                f(s, oldi, toSVector(Int, Tuple(dn)), newi)
+            end
+        end
+    end
+    return nothing
+end
+
+issemibounded(lat::Superlattice) = issemibounded(lat.supercell)
+
+#######################################################################
+# AbstractLattice interface
+#######################################################################
+
+Base.copy(lat::Lattice) = Lattice(lat.bravais, copy(lat.unitcell))
+Base.copy(lat::Superlattice) = Superlattice(lat.bravais, copy(lat.unitcell), copy(lat.supercell))
+
+numbertype(::AbstractLattice{E,L,T}) where {E,L,T} = T
+positiontype(::AbstractLattice{E,L,T}) where {E,L,T} = SVector{E,T}
+dntype(::AbstractLattice{E,L}) where {E,L} = SVector{L,Int}
+
+sublat(lat::AbstractLattice, siteidx) = sublat(lat.unitcell, siteidx)
+sublats(lat::AbstractLattice) = sublats(lat.unitcell)
+
+siterange(lat::AbstractLattice, sublat) = siterange(lat.unitcell, sublat)
+
+siteindex(lat::AbstractLattice, sublat, idx) = siteindex(lat.unitcell, sublat, idx)
+
+offsets(lat::AbstractLattice) = offsets(lat.unitcell)
+
+sublatsites(lat::AbstractLattice) = sublatsites(lat.unitcell)
+
+nsites(lat::AbstractLattice) = nsites(lat.unitcell)
+nsites(lat::AbstractLattice, sublat) = nsites(lat.unitcell, sublat)
+
+nsublats(lat::AbstractLattice) = nsublats(lat.unitcell)
+
+issuperlattice(lat::Lattice) = false
+issuperlattice(lat::Superlattice) = true
+
+ismasked(lat::Lattice) = false
+ismasked(lat::Superlattice) = ismasked(lat.supercell)
+
+maskranges(lat::Superlattice) = (1:nsites(lat), lat.supercell.cells.indices...)
+maskranges(lat::Lattice) = (1:nsites(lat),)
+
+# External API #
+
+"""
+    sites(lat[, sublat::Int])
+
+Extract the positions of all sites in a lattice, or in a specific sublattice
+"""
+sites(lat::AbstractLattice) = sites(lat.unitcell)
+sites(lat::AbstractLattice, s) = sites(lat.unitcell, s)
+
+"""
+    transform!(lat::Lattice, f::Function)
+
+Transform the site positions of `lat` by applying `f` to them in place.
+"""
+function transform!(lat::Lattice, f::Function)
+    transform!(lat.unitcell, f)
+    bravais´ = transform(lat.bravais, f)
+    return Lattice(bravais´, lat.unitcell)
+end
+
+"""
+    combine(lats::Lattice...)
+
+If all `lats` have compatible Bravais vectors, combine them into a single lattice.
+Sublattice names are renamed to be unique if necessary.
+"""
+function combine(lats::Lattice...)
+    is_bravais_compatible(lats...) || throw(ArgumentError("Lattices must share all Bravais vectors, $(bravais.(lats))"))
+    bravais´ = first(lats).bravais
+    unitcell´ = combine((l -> l.unitcell).(lats)...)
+    return Lattice(bravais´, unitcell´)
+end
+
+function combine(us::Vararg{Unitcell,N}) where {N}
+    sites = vcat(ntuple(i -> us[i].sites, Val(N))...)
+    names = uniquenames(tuplejoin(ntuple(i -> us[i].names, Val(N))...))
+    offsets = combined_offsets(us...)
+    return Unitcell(sites, names, offsets)
+end
+
+is_bravais_compatible() = true
+is_bravais_compatible(lat::Lattice, lats::Lattice...) = all(l -> isequal(lat.bravais, l.bravais), lats)
+
+function Base.isequal(b1::Bravais{E,L}, b2::Bravais{E,L}) where {E,L}
+    vs1 = ntuple(i -> b1.matrix[:, i], Val(L))
+    vs2 = ntuple(i -> b2.matrix[:, i], Val(L))
+    for v2 in vs2
+        found = false
+        for v1 in vs1
+            (isapprox(v1, v2) || isapprox(v1, -v2)) && (found = true; break)
+        end
+        !found && return false
+    end
+    return true
+end
+
+function combined_offsets(us::Unitcell...)
+    nsubs = sum(nsublats, us)
+    offsets = Vector{Int}(undef, nsubs + 1)
+    lastoffset = 0
+    idx = 1
+    for u in us
+        for idx´ in 1:(length(u.offsets) - 1)
+            offsets[idx] = lastoffset + u.offsets[idx´]
+            idx += 1
+        end
+        lastoffset = u.offsets[end]
+    end
+    offsets[end] = lastoffset + last(us).offsets[end]
+    return offsets
+end
+
+#######################################################################
+# supercell
+#######################################################################
+"""
+    supercell(lat::AbstractLattice{E,L}, v::NTuple{L,Integer}...; region = missing)
+    supercell(lat::AbstractLattice{E,L}, sc::SMatrix{L,L´,Int}; region = missing)
+
+Generates a `Superlattice` from an `L`-dimensional lattice `lat` with Bravais vectors
+`br´= br * sc`, where `sc::SMatrix{L,L´,Int}` is the integer supercell matrix with the `L´`
+vectors `v`s as columns. If no `v` are given, the superlattice will be bounded. If `lat` has
+semibounded axes, these cannot be mixed with any other axes (they can only be removed, kept
+intact or scaled by a factor, see below).
+
+Only sites at position `r` such that `region(r) == true` will be included in the supercell.
+If `region` is missing, a Bravais unit cell perpendicular to the `v` axes will be selected
+for the `L-L´` non-periodic directions.
+
+    supercell(lattice::AbstractLattice{E,L}, factor::Integer; region = missing)
+
+Calls `supercell` with a uniformly scaled `sc = SMatrix{L,L}(factor * I)`
+
+    supercell(lattice::AbstractLattice, factors::Integer...; region = missing)
+
+Calls `supercell` with different scaling along each Bravais vector (diagonal supercell
+with factors along the diagonal)
+
+    lat |> supercell(v...; kw...)
+
+Functional syntax, equivalent to `supercell(lat, v...; kw...)
+
+    supercell(h::Hamiltonian, v...; kw...)
+
+Promotes the `Lattice` of `h` to a `Superlattice` without changing the Hamiltonian itself,
+which always refers to the unitcell of the lattice.
+
+# Examples
+```jldoctest
+julia> supercell(LatticePresets.honeycomb(), region = RegionPresets.circle(300))
+Superlattice{2,2,Float64,0} : 2D lattice in 2D space, filling a 0D supercell
+  Bravais vectors : ((0.5, 0.866025), (-0.5, 0.866025))
+  Sublattices     : 2
+    Names         : (:A, :B)
+    Orbitals      : ((:noname,), (:noname,))
+    Sites         : (1, 1) --> 2 total per unit cell
+  Supercell{2,0} for 0D superlattice of the base 2D lattice
+    Supervectors  : ()
+    Supersites    : 652966
+
+julia> supercell(LatticePresets.triangular(), (1,1), (1, -1))
+Superlattice{2,2,Float64,2} : 2D lattice in 2D space, filling a 2D supercell
+  Bravais vectors : ((0.5, 0.866025), (-0.5, 0.866025))
+  Sublattices     : 1
+    Names         : (:A)
+    Orbitals      : ((:noname,),)
+    Sites         : (1) --> 1 total per unit cell
+  Supercell{2,2} for 2D superlattice of the base 2D lattice
+    Supervectors  : ((1, 1), (1, -1))
+    Supersites    : 2
+
+julia> LatticePresets.square() |> supercell(3)
+Superlattice{2,2,Float64,2} : 2D lattice in 2D space, filling a 2D supercell
+  Bravais vectors : ((1.0, 0.0), (0.0, 1.0))
+  Sublattices     : 1
+    Names         : (:A)
+    Orbitals      : ((:noname,),)
+    Sites         : (1) --> 1 total per unit cell
+  Supercell{2,2} for 2D superlattice of the base 2D lattice
+    Supervectors  : ((3, 0), (0, 3))
+    Supersites    : 9
+```
+
+# See also:
+    unitcell
+"""
+supercell(v::Union{SMatrix,Tuple,SVector,Integer}...; kw...) = lat -> supercell(lat, v...; kw...)
+
+supercell(lat::AbstractLattice{E,L}; kw...) where {E,L} =
+    supercell(lat, SMatrix{L,0,Int}(); kw...)
+supercell(lat::AbstractLattice{E,L}, factors::Vararg{<:Integer,L}; kw...) where {E,L} =
+    _supercell(lat, factors...)
+supercell(lat::AbstractLattice{E,L}, factors::Vararg{<:Integer,L´}; kw...) where {E,L,L´} =
+    throw(ArgumentError("Provide either a single scaling factor or one for each of the $L lattice dimensions"))
+supercell(lat::AbstractLattice{E,L}, factor::Integer; kw...) where {E,L} =
+    _supercell(lat, ntuple(_ -> factor, Val(L))...)
+supercell(lat::AbstractLattice, vecs::NTuple{L,Integer}...; region = missing) where {L} =
+    _supercell(lat, toSMatrix(Int, vecs...), region)
+supercell(lat::AbstractLattice, s::SMatrix; region = missing) = _supercell(lat, s, region)
+
+function _supercell(lat::AbstractLattice{E,L}, factors::Vararg{Integer,L}) where {E,L}
+    scmatrix = SMatrix{L,L,Int}(Diagonal(SVector(factors)))
+    sites = 1:nsites(lat)
+    cells = CartesianIndices((i -> 0 : i - 1).(factors))
+    mask = missing
+    semibounded = supercell_semibounded(lat, scmatrix)
+    supercell = Supercell(scmatrix, sites, cells, mask, semibounded)
+    return Superlattice(lat.bravais, lat.unitcell, supercell)
+end
+
+function _supercell(lat::AbstractLattice{E,L}, scmatrix::SMatrix{L,L´,Int}, region) where {E,L,L´}
+    semibounded = supercell_semibounded(lat, scmatrix)
+    brmatrix = lat.bravais.matrix
+    regionfunc = region === missing ? ribbonfunc(brmatrix, scmatrix) : region
+    in_supercell_func = is_perp_dir(scmatrix)
+    cells = supercell_cells(lat, regionfunc, in_supercell_func)
+    ns = nsites(lat)
+    mask = OffsetArray(BitArray(undef, ns, size(cells)...), 1:ns, cells.indices...)
+    @inbounds for dn in cells
+        dntup = Tuple(dn)
+        dnvec = toSVector(Int, dntup)
+        in_supercell = in_supercell_func(dnvec)
+        in_supercell || (mask[:, dntup...] .= false; continue)
+        r0 = brmatrix * dnvec
+        for (i, site) in enumerate(lat.unitcell.sites)
+            r = site + r0
+            mask[i, dntup...] = in_supercell && regionfunc(r)
+        end
+    end
+    supercell = Supercell(scmatrix, 1:ns, cells, all(mask) ? missing : mask, semibounded)
+    return Superlattice(lat.bravais, lat.unitcell, supercell)
+end
+
+# This is true whenever old ndist is perpendicular to new lattice
+is_perp_dir(supercell) = let invs = pinvmultiple(supercell); dn -> iszero(new_dn(dn, invs)); end
+
+new_dn(oldndist, (pinvs, n)) = fld.(pinvs * oldndist, n)
+new_dn(oldndist, ::Tuple{<:SMatrix{0,0},Int}) = SVector{0,Int}()
+
+function ribbonfunc(bravais::SMatrix{E,L,T}, supercell::SMatrix{L,L´}) where {E,L,T,L´}
+    L <= L´ && return r -> true
+    # real-space supercell axes + all space
+    s = hcat(bravais * supercell, SMatrix{E,E,T}(I))
+    q = qr(s).Q
+    # last vecs in Q are orthogonal to axes
+    os = ntuple(i -> SVector(q[:,i+L´]), Val(E-L´))
+    # range of projected bravais, including zero
+    ranges = (o -> extrema(vcat(SVector(zero(T)), bravais' * o)) .- sqrt(eps(T))).(os)
+    # projector * r gives the projection of r on orthogonal vectors
+    projector = hcat(os...)'
+    # ribbon defined by r's with projection within ranges for all orthogonal vectors
+    regionfunc(r) = all(first.(ranges) .<= Tuple(projector * r) .< last.(ranges))
+    return regionfunc
+end
+
+function supercell_cells(lat::Lattice{E,L}, regionfunc, in_supercell_func) where {E,L}
+    bravais = lat.bravais.matrix
+    iter = BoxIterator(zero(SVector{L,Int}))
+    foundfirst = false
+    counter = 0
+    for dn in iter
+        found = false
+        counter += 1; counter == TOOMANYITERS &&
+            throw(ArgumentError("`region` seems unbounded (after $TOOMANYITERS iterations)"))
+        in_supercell = in_supercell_func(toSVector(Int, dn))
+        r0 = bravais * toSVector(Int, dn)
+        for site in lat.unitcell.sites
+            r = r0 + site
+            found = in_supercell && regionfunc(r)
+            if found || !foundfirst
+                acceptcell!(iter, dn)
+                foundfirst = found
+                break
+            end
+        end
+    end
+    c = CartesianIndices(iter)
+    return c
+end
+
+supercell_semibounded(lat::Lattice, s::SMatrix) = supercell_semibounded(lat.bravais, s)
+function supercell_semibounded(b::Bravais, s::SMatrix{L,L´,Int}) where {L,L´}
+    lsb = b.semibounded
+    err = ArgumentError("Cannot mix semibounded axes in a supercell")
+    ssb = ntuple(Val(L´)) do i
+        vec_semi = s[lsb, i]
+        vec_other = s[(!).(lsb), i]
+        if iszero(vec_other)
+            count(!iszero, vec_semi) != 1 && throw(err)
+            return true
+        else
+            iszero(vec_semi) || throw(err)
+            return false
+        end
+    end
+    return SVector{L´,Bool}(ssb)
+end
+
+#######################################################################
+# unitcell
+#######################################################################
+"""
+    unitcell(lat::Lattice{E,L}, v::NTuple{L,Integer}...; region = missing)
+    unitcell(lat::Lattice{E,L}, uc::SMatrix{L,L´,Int}; region = missing)
+
+Generates a `Lattice` from an `L`-dimensional lattice `lat` and a larger unit cell, such
+that its Bravais vectors are `br´= br * uc`. Here `uc::SMatrix{L,L´,Int}` is the integer
+unitcell matrix, with the `L´` vectors `v`s as columns. If no `v` are given, the new lattice
+will be bounded.
+
+Only sites at position `r` such that `region(r) == true` will be included in the new
+unitcell. If `region` is missing, a Bravais unitcell perpendicular to the `v` axes will be
+selected for the `L-L´` non-periodic directions.
+
+    unitcell(lattice::Lattice{E,L}, factor::Integer; region = missing)
+
+Calls `unitcell` with a uniformly scaled `uc = SMatrix{L,L}(factor * I)`
+
+    unitcell(lattice::Lattice{E,L}, factors::Integer...; region = missing)
+
+Calls `unitcell` with different scaling along each Bravais vector (diagonal supercell
+with factors along the diagonal)
+
+    unitcell(slat::Superlattice)
+
+Convert Superlattice `slat` into a lattice with its unit cell matching `slat`'s supercell.
+
+    unitcell(h::Hamiltonian, v...; modifiers = (), kw...)
+
+Transforms the `Lattice` of `h` to have a larger unitcell, while expanding the Hamiltonian
+accordingly. The modifiers (a tuple of `ElementModifier`s, either `onsite!` or `hopping!`)
+will be applied to onsite and hoppings as the hamiltonian is expanded. See `onsite!` and
+`hopping!` for details
+
+Note: for performance reasons, in sparse hamiltonians only the stored onsites and hoppings
+will be transformed by `ElementModifier`s, so you might want to add zero onsites or hoppings
+when building `h` to have a modifier applied to them later. Note also that additional
+onsites and hoppings may be stored when calling `optimize!` or `bloch`/`bloch!` on `h` for
+the first time.
+
+    lat_or_h |> unitcell(v...; kw...)
+
+Functional syntax, equivalent to `unitcell(lat_or_h, v...; kw...)
+
+# Examples
+```jldoctest
+julia> unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(300))
+Lattice{2,0,Float64} : 0D lattice in 2D space
+  Bravais vectors : ()
+  Sublattices     : 2
+    Names         : (:A, :B)
+    Orbitals      : ((:noname,), (:noname,))
+    Sites         : (326483, 326483) --> 652966 total per unit cell
+
+julia> unitcell(LatticePresets.triangular(), (1,1), (1, -1))
+Lattice{2,2,Float64} : 2D lattice in 2D space
+  Bravais vectors : ((0.0, 1.732051), (1.0, 0.0))
+  Sublattices     : 1
+    Names         : (:A)
+    Orbitals      : ((:noname,),)
+    Sites         : (2) --> 2 total per unit cell
+
+julia> LatticePresets.square() |> unitcell(3)
+Lattice{2,2,Float64} : 2D lattice in 2D space
+  Bravais vectors : ((3.0, 0.0), (0.0, 3.0))
+  Sublattices     : 1
+    Names         : (:A)
+    Orbitals      : ((:noname,),)
+    Sites         : (9) --> 9 total per unit cell
+
+julia> supercell(LatticePresets.square(), 3) |> unitcell
+Lattice{2,2,Float64} : 2D lattice in 2D space
+  Bravais vectors : ((3.0, 0.0), (0.0, 3.0))
+  Sublattices     : 1
+    Names         : (:A)
+    Orbitals      : ((:noname,),)
+    Sites         : (9) --> 9 total per unit cell
+```
+
+# See also:
+    supercell
+"""
+unitcell(v::Union{SMatrix,Tuple,SVector,Integer}...; kw...) = lat -> unitcell(lat, v...; kw...)
+unitcell(lat::Lattice, args...; kw...) = unitcell(supercell(lat, args...; kw...))
+
+function unitcell(lat::Superlattice)
+    newoffsets = supercell_offsets(lat)
+    newsites = supercell_sites(lat)
+    unitcell = Unitcell(newsites, lat.unitcell.names, newoffsets)
+    bravais = Bravais(lat.bravais.matrix * lat.supercell.matrix, lat.supercell.semibounded)
+    return Lattice(bravais, unitcell)
+end
+
+function supercell_offsets(lat::Superlattice)
+    sitecounts = zeros(Int, nsublats(lat) + 1)
+    foreach_supersite((s, oldi, dn, newi) -> sitecounts[s + 1] += 1, lat)
+    newoffsets = cumsum!(sitecounts, sitecounts)
+    return newoffsets
+end
+
+function supercell_sites(lat::Superlattice)
+    newsites = similar(lat.unitcell.sites, nsites(lat.supercell))
+    oldsites = lat.unitcell.sites
+    bravais = lat.bravais.matrix
+    foreach_supersite((s, oldi, dn, newi) -> newsites[newi] = bravais * dn + oldsites[oldi], lat)
+    return newsites
+end
+
+# #######################################################################
+# # semibounded
+# #######################################################################
+# """
+#     semibounded(lat::AbstractLattice, axes)
+
+# Create an AbstractLattice like `lat` but with a specific set of semibound axes. These can be
+# a boolean (i.e. all or none are semibounded), a tuple of booleans (one per axis) or a
+# collection of axis indices to make semibounded
+
+#     lat |> semibounded(axes)
+
+# Function form equivalent to semibounded(lat, axes)
+
+# # Examples
+# ```jldoctest
+# julia> semibounded(LatticePresets.honeycomb(), 2)
+# Lattice{2,2,Float64} : 2D lattice in 2D space
+#   Bravais vectors : ((0.5, 0.866025), (-0.5, 0.866025))
+#     Semibounded   : (2)
+#   Sublattices     : 2
+#     Names         : (:A, :B)
+#     Sites         : (1, 1) --> 2 total per unit cell
+
+# julia> LatticePresets.honeycomb() |> supercell(4) |> semibounded((true, false))
+# Superlattice{2,2,Float64,2} : 2D lattice in 2D space, filling a 2D supercell
+#   Bravais vectors : ((0.5, 0.866025), (-0.5, 0.866025))
+#   Sublattices     : 2
+#     Names         : (:A, :B)
+#     Sites         : (1, 1) --> 2 total per unit cell
+#   Supercell{2,2} for 2D superlattice of the base 2D lattice
+#     Supervectors  : ((4, 0), (0, 4))
+#     Supersites    : 32
+#     Semibounded   : (1)
+# ```
+# """
+# semibounded(axes) = lat -> semibounded(lat, axes)
+
+# function semibounded(lat::Lattice, axes = true)
+#     matrix = lat.bravais.matrix
+#     sb = sanitize_semibounded(axes, matrix)
+#     br = Bravais(matrix, sb)
+#     return Lattice(br, lat.unitcell)
+# end
+
+# function semibounded(lat::Superlattice, axes = true)
+#     sc = lat.supercell
+#     matrix = lat.bravais.matrix * sc.matrix
+#     sb = sanitize_semibounded(axes, matrix)
+#     scell = Supercell(sc.matrix, sc.sites, sc.cells, sc.mask, sb)
+#     return Superlattice(lat.bravais, lat.unitcell, scell)
+# end

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1,0 +1,194 @@
+######################################################################
+# Mesh
+#######################################################################
+
+abstract type AbstractMesh{D} end
+
+struct Mesh{D,T,V<:AbstractArray{SVector{D,T}}} <: AbstractMesh{D}   # D is dimension of parameter space
+    vertices::V                         # Iterable vertex container with SVector{D,T} eltype
+    adjmat::SparseMatrixCSC{Bool,Int}   # Undirected graph: both dest > src and dest < src
+end
+
+# const Mesh{D,T} = Mesh{D,T,Vector{SVector{D,T}},Vector{Tuple{Int,Vararg{Int,D}}}}
+
+# Mesh{D,T}() where {D,T} = Mesh(SVector{D,T}[], sparse(Int[], Int[], Bool[]), NTuple{D+1,Int}[])
+
+function Base.show(io::IO, mesh::Mesh{D}) where {D}
+    i = get(io, :indent, "")
+    print(io,
+"$(i)Mesh{$D}: mesh of a $D-dimensional manifold
+$i  Vertices   : $(nvertices(mesh))
+$i  Edges      : $(nedges(mesh))")
+end
+
+nvertices(m::Mesh) = length(m.vertices)
+
+nedges(m::Mesh) = div(nnz(m.adjmat), 2)
+
+nsimplices(m::Mesh) = length(simplices(m))
+
+vertices(m::Mesh) = m.vertices
+
+edges(m::Mesh, src) = nzrange(m.adjmat, src)
+
+edgedest(m::Mesh, edge) = rowvals(m.adjmat)[edge]
+
+edgevertices(m::Mesh) =
+    ((vsrc, m.vertices[edgedest(m, edge)]) for (i, vsrc) in enumerate(m.vertices) for edge in edges(m, i))
+
+function minmax_edge_length(m::Mesh{D,T}) where {D,T<:Real}
+    minlen2 = typemax(T)
+    maxlen2 = zero(T)
+    verts = vertices(m)
+    for src in eachindex(verts), edge in edges(m, src)
+        dest = edgedest(m, edge)
+        dest > src || continue # Need only directed graph
+        vec = verts[dest] - verts[src]
+        norm2 = vec' * vec
+        norm2 < minlen2 && (minlen2 = norm2)
+        norm2 > maxlen2 && (maxlen2 = norm2)
+    end
+    return sqrt(minlen2), sqrt(maxlen2)
+end
+
+######################################################################
+# Compute N-simplices (N = number of vertices)
+######################################################################
+function simplices(mesh::Mesh{D}, ::Val{N} = Val(D+1)) where {D,N}
+    N > 0 || throw(ArgumentError("Need a positive number of vertices for simplices"))
+    N == 1 && return Tuple.(1:nvertices(mesh))
+    simps = NTuple{N,Int}[]
+    buffer = (NTuple{N,Int}[], NTuple{N,Int}[], Int[])
+    for src in eachindex(vertices(mesh))
+        append!(simps, _simplices(buffer, mesh, src))
+    end
+    N > 2 && alignnormals!(simps, vertices(mesh))
+    return simps
+end
+
+# Add (greater) neighbors to last vertex of partials that are also neighbors of scr, till N
+function _simplices(buffer::Tuple{P,P,V}, mesh, src) where {N,P<:AbstractArray{<:NTuple{N}},V}
+    partials, partials´, srcneighs = buffer
+    resize!(srcneighs, 0)
+    resize!(partials, 0)
+    for edge in edges(mesh, src)
+        srcneigh = edgedest(mesh, edge)
+        srcneigh > src || continue # Directed graph, to avoid simplex duplicates
+        push!(srcneighs, srcneigh)
+        push!(partials, padright((src, srcneigh), 0, Val(N)))
+    end
+    for pass in 3:N
+        resize!(partials´, 0)
+        for partial in partials
+            nextsrc = partial[pass - 1]
+            for edge in edges(mesh, nextsrc)
+                dest = edgedest(mesh, edge)
+                dest > nextsrc || continue # If not directed, no need to check
+                dest in srcneighs && push!(partials´, modifyat(partial, pass, dest))
+            end
+        end
+        partials, partials´ = partials´, partials
+    end
+    return partials
+end
+
+modifyat(s::NTuple{N,T}, ind, el) where {N,T} = ntuple(i -> i === ind ? el : s[i], Val(N))
+
+function alignnormals!(simplices, vertices)
+    for (i, s) in enumerate(simplices)
+        volume = elementvolume(vertices, s)
+        volume < 0 && (simplices[i] = switchlast(s))
+    end
+    return simplices
+end
+
+# Project N-1 edges onto (N-1)-dimensional vectors to have a deterministic volume
+elementvolume(verts, s::NTuple{N,Int}) where {N} =
+    elementvolume(hcat(ntuple(i -> padright(SVector(verts[s[i+1]] - verts[s[1]]), Val(N-1)), Val(N-1))...))
+elementvolume(mat::SMatrix{N,N}) where {N} = det(mat)
+
+switchlast(s::NTuple{N,T}) where {N,T} = ntuple(i -> i < N - 1 ? s[i] : s[2N - i - 1] , Val(N))
+
+######################################################################
+# Special meshes
+######################################################################
+"""
+    marchingmesh(npoints::Integer...; axes = 1.0 * I, shift = missing)
+
+Creates a L-dimensional marching-tetrahedra `Mesh`. The mesh is confined to the box defined
+by the rows of `axes`, shifted by `shift` (an `NTuple` or `Number`) if not `missing`, and
+contains `npoints[i]` along each axis `i`.
+
+    marchingmesh(ranges::AbstractRange...; axes = 1.0 * I, shift = missing)
+
+The same as above, but allows to specify the points in axis `i` by a range `ranges[i]`, such
+as e.g. `-1.0:0.1:1.0`.
+
+Note that the size of `axes` should match the number `L` of elements in `npoints` or
+`ranges`. The `eltype` of points is given by that of `ranges` or `axes`.
+
+    marchingmesh(h::Hamiltonian{<:Lattice}; npoints = 13, shift = missing)
+
+Equivalent to `marchingmesh(ntuple(_ -> range(-π, π; length = npoints), Val(L))...)` where
+`L` is the dimension of the Hamiltonian's lattice.
+
+# External links
+
+- Marching tetrahedra (https://en.wikipedia.org/wiki/Marching_tetrahedra) in Wikipedia
+"""
+marchingmesh(ranges::Vararg{AbstractRange,L}; axes = 1.0 * I, shift = missing) where {L} =
+    _marchingmesh(shiftranges(ranges, shift), SMatrix{L,L}(axes))
+
+function marchingmesh(npoints::Vararg{Integer,L}; axes = 1.0 * I, shift = missing) where {L}
+    ranges = meshranges(npoints, Val(L))
+    ranges´ = shiftranges(ranges, shift)
+    return _marchingmesh(ranges´, SMatrix{L,L}(axes))
+end
+
+marchingmesh(; kw...) = throw(ArgumentError("Need a finite number of points"))
+
+function marchingmesh(h::Hamiltonian{<:Lattice,L}; npoints = 13, shift = missing) where {L}
+    checkfinitedim(h)
+    ranges = meshranges(npoints, Val(L))
+    ranges´ = shiftranges(ranges, shift)
+    return _marchingmesh(ranges´, SMatrix{L,L}(I))
+end
+
+meshranges(n::Int, ::Val{L}) where {L} = meshranges(filltuple(n, Val(L)), Val(L))
+meshranges(ns::NTuple{L,Int}, ::Val{L}) where {L} = (n -> range(-π, π; length = n)).(ns)
+
+shiftranges(rs, shift::Missing) = rs
+shiftranges(rs::NTuple{L}, shift::Number) where {L} = shiftranges(rs, filltuple(shift, Val(L)))
+shiftranges(rs::NTuple{L}, shifts::NTuple{L}) where {L} = ((r, s) -> r .+ s).(rs, shifts)
+
+function _marchingmesh(ranges::NTuple{D,AbstractRange}, axes::SMatrix{D,D}) where {D}
+    npoints = length.(ranges)
+    projection = axes' # ./ (SVector(npoints) - 1)' # Projects binary vector to m box with npoints
+    cs = CartesianIndices(ntuple(n -> 1:npoints[n], Val(D)))
+    ls = LinearIndices(cs)
+    csinner = CartesianIndices(ntuple(n -> 1:npoints[n]-1, Val(D)))
+
+    # edge vectors for marching tetrahedra in D-dimensions (skip zero vector [first])
+    uedges = [c for c in CartesianIndices(ntuple(_ -> 0:1, Val(D)))][2:end]
+    # tetrahedra built from the D unit-length uvecs added in any permutation
+    perms = permutations(
+            ntuple(i -> CartesianIndex(ntuple(j -> i == j ? 1 : 0, Val(D))), Val(D)))
+    utets = [cumsum(pushfirst!(perm, zero(CartesianIndex{D}))) for perm in perms]
+
+    # We don't use generators because their non-inferreble eltype causes problems later
+    verts = [projection * SVector(getindex.(ranges, Tuple(c))) for c in cs]
+
+    s = SparseMatrixBuilder{Bool}(length(cs), length(cs))
+    for c in cs
+        for u in uedges
+            dest = c + u    # dest > src
+            dest in cs && pushtocolumn!(s, ls[dest], true)
+            dest = c - u    # dest < src
+            dest in cs && pushtocolumn!(s, ls[dest], true)
+        end
+        finalizecolumn!(s)
+    end
+    adjmat = sparse(s)
+
+    return Mesh(verts, adjmat)
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,0 +1,492 @@
+#######################################################################
+# Onsite/Hopping selectors
+#######################################################################
+abstract type Selector{M,S} end
+
+struct OnsiteSelector{M,S} <: Selector{M,S}
+    region::M
+    sublats::S  # NTuple{N,NameType} (unresolved) or Vector{Int} (resolved on a lattice)
+end
+
+struct HoppingSelector{M,S,D,T} <: Selector{M,S}
+    region::M
+    sublats::S  # NTuple{N,Tuple{NameType,NameType}} (unres) or Vector{Tuple{Int,Int}} (res)
+    dns::D
+    range::T
+end
+
+"""
+    onsiteselector(; region = missing, sublats = missing)
+
+Specifies a subset of onsites energies in a given hamiltonian. Only sites at position `r` in
+sublattice with name `s::NameType` will be selected if `region(r) && s in sublats` is true.
+Any missing `region` or `sublat` will not be used to constraint the selection.
+
+# See also:
+    `hoppingselector`, `onsite`, `hopping`
+"""
+onsiteselector(; region = missing, sublats = missing) =
+    OnsiteSelector(region, sanitize_sublats(sublats))
+
+"""
+    hoppingselector(; region = missing, sublats = missing, dn = missing, range = missing)
+
+Specifies a subset of hoppings in a given hamiltonian. Only hoppings between two sites at
+positions `r₁ = r - dr/2` and `r₂ = r + dr`, belonging to unit cells at integer
+distance `dn´` and to sublattices `s₁` and `s₂` will be selected if: `region(r, dr) && s in
+sublats && dn´ in dn && norm(dr) <= range`. If any of these is `missing` it will not be used
+to constraint the selection.
+
+# See also:
+    `onsiteselector`, `onsite`, `hopping`
+"""
+hoppingselector(; region = missing, sublats = missing, dn = missing, range = missing) =
+    HoppingSelector(region, sanitize_sublatpairs(sublats), sanitize_dn(dn), sanitize_range(range))
+
+sanitize_sublats(s::Missing) = missing
+sanitize_sublats(s::Integer) = (nametype(s),)
+sanitize_sublats(s::NameType) = (s,)
+sanitize_sublats(s::Tuple) = nametype.(s)
+sanitize_sublats(s::Tuple{}) = ()
+sanitize_sublats(n) = throw(ErrorException(
+    "`sublats` for `onsite` must be either `missing`, an `s` or a tuple of `s`s, with `s::$NameType` is a sublattice name"))
+
+sanitize_sublatpairs(s::Missing) = missing
+sanitize_sublatpairs((s1, s2)::NTuple{2,Union{Integer,NameType}}) = ((nametype(s1), nametype(s2)),)
+sanitize_sublatpairs((s2, s1)::Pair) = sanitize_sublatpairs((s1, s2))
+sanitize_sublatpairs(s::Union{Integer,NameType}) = sanitize_sublatpairs((s,s))
+sanitize_sublatpairs(s::NTuple{N,Any}) where {N} =
+    ntuple(n -> first(sanitize_sublatpairs(s[n])), Val(N))
+sanitize_sublatpairs(s) = throw(ErrorException(
+    "`sublats` for `hopping` must be either `missing`, a tuple `(s₁, s₂)`, or a tuple of such tuples, with `sᵢ::$NameType` a sublattice name"))
+
+sanitize_dn(dn::Missing) = missing
+sanitize_dn(dn::Tuple{Vararg{NTuple{N}}}) where {N} = SVector{N,Int}.(dn)
+sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = (SVector{N,Int}(dn),)
+sanitize_dn(dn::Tuple{}) = ()
+
+sanitize_range(::Missing) = missing
+sanitize_range(range::Real) = isfinite(range) ? float(range) + sqrt(eps(float(range))) : float(range)
+
+sublats(s::OnsiteSelector{<:Any,Missing}, lat::AbstractLattice) = collect(1:nsublats(lat))
+
+function sublats(s::OnsiteSelector{<:Any,<:Tuple}, lat::AbstractLattice)
+    names = lat.unitcell.names
+    ss = Int[]
+    for name in s.sublats
+        i = findfirst(isequal(name), names)
+        i !== nothing && push!(ss, i)
+    end
+    return ss
+end
+
+sublats(s::HoppingSelector{<:Any,Missing}, lat::AbstractLattice) =
+    vec(collect(Iterators.product(1:nsublats(lat), 1:nsublats(lat))))
+
+function sublats(s::HoppingSelector{<:Any,<:Tuple}, lat::AbstractLattice)
+    names = lat.unitcell.names
+    ss = Tuple{Int,Int}[]
+    for (n1, n2) in s.sublats
+        i1 = findfirst(isequal(n1), names)
+        i2 = findfirst(isequal(n2), names)
+        i1 !== nothing && i2 !== nothing && push!(ss, (i1, i2))
+    end
+    return ss
+end
+
+# selector already resolved for a lattice
+sublats(s::Selector{<:Any,<:Vector}, lat) = s.sublats
+
+# API
+
+resolve(s::HoppingSelector, lat::AbstractLattice) =
+    HoppingSelector(s.region, sublats(s, lat), _checkdims(s.dns, lat), s.range)
+resolve(s::OnsiteSelector, lat::AbstractLattice) = OnsiteSelector(s.region, sublats(s, lat))
+
+_checkdims(dns::Missing, lat::Lattice{E,L}) where {E,L} = dns
+_checkdims(dns::Tuple{Vararg{SVector{L,Int}}}, lat::Lattice{E,L}) where {E,L} = dns
+_checkdims(dns, lat::Lattice{E,L}) where {E,L} =
+    throw(DimensionMismatch("Specified cell distance `dn` does not match lattice dimension $L"))
+
+# are sites at (i,j) and (dni, dnj) or (dn, 0) selected?
+(s::OnsiteSelector)(lat::AbstractLattice, (i, j)::Tuple, (dni, dnj)::Tuple{SVector, SVector}) =
+    isonsite((i, j), (dni, dnj)) && isinregion(i, dni, s.region, lat) && isinsublats(sublat(lat, i), s.sublats)
+
+(s::HoppingSelector)(lat::AbstractLattice, inds, dns) =
+    !isonsite(inds, dns) && isinregion(inds, dns, s.region, lat) && isindns(dns, s.dns) &&
+    isinrange(inds, s.range, lat) && isinsublats(sublat.(Ref(lat), inds), s.sublats)
+
+isonsite((i, j), (dni, dnj)) = i == j && dni == dnj
+
+isinregion(i::Int, dn, ::Missing, lat) = true
+isinregion(i::Int, dn, region::Function, lat) = region(sites(lat)[i] + bravais(lat) * dn)
+
+isinregion(is::Tuple{Int,Int}, dns, ::Missing, lat) = true
+function isinregion((row, col)::Tuple{Int,Int}, (dnrow, dncol), region::Function, lat)
+    br = bravais(lat)
+    r, dr = _rdr(sites(lat)[col] + br * dncol, sites(lat)[row] + br * dnrow)
+    return region(r, dr)
+end
+
+isinsublats(s::Int, ::Missing) = true
+isinsublats(s::Int, sublats::Vector{Int}) = s in sublats
+isinsublats(ss::Tuple{Int,Int}, ::Missing) = true
+isinsublats(ss::Tuple{Int,Int}, sublats::Vector{Tuple{Int,Int}}) = ss in sublats
+isinsublats(s, sublats) =
+    throw(ArgumentError("Sublattices $sublats in selector are not resolved."))
+
+isindns((dnrow, dncol)::Tuple{SVector,SVector}, dns) = isindns(dnrow - dncol, dns)
+isindns(dn::SVector{L,Int}, dns::Tuple{Vararg{SVector{L,Int}}}) where {L} = dn in dns
+isindns(dn::SVector, dns::Missing) = true
+isindns(dn, dns) =
+    throw(ArgumentError("Cell distance dn in selector is incompatible with Lattice."))
+
+isinrange(inds, ::Missing, lat) = true
+isinrange((row, col)::Tuple{Int,Int}, range::Number, lat) =
+    norm(sites(lat)[col] - sites(lat)[row]) <= range
+
+#######################################################################
+# TightbindingModelTerm
+#######################################################################
+abstract type TightbindingModelTerm end
+abstract type AbstractOnsiteTerm <: TightbindingModelTerm end
+abstract type AbstractHoppingTerm <: TightbindingModelTerm end
+
+struct OnsiteTerm{F,S<:OnsiteSelector,C} <: AbstractOnsiteTerm
+    o::F
+    selector::S
+    coefficient::C
+    forcehermitian::Bool
+end
+
+struct HoppingTerm{F,S<:HoppingSelector,C} <: AbstractHoppingTerm
+    t::F
+    selector::S
+    coefficient::C
+    forcehermitian::Bool
+end
+
+(o::OnsiteTerm{<:Function})(r,dr) = o.coefficient * o.o(r)
+(o::OnsiteTerm)(r,dr) = o.coefficient * o.o
+
+(h::HoppingTerm{<:Function})(r, dr) = h.coefficient * h.t(r, dr)
+(h::HoppingTerm)(r, dr) = h.coefficient * h.t
+
+sublats(t::TightbindingModelTerm, lat) = sublats(t.selector, lat)
+
+displayparameter(::Type{<:Function}) = "Function"
+displayparameter(::Type{T}) where {T} = "$T"
+
+function Base.show(io::IO, o::OnsiteTerm{F}) where {F}
+    i = get(io, :indent, "")
+    print(io,
+"$(i)OnsiteTerm{$(displayparameter(F))}:
+$(i)  Sublattices      : $(o.selector.sublats === missing ? "any" : o.selector.sublats)
+$(i)  Force hermitian  : $(o.forcehermitian)
+$(i)  Coefficient      : $(o.coefficient)")
+end
+
+function Base.show(io::IO, h::HoppingTerm{F}) where {F}
+    i = get(io, :indent, "")
+    print(io,
+"$(i)HoppingTerm{$(displayparameter(F))}:
+$(i)  Sublattice pairs : $(h.selector.sublats === missing ? "any" : (t -> Pair(reverse(t)...)).(h.selector.sublats))
+$(i)  dn cell distance : $(h.selector.dns === missing ? "any" : h.selector.dns)
+$(i)  Hopping range    : $(round(h.selector.range, digits = 6))
+$(i)  Force hermitian  : $(h.forcehermitian)
+$(i)  Coefficient      : $(h.coefficient)")
+end
+
+# External API #
+"""
+    onsite(o; forcehermitian = true, kw...)
+    onsite(o, onsiteselector(; kw...); forcehermitian = true)
+
+Create an `TightbindingModelTerm` that applies an onsite energy `o` to a `Lattice` when
+creating a `Hamiltonian` with `hamiltonian`. A subset of sites can be specified with the
+`kw...`, see `onsiteselector` for details.
+
+The onsite energy `o` can be a number, a matrix (preferably `SMatrix`) or a function of the
+form `r -> ...` for a position-dependent onsite energy. If `forcehermitian` is true, the
+model will produce an hermitian Hamiltonian.
+
+The dimension of `o::AbstractMatrix` must match the orbital dimension of applicable
+sublattices (see also `orbitals` option for `hamiltonian`). If `o::Number` it will be
+treated as `o * I` (proportional to identity matrix) when applied to multiorbital
+sublattices.
+
+`TightbindingModelTerm`s created with `onsite` or `hopping` can be added or substracted
+together to build more complicated `TightbindingModel`s.
+
+# Examples
+```
+julia> onsite(1, sublats = (:A,:B)) - hopping(2, sublats = :A=>:A)
+TightbindingModel{2}: model with 2 terms
+  OnsiteTerm{Int64}:
+    Sublattices      : (:A, :B)
+    Force hermitian  : true
+    Coefficient      : 1
+  HoppingTerm{Int64}:
+    Sublattice pairs : (:A => :A,)
+    dn cell distance : any
+    Hopping range    : 1.0
+    Force hermitian  : true
+    Coefficient      : -1
+
+julia> LatticePresets.honeycomb() |> hamiltonian(onsite(r->@SMatrix[1 2; 3 4]), orbitals = Val(2))
+Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 1 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a, :a), (:a, :a))
+  Element type     : 2 × 2 blocks (Complex{Float64})
+  Onsites          : 2
+  Hoppings         : 0
+  Coordination     : 0.0
+```
+
+# See also:
+    `hopping`, `onsiteselector`, `hoppingselector`
+"""
+onsite(o; forcehermitian = true, kw...) =
+    onsite(o, onsiteselector(; kw...); forcehermitian = forcehermitian)
+onsite(o, selector; forcehermitian::Bool = true) =
+    TightbindingModel(OnsiteTerm(o, selector, 1, forcehermitian))
+
+"""
+    hopping(t; forcehermitian = true, range = 1, kw...)
+    hopping(t, hoppingselector(; range = 1, kw...); forcehermitian = true)
+
+Create an `TightbindingModelTerm` that applies a hopping `t` to a `Lattice` when
+creating a `Hamiltonian` with `hamiltonian`. A subset of hoppings can be specified with the
+`kw...`, see `hoppingselector` for details. Note that a default `range = 1` is assumed.
+
+The hopping amplitude `t` can be a number, a matrix (preferably `SMatrix`) or a function
+of the form `(r, dr) -> ...` for a position-dependent hopping (`r` is the bond center,
+and `dr` the bond vector). If `sublats` is specified as a sublattice name pair, or tuple
+thereof, `hopping` is only applied between sublattices with said names. If `forcehermitian`
+is true, the model will produce an hermitian Hamiltonian.
+
+The dimension of `t::AbstractMatrix` must match the orbital dimension of applicable
+sublattices (see also `orbitals` option for `hamiltonian`). If `t::Number` it will be
+treated as `t * I` (proportional to identity matrix) when applied to multiorbital
+sublattices.
+
+`TightbindingModelTerm`s created with `onsite` or `hopping` can be added or substracted
+together to build more complicated `TightbindingModel`s.
+
+# Examples
+```
+julia> onsite(1) - hopping(2, dn = ((1,2), (0,0)), sublats = :A=>:B)
+TightbindingModel{2}: model with 2 terms
+  OnsiteTerm{Int64}:
+    Sublattices      : any
+    Force hermitian  : true
+    Coefficient      : 1
+  HoppingTerm{Int64}:
+    Sublattice pairs : (:A => :B,)
+    dn cell distance : ([1, 2], [0, 0])
+    Hopping range    : 1.0
+    Force hermitian  : true
+    Coefficient      : -1
+
+julia> LatticePresets.honeycomb() |> hamiltonian(hopping((r,dr) -> cos(r[1]), sublats = ((:A,:A), (:B,:B))))
+Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 7 (SparseMatrixCSC, sparse)
+  Harmonic size    : 2 × 2
+  Orbitals         : ((:a,), (:a,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 0
+  Hoppings         : 12
+  Coordination     : 6.0
+```
+
+# See also:
+    `onsite`, `onsiteselector`, `hoppingselector`
+"""
+hopping(t; forcehermitian = true, range = 1, kw...) =
+    hopping(t, hoppingselector(; range = range, kw...); forcehermitian = forcehermitian)
+hopping(t, selector; forcehermitian = true) =
+    TightbindingModel(HoppingTerm(t, selector, 1, forcehermitian))
+
+Base.:*(x, o::OnsiteTerm) =
+    OnsiteTerm(o.o, o.selector, x * o.coefficient, o.forcehermitian)
+Base.:*(x, t::HoppingTerm) =
+    HoppingTerm(t.t, t.selector, x * t.coefficient, t.forcehermitian)
+Base.:*(t::TightbindingModelTerm, x) = x * t
+Base.:-(t::TightbindingModelTerm) = (-1) * t
+
+LinearAlgebra.ishermitian(t::OnsiteTerm) = t.forcehermitian
+LinearAlgebra.ishermitian(t::HoppingTerm) = t.forcehermitian
+
+#######################################################################
+# TightbindingModel
+#######################################################################
+struct TightbindingModel{N,T<:Tuple{Vararg{TightbindingModelTerm,N}}}
+    terms::T
+end
+
+terms(t::TightbindingModel) = t.terms
+
+TightbindingModel(ts::TightbindingModelTerm...) = TightbindingModel(ts)
+
+(m::TightbindingModel)(r, dr) = sum(t -> t(r, dr), m.terms)
+
+# External API #
+
+Base.:*(x, m::TightbindingModel) = TightbindingModel(x .* m.terms)
+Base.:*(m::TightbindingModel, x) = x * m
+Base.:-(m::TightbindingModel) = TightbindingModel((-1) .* m.terms)
+
+Base.:+(m::TightbindingModel, t::TightbindingModel) = TightbindingModel((m.terms..., t.terms...))
+Base.:-(m::TightbindingModel, t::TightbindingModel) = m + (-t)
+
+function Base.show(io::IO, m::TightbindingModel{N}) where {N}
+    ioindent = IOContext(io, :indent => "  ")
+    print(io, "TightbindingModel{$N}: model with $N terms", "\n")
+    foreach(t -> print(ioindent, t, "\n"), m.terms)
+end
+
+LinearAlgebra.ishermitian(m::TightbindingModel) = all(t -> ishermitian(t), m.terms)
+
+#######################################################################
+# offdiagonal
+#######################################################################
+"""
+    offdiagonal(model, lat, nsublats::NTuple{N,Int})
+
+Build a restricted version of `model` that applies only to off-diagonal blocks formed by
+sublattice groups of size `nsublats`.
+"""
+offdiagonal(m::TightbindingModel, lat, nsublats) =
+    TightbindingModel(offdiagonal.(m.terms, Ref(lat), Ref(nsublats)))
+
+offdiagonal(o::OnsiteTerm, lat, nsublats) =
+    throw(ArgumentError("No onsite terms allowed in off-diagonal coupling"))
+
+function offdiagonal(t::HoppingTerm, lat, nsublats)
+    selector´ = resolve(t.selector, lat)
+    s = selector´.sublats
+    sr = sublatranges(nsublats...)
+    filter!(spair ->  findblock(first(spair), sr) != findblock(last(spair), sr), s)
+    return HoppingTerm(t.t, selector´, t.coefficient, t.forcehermitian)
+end
+
+sublatranges(i::Int, is::Int...) = _sublatranges((1:i,), is...)
+_sublatranges(rs::Tuple, i::Int, is...) = _sublatranges((rs..., last(last(rs)) + 1: last(last(rs)) + i), is...)
+_sublatranges(rs::Tuple) = rs
+
+findblock(s, sr) = findfirst(r -> s in r, sr)
+
+#######################################################################
+# checkmodelorbs - check for inconsistent orbital dimensions
+#######################################################################
+checkmodelorbs(model::TightbindingModel, orbs, lat) =
+    foreach(term -> _checkmodelorbs(term, orbs, lat), model.terms)
+
+function _checkmodelorbs(term::HoppingTerm, orbs, lat)
+    for (s1, s2) in sublats(term, lat)
+        _checkmodelorbs(term(first(sites(lat, s1)), first(sites(lat, s2))), length(orbs[s1]), length(orbs[s2]))
+    end
+    return nothing
+end
+
+function _checkmodelorbs(term::OnsiteTerm, orbs, lat)
+    for s in sublats(term, lat)
+        _checkmodelorbs(term(first(sites(lat, s)), first(sites(lat, s))), length(orbs[s]))
+    end
+    return nothing
+end
+
+_checkmodelorbs(s::SMatrix, m, n = m) =
+    size(s) == (m, n) || @warn("Possible dimension mismatch between model and Hamiltonian. Did you correctly specify the `orbitals` in hamiltonian?")
+
+_checkmodelorbs(s::Number, m, n = m) = _checkmodelorbs(SMatrix{1,1}(s), m, n)
+
+#######################################################################
+# onsite! and hopping!
+#######################################################################
+abstract type ElementModifier{V,F,S} end
+
+struct Onsite!{V<:Val,F<:Function,S<:Selector} <: ElementModifier{V,F,S}
+    f::F
+    needspositions::V    # Val{false} for f(o; kw...), Val{true} for f(o, r; kw...) or other
+    selector::S
+    forcehermitian::Bool
+    addconjugate::Bool   # determines whether to return f(o) or (f(o) + f(o')')/2
+end
+
+Onsite!(f, selector, forcehermitian = true) =
+    Onsite!(f, Val(!applicable(f, 0.0)), selector, forcehermitian, false)
+
+struct Hopping!{V<:Val,F<:Function,S<:Selector} <: ElementModifier{V,F,S}
+    f::F
+    needspositions::V    # Val{false} for f(h; kw...), Val{true} for f(h, r, dr; kw...) or other
+    selector::S
+    forcehermitian::Bool
+    addconjugate::Bool   # determines whether to return f(t) or (f(t) + f(t')')/2
+end
+
+Hopping!(f, selector, forcehermitian = true) =
+    Hopping!(f, Val(!applicable(f, 0.0)), selector, forcehermitian, false)
+
+# API #
+
+"""
+    onsite!(f; forcehermitian = true, kw...)
+    onsite!(f, onsiteselector(; kw...); forcehermitian = true)
+
+Create an `ElementModifier`, to be used with `parametric`, that applies `f` to onsite
+energies specified by `onsiteselector(; kw...)`. The form of `f` may be `f = (o; kw...) ->
+...` or `f = (o, r; kw...) -> ...` if the modification is position (`r`) dependent. The
+former is naturally more efficient, as there is no need to compute the positions of each
+onsite energy. If `forcehermitian == true` the modification is forced to yield a hermitian
+Hamiltonian if the original was hermitian.
+
+# See also:
+    `hopping!`, `parametric`
+"""
+onsite!(f; forcehermitian = true, kw...) =
+    onsite!(f, onsiteselector(; kw...); forcehermitian = forcehermitian)
+onsite!(f, selector; forcehermitian = true) = Onsite!(f, selector, forcehermitian)
+
+"""
+    hopping!(f; forcehermitian = true, kw...)
+    hopping!(f, hoppingselector(; kw...); forcehermitian = true)
+
+Create an `ElementModifier`, to be used with `parametric`, that applies `f` to hoppings
+specified by `hoppingselector(; kw...)`. The form of `f` may be `f = (t; kw...) -> ...` or
+`f = (t, r, dr; kw...) -> ...` if the modification is position (`r, dr`) dependent. The
+former is naturally more efficient, as there is no need to compute the positions of the two
+sites involved in each hopping. If `forcehermitian == true` the modification is forced to
+yield a hermitian Hamiltonian if the original was hermitian.
+
+# See also:
+    `onsite!`, `parametric`
+"""
+hopping!(f; forcehermitian = true, kw...) = hopping!(f, hoppingselector(; kw...); forcehermitian = forcehermitian)
+hopping!(f, selector; forcehermitian = true) = Hopping!(f, selector, forcehermitian)
+
+function resolve(o::Onsite!, lat)
+    addconjugate = o.forcehermitian
+    Onsite!(o.f, o.needspositions, resolve(o.selector, lat), o.forcehermitian, addconjugate)
+end
+
+function resolve(h::Hopping!, lat)
+    addconjugate = h.selector.sublats === missing && h.forcehermitian
+    Hopping!(h.f, h.needspositions, resolve(h.selector, lat), h.forcehermitian, addconjugate)
+end
+
+# Intended for resolved ElementModifiers only
+@inline (o!::Onsite!{Val{false}})(o, r; kw...) = o!(o; kw...)
+@inline (o!::Onsite!{Val{false}})(o, r, dr; kw...) = o!(o; kw...)
+@inline (o!::Onsite!{Val{false}})(o; kw...) =
+    o!.addconjugate ? 0.5 * (o!.f(o; kw...) + o!.f(o'; kw...)') : o!.f(o; kw...)
+@inline (o!::Onsite!{Val{true}})(o, r, dr; kw...) = o!(o, r; kw...)
+@inline (o!::Onsite!{Val{true}})(o, r; kw...) =
+    o!.addconjugate ? 0.5 * (o!.f(o, r; kw...) + o!.f(o', r; kw...)') : o!.f(o, r; kw...)
+
+@inline (h!::Hopping!{Val{false}})(t, r, dr; kw...) = h!(t; kw...)
+@inline (h!::Hopping!{Val{false}})(t; kw...) =
+    h!.addconjugate ? 0.5 * (h!.f(t; kw...) + h!.f(t'; kw...)') : h!.f(t; kw...)
+@inline (h!::Hopping!{Val{true}})(t, r, dr; kw...) =
+    h!.addconjugate ? 0.5 * (h!.f(t, r, dr; kw...) + h!.f(t', r, -dr; kw...)') : h!.f(t, r, dr; kw...)

--- a/src/parametric.jl
+++ b/src/parametric.jl
@@ -1,0 +1,160 @@
+#######################################################################
+# ParametricHamiltonian
+#######################################################################
+struct ParametricHamiltonian{N,M<:NTuple{N,ElementModifier},P<:NTuple{N,Any},H<:Hamiltonian}
+    originalh::H
+    h::H
+    modifiers::M  # N modifiers
+    ptrdata::P    # P is an NTuple{N,Vector{Vector{ptrdata}}}, one per harmonic
+end               # ptrdata may be a nzval ptr, a (ptr,r) or a (ptr, r, dr)
+
+function Base.show(io::IO, ::MIME"text/plain", pham::ParametricHamiltonian{N}) where {N}
+    i = get(io, :indent, "")
+    print(io, i, "Parametric")
+    show(io, pham.h)
+    print(io, i, "\n", "$i  Param Modifiers  : $N")
+end
+
+"""
+    parametric(h::Hamiltonian, modifiers::ElementModifier...)
+
+Builds a `ParametricHamiltonian` that can be used to efficiently apply `modifiers` to `h`.
+`modifiers` can be any number of `onsite!(f;...)` and `hopping!(f; ...)` transformations,
+each with a set of parameters given as keyword arguments of functions `f`. The resulting
+`ph::ParamtricHamiltonian` can be used to produced the modified Hamiltonian simply by
+calling it with those same parameters as keyword arguments.
+
+Note 1: for sparse `h`, `parametric` only modifies existing onsites and hoppings in `h`,
+so be sure to add zero onsites and/or hoppings to `h` if they are originally not present but
+you need to apply modifiers to them.
+
+Note 2: `optimize!(h)` is called prior to building the parametric Hamiltonian. This can lead
+to extra zero onsites and hoppings being stored in sparse `h`s.
+
+    h |> parametric(modifiers::ElementModifier...)
+
+Function form of `parametric`, equivalent to `parametric(h, modifiers...)`.
+
+# Examples
+```
+julia> ph = LatticePresets.honeycomb() |> hamiltonian(onsite(0) + hopping(1, range = 1/√3)) |> unitcell(10) |> parametric(onsite!((o; μ) -> o - μ))
+ParametricHamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 200 × 200
+  Orbitals         : ((:a,), (:a,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 200
+  Hoppings         : 600
+  Coordination     : 3.0
+  Param Modifiers  : 1
+
+julia> ph(; μ = 2)
+Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
+  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
+  Harmonic size    : 200 × 200
+  Orbitals         : ((:a,), (:a,))
+  Element type     : scalar (Complex{Float64})
+  Onsites          : 200
+  Hoppings         : 600
+  Coordination     : 3.0
+
+# See also
+    `onsite!`, `hopping!`
+```
+"""
+function parametric(h::Hamiltonian, ts::ElementModifier...)
+    ts´ = resolve.(ts, Ref(h.lattice))
+    optimize!(h)  # to avoid ptrs getting out of sync if optimize! later
+    return ParametricHamiltonian(h, copy(h), ts´, parametric_ptrdata.(Ref(h), ts´))
+end
+
+parametric(ts::ElementModifier...) = h -> parametric(h, ts...)
+
+function parametric_ptrdata(h::Hamiltonian{LA,L,M,<:AbstractSparseMatrix}, t::ElementModifier) where {LA,L,M}
+    harmonic_ptrdata = empty_ptrdata(h, t)
+    lat = h.lattice
+    selector = t.selector
+    for (har, ptrdata) in zip(h.harmonics, harmonic_ptrdata)
+        matrix = har.h
+        dn = har.dn
+        rows = rowvals(matrix)
+        for col in 1:size(matrix, 2), ptr in nzrange(matrix, col)
+            row = rows[ptr]
+            selected  = selector(lat, (row, col), (dn, zero(dn)))
+            selected´ = t.forcehermitian && selector(lat, (col, row), (zero(dn), dn))
+            selected  && push!(ptrdata, ptrdatum(t, lat,  ptr, (row, col)))
+            selected´ && push!(ptrdata, ptrdatum(t, lat, -ptr, (col, row)))
+        end
+    end
+    return harmonic_ptrdata
+end
+
+# needspositions = false, one vector of nzval ptr per harmonic
+empty_ptrdata(h, t::Onsite!{Val{false}})  = [Int[] for _ in h.harmonics]
+empty_ptrdata(h, t::Hopping!{Val{false}}) = [Int[] for _ in h.harmonics]
+# needspositions = true, one vector of (ptr, r, dr) per harmonic
+function empty_ptrdata(h, t::Onsite!{Val{true}})
+    S = positiontype(h.lattice)
+    return [Tuple{Int,S}[] for _ in h.harmonics]
+end
+function empty_ptrdata(h, t::Hopping!{Val{true}})
+    S = positiontype(h.lattice)
+    return [Tuple{Int,S,S}[] for _ in h.harmonics]
+end
+
+ptrdatum(t::ElementModifier{Val{false}}, lat, ptr, (row, col)) = ptr
+ptrdatum(t::Onsite!{Val{true}}, lat, ptr, (row, col)) = (ptr, sites(lat)[col])
+function ptrdatum(t::Hopping!{Val{true}}, lat, ptr, (row, col))
+    r, dr = _rdr(sites(lat)[col], sites(lat)[row])
+    return (ptr, r, dr)
+end
+
+function (ph::ParametricHamiltonian)(; kw...)
+    checkconsistency(ph, false) # only weak check for performance
+    applymodifier_ptrdata!.(Ref(ph.h), Ref(ph.originalh), ph.modifiers, ph.ptrdata, Ref(values(kw)))
+    return ph.h
+end
+
+function applymodifier_ptrdata!(h, originalh, modifier, ptrdata, kw)
+    for (ohar, har, hardata) in zip(originalh.harmonics, h.harmonics, ptrdata)
+        nz = nonzeros(har.h)
+        onz = nonzeros(ohar.h)
+        for data in hardata
+            ptr = first(data)
+            isadjoint = ptr < 0
+            isadjoint && (ptr = -ptr)
+            args = modifier_args(onz, data)
+            val = modifier(args...; kw...)
+            nz[ptr] = isadjoint ? val' : val
+        end
+    end
+    return h
+end
+
+modifier_args(onz, ptr::Int) = (onz[abs(ptr)],)
+modifier_args(onz, (ptr, r)::Tuple{Int,SVector}) = (onz[abs(ptr)], r)
+modifier_args(onz, (ptr, r, dr)::Tuple{Int,SVector,SVector}) = (onz[abs(ptr)], r, dr)
+
+function checkconsistency(ph::ParametricHamiltonian, fullcheck = true)
+    isconsistent = true
+    length(ph.originalh.harmonics) == length(ph.h.harmonics) || (isconsitent = false)
+    if fullcheck && isconsistent
+        for (ohar, har) in zip(ph.originalh.harmonics, ph.h.harmonics)
+            length(nonzeros(har.h)) == length(nonzeros(ohar.h)) || (isconsistent = false; break)
+            rowvals(har.h) == rowvals(ohar.h) || (isconsistent = false; break)
+            getcolptr(har.h) == getcolptr(ohar.h) || (isconsistent = false; break)
+        end
+    end
+    isconsistent ||
+        throw(error("ParametricHamiltonian is not internally consistent, it may have been modified after creation"))
+    return nothing
+end
+
+Base.copy(ph::ParametricHamiltonian) =
+    ParametricHamiltonian(copy(ph.originalh), copy(ph.h), ph.modifiers, copy(h.ptrdata))
+
+Base.size(ph::ParametricHamiltonian, n...) = size(ph.h, n...)
+
+bravais(ph::ParametricHamiltonian) = bravais(ph.hamiltonian.lattice)
+
+Base.eltype(ph::ParametricHamiltonian) = eltype(ph.h)

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -1,0 +1,144 @@
+#######################################################################
+# Lattice presets
+#######################################################################
+
+module LatticePresets
+
+using Quantica
+using Quantica: NameType
+
+linear(; a0 = 1, semibounded = false, kw...) =
+    lattice(a0 * bravais((1.,); kw...), sublat((0.,)); kw...)
+
+square(; a0 = 1, kw...) =
+    lattice(a0 * bravais((1., 0.), (0., 1.); kw...), sublat((0., 0.)); kw...)
+
+triangular(; a0 = 1, kw...) =
+    lattice(a0 * bravais(( cos(pi/3), sin(pi/3)),(-cos(pi/3), sin(pi/3)); kw...),
+        sublat((0., 0.)); kw...)
+
+honeycomb(; a0 = 1, kw...) =
+    lattice(a0 * bravais((cos(pi/3), sin(pi/3)), (-cos(pi/3), sin(pi/3)); kw...),
+        sublat((0.0, -0.5/sqrt(3.0)), name = :A),
+        sublat((0.0,  0.5/sqrt(3.0)), name = :B); kw...)
+
+cubic(; a0 = 1, kw...) =
+    lattice(a0 * bravais((1., 0., 0.), (0., 1., 0.), (0., 0., 1.); kw...),
+        sublat((0., 0., 0.)); kw...)
+
+fcc(; a0 = 1, kw...) =
+    lattice(a0 * bravais(@SMatrix([-1. -1. 0.; 1. -1. 0.; 0. 1. -1.])'/sqrt(2.); kw...),
+        sublat((0., 0., 0.)); kw...)
+
+bcc(; a0 = 1, kw...) =
+    lattice(a0 * bravais((1., 0., 0.), (0., 1., 0.), (0.5, 0.5, 0.5); kw...),
+        sublat((0., 0., 0.)); kw...)
+
+end # module
+
+#######################################################################
+# Hamiltonian presets
+#######################################################################
+
+module HamiltonianPresets
+
+using Quantica, LinearAlgebra
+
+function twisted_bilayer_graphene(;
+    twistindex = 1, twistindices = (twistindex, 1), a0 = 0.246, interlayerdistance = 1.36a0,
+    rangeintralayer = a0/sqrt(3), rangeinterlayer = 4a0/sqrt(3), hopintra = 2.70,
+    hopinter = 0.48, modelintra = hopping(hopintra, range = rangeintralayer), kw...)
+
+    (m, r) = twistindices
+    θ = acos((3m^2 + 3m*r +r^2/2)/(3m^2 + 3m*r + r^2))
+    sAbot = sublat((0.0, -0.5a0/sqrt(3.0), - interlayerdistance / 2); name = :Ab)
+    sBbot = sublat((0.0,  0.5a0/sqrt(3.0), - interlayerdistance / 2); name = :Bb)
+    sAtop = sublat((0.0, -0.5a0/sqrt(3.0),   interlayerdistance / 2); name = :At)
+    sBtop = sublat((0.0,  0.5a0/sqrt(3.0),   interlayerdistance / 2); name = :Bt)
+    brbot = a0 * bravais(( cos(pi/3), sin(pi/3), 0), (-cos(pi/3), sin(pi/3), 0))
+    brtop = a0 * bravais((-cos(pi/3), sin(pi/3), 0), ( cos(pi/3), sin(pi/3), 0))
+    # Supercell matrices sc.
+    # The one here is a [1 0; -1 1] rotation of the one in Phys. Rev. B 86, 155449 (2012)
+    if gcd(r, 3) == 1
+        scbot = @SMatrix[m -(m+r); (m+r) 2m+r] * @SMatrix[1 0; -1 1]
+        sctop = @SMatrix[m+r -m; m 2m+r] * @SMatrix[1 0; -1 1]
+    else
+        scbot = @SMatrix[m+r÷3 -r÷3; r÷3 m+2r÷3] * @SMatrix[1 0; -1 1]
+        sctop = @SMatrix[m+2r÷3 r÷3; -r÷3 m+r÷3] * @SMatrix[1 0; -1 1]
+    end
+    latbot = lattice(brbot, sAbot, sBbot)
+    lattop = lattice(brtop, sAtop, sBtop)
+    htop = hamiltonian(lattop, modelintra; kw...) |> unitcell(sctop)
+    hbot = hamiltonian(latbot, modelintra; kw...) |> unitcell(scbot)
+    let R = @SMatrix[cos(θ/2) -sin(θ/2) 0; sin(θ/2) cos(θ/2) 0; 0 0 1]
+        transform!(htop, r -> R * r)
+    end
+    let R = @SMatrix[cos(θ/2) sin(θ/2) 0; -sin(θ/2) cos(θ/2) 0; 0 0 1]
+        transform!(hbot, r -> R * r)
+    end
+    modelinter = hopping((r,dr) -> (
+        hopintra * exp(-3*(norm(dr)/a0 - 1))  *  dot(dr, SVector(1,1,0))^2/sum(abs2, dr) -
+        hopinter * exp(-3*(norm(dr)/a0 - interlayerdistance/a0)) * dr[3]^2/sum(abs2, dr)),
+        range = rangeinterlayer)
+    return combine(hbot, htop; coupling = modelinter)
+end
+
+end # module
+
+#######################################################################
+# Region presets
+#######################################################################
+
+module RegionPresets
+
+using StaticArrays
+
+struct Region{E,F}
+    f::F
+end
+
+Region{E}(f::F) where {E,F<:Function} = Region{E,F}(f)
+
+(region::Region{E})(r::SVector{E2}) where {E,E2} = region.f(r)
+
+Base.show(io::IO, ::Region{E}) where {E} =
+    print(io, "Region{$E} : region in $(E)D space")
+
+extended_eps(T = Float64) = sqrt(eps(T))
+
+circle(radius = 10.0) = Region{2}(_region_ellipse((radius, radius)))
+
+ellipse(radii = (10.0, 15.0)) = Region{2}(_region_ellipse(radii))
+
+square(side = 10.0) = Region{2}(_region_rectangle((side, side)))
+
+rectangle(sides = (10.0, 15.0)) = Region{2}(_region_rectangle(sides))
+
+sphere(radius = 10.0) = Region{3}(_region_ellipsoid((radius, radius, radius)))
+
+spheroid(radii = (10.0, 15.0, 20.0)) = Region{3}(_region_ellipsoid(radii))
+
+cube(side = 10.0) = Region{3}(_region_cuboid((side, side, side)))
+
+cuboid(sides = (10.0, 15.0, 20.0)) = Region{3}(_region_cuboid(sides))
+
+function _region_ellipse((rx, ry))
+    return r -> (r[1]/rx)^2 + (r[2]/ry)^2 <= 1 + extended_eps(Float64)
+end
+
+function _region_rectangle((lx, ly))
+    return r -> abs(2*r[1]) <= lx * (1 + extended_eps()) &&
+                abs(2*r[2]) <= ly * (1 + extended_eps())
+end
+
+function _region_ellipsoid((rx, ry, rz))
+    return r -> (r[1]/rx)^2 + (r[2]/ry)^2 + (r[3]/rz)^2 <= 1 + eps()
+end
+
+function _region_cuboid((lx, ly, lz))
+    return r -> abs(2*r[1]) <= lx * (1 + extended_eps()) &&
+                abs(2*r[2]) <= ly * (1 + extended_eps()) &&
+                abs(2*r[3]) <= lz * (1 + extended_eps())
+end
+
+end # module

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,0 +1,476 @@
+toSMatrix() = SMatrix{0,0,Float64}()
+toSMatrix(ss::NTuple{N,Number}...) where {N} = toSMatrix(SVector{N}.(ss)...)
+toSMatrix(ss::SVector{N}...) where {N} = hcat(ss...)
+toSMatrix(::Type{T}, ss...) where {T} = _toSMatrix(T, toSMatrix(ss...))
+_toSMatrix(::Type{T}, s::SMatrix{N,M}) where {N,M,T} = convert(SMatrix{N,M,T}, s)
+# Dynamic dispatch
+toSMatrix(ss::AbstractVector...) = toSMatrix(Tuple.(ss)...)
+toSMatrix(s::AbstractMatrix) = SMatrix{size(s,1), size(s,2)}(s)
+
+toSVector(::Tuple{}) = SVector{0,Float64}()
+toSVectors(vs...) = [promote(toSVector.(vs)...)...]
+toSVector(v::SVector) = v
+toSVector(v::NTuple{N,Number}) where {N} = SVector(v)
+toSVector(x::Number) = SVector{1}(x)
+toSVector(::Type{T}, v) where {T} = T.(toSVector(v))
+toSVector(::Type{T}, ::Tuple{}) where {T} = SVector{0,T}()
+# Dynamic dispatch
+toSVector(v::AbstractVector) = SVector(Tuple(v))
+
+ensuretuple(s::Tuple) = s
+ensuretuple(s) = (s,)
+
+# ensureSMatrix(f::Function) = f
+# ensureSMatrix(m::T) where T<:Number = SMatrix{1,1,T,1}(m)
+# ensureSMatrix(m::SMatrix) = m
+# ensureSMatrix(m::Array) =
+#     throw(ErrorException("Write all model terms using scalars or @SMatrix[matrix]"))
+
+_rdr(r1, r2) = (0.5 * (r1 + r2), r2 - r1)
+
+# zerotuple(::Type{T}, ::Val{L}) where {T,L} = ntuple(_ -> zero(T), Val(L))
+
+function padright!(v::Vector, x, n::Integer)
+    n0 = length(v)
+    resize!(v, max(n, n0))
+    for i in (n0 + 1):n
+        v[i] = x
+    end
+    return v
+end
+
+padright(sv::StaticVector{E,T}, x::T, ::Val{E}) where {E,T} = sv
+padright(sv::StaticVector{E1,T1}, x::T2, ::Val{E2}) where {E1,T1,E2,T2} =
+    (T = promote_type(T1,T2); SVector{E2, T}(ntuple(i -> i > E1 ? x : convert(T, sv[i]), Val(E2))))
+padright(sv::StaticVector{E,T}, ::Val{E2}) where {E,T,E2} = padright(sv, zero(T), Val(E2))
+padright(sv::StaticVector{E,T}, ::Val{E}) where {E,T} = sv
+padright(t::NTuple{N´,<:Any}, x, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? x : t[i], Val(N))
+padright(t::NTuple{N´,<:Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 : t[i], Val(N))
+
+filltuple(x, ::Val{L}) where {L} = ntuple(_ -> x, Val(L))
+
+@inline padtotype(s::SMatrix{E,L}, st::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =
+    S(SMatrix{E2,E}(I) * s * SMatrix{L,L2}(I))
+@inline padtotype(s::UniformScaling, st::Type{S}) where {S<:SMatrix} = S(s)
+@inline padtotype(s::Number, ::Type{S}) where {S<:SMatrix} = S(s*I)
+@inline padtotype(s::Number, ::Type{T}) where {T<:Number} = T(s)
+@inline padtotype(s::AbstractArray, ::Type{T}) where {T<:Number} = T(first(s))
+@inline padtotype(s::UniformScaling, ::Type{T}) where {T<:Number} = T(s.λ)
+
+## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}
+negative(s::SVector{L,<:Number}) where {L} = -s
+negative(s::SVector{0,<:Number}) = s
+
+empty_sparse(::Type{M}, n, m) where {M} = sparse(Int[], Int[], M[], n, m)
+
+display_as_tuple(v, prefix = "") = isempty(v) ? "()" :
+    string("(", prefix, join(v, string(", ", prefix)), ")")
+
+displayvectors(mat::SMatrix{E,L,<:AbstractFloat}; kw...) where {E,L} =
+    ntuple(l -> round.(Tuple(mat[:,l]); kw...), Val(L))
+displayvectors(mat::SMatrix{E,L,<:Integer}; kw...) where {E,L} =
+    ntuple(l -> Tuple(mat[:,l]), Val(L))
+
+# pseudoinverse of s times an integer n, so that it is an integer matrix (for accuracy)
+pinvmultiple(s::SMatrix{L,0}) where {L} = (SMatrix{0,0,Int}(), 0)
+function pinvmultiple(s::SMatrix{L,L´}) where {L,L´}
+    L < L´ && throw(DimensionMismatch("Supercell dimensions $(L´) cannot exceed lattice dimensions $L"))
+    qrfact = qr(s)
+    n = det(qrfact.R)
+    # Cannot check det(s) ≈ 0 because s can be non-square
+    abs(n) ≈ 0 && throw(ErrorException("Supercell appears to be singular"))
+    pinverse = inv(qrfact.R) * qrfact.Q'
+    return round.(Int, n * inv(qrfact.R) * qrfact.Q'), round(Int, n)
+end
+
+@inline tuplejoin() = ()
+@inline tuplejoin(x) = x
+@inline tuplejoin(x, y) = (x..., y...)
+@inline tuplejoin(x, y, z...) = (x..., tuplejoin(y, z...)...)
+
+function isgrowing(vs::AbstractVector, i0 = 1)
+    i0 > length(vs) && return true
+    vprev = vs[i0]
+    for i in i0 + 1:length(vs)
+        v = vs[i]
+        v <= vprev && return false
+        vprev = v
+    end
+    return true
+end
+
+function ispositive(ndist)
+    result = false
+    for i in ndist
+        i == 0 || (result = i > 0; break)
+    end
+    return result
+end
+
+isnonnegative(ndist) = iszero(ndist) || ispositive(ndist)
+
+############################################################################################
+######## _copy! and _add! #  Revise after #33589 is merged #################################
+############################################################################################
+
+_copy!(dest, src) = copy!(dest, src)
+_copy!(dst::DenseMatrix{<:Number}, src::SparseMatrixCSC{<:Number}) = _fast_sparse_copy!(dst, src)
+_copy!(dst::DenseMatrix{<:SMatrix{N,N}}, src::SparseMatrixCSC{<:SMatrix{N,N}}) where {N} = _fast_sparse_copy!(dst, src)
+# _copy!(dst::AbstractMatrix{<:Number}, src::AbstractMatrix{<:SMatrix}) = _flatten_muladd!(dst, src)
+
+_add!(dest, src, α) = _plain_muladd(dest, src, α)
+_add!(dst::DenseMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, α = 1) = _fast_sparse_muladd!(dst, src, α)
+_add!(dst::DenseMatrix{<:SMatrix{N,N}}, src::SparseMatrixCSC{<:SMatrix{N,N}}, α = I) where {N} = _fast_sparse_muladd!(dst, src, α)
+# _add!(dst::AbstractMatrix{<:Number}, src::AbstractMatrix{<:SMatrix}, α = I) = _flatten_muladd!(dst, src, α)
+
+# Using broadcast .+= instead allocates unnecesarily
+function _plain_muladd(dst, src, α)
+    @boundscheck checkbounds(dst, axes(src)...)
+    for i in eachindex(src)
+        @inbounds dst[i] += α * src[i]
+    end
+    return dst
+end
+
+function _fast_sparse_copy!(dst::DenseMatrix{T}, src::SparseMatrixCSC) where {T}
+    @boundscheck checkbounds(dst, axes(src)...)
+    fill!(dst, zero(eltype(src)))
+    for col in 1:size(src, 1)
+        for p in nzrange(src, col)
+            @inbounds dst[rowvals(src)[p], col] = nonzeros(src)[p]
+        end
+    end
+    return dst
+end
+
+# Only needed for dense <- sparse (#33589), copy!(sparse, sparse) is fine
+function _fast_sparse_muladd!(dst::DenseMatrix{T}, src::SparseMatrixCSC, α = I) where {T}
+    @boundscheck checkbounds(dst, axes(src)...)
+    for col in 1:size(src, 1)
+        for p in nzrange(src, col)
+            @inbounds dst[rowvals(src)[p], col] += α * nonzeros(src)[p]
+        end
+    end
+    return dst
+end
+
+rclamp(r1::UnitRange, r2::UnitRange) = clamp(minimum(r1), extrema(r2)...):clamp(maximum(r1), extrema(r2)...)
+
+# function _flatten_muladd!(dst::DenseMatrix{T}, src::SparseMatrixCSC{S}, α = zero(T)) where {T<:Number,N,S<:SMatrix{N,N}}
+#     checkflattenaxes(dst, src)
+#     iszero(α) ? fill!(dst, zero(eltype(src))) : (α != 1 && α != I && rmul!(dst, α))
+#     for col in 1:size(src, 1)
+#         for p in nzrange(src, col)
+#             coffset = CartesianIndex(((rowvals(src)[p] - 1) * N, (col - 1) * N))
+#             smatrix = nonzeros(src)[p]
+#             for i in CartesianIndices((1:N, 1:N))
+#                 @inbounds dst[coffset + i] += smatrix[i]
+#             end
+#         end
+#     end
+#     return dst
+# end
+
+# function _flatten_muladd!(dst::SparseMatrixCSC{T}, src::SparseMatrixCSC{S}, α = zero(T)) where {T<:Number,N,S<:SMatrix{N,N}}
+#     rdst = rowvals(dst)
+#     ndst = nonzeros(dst)
+#     cdst = getcolptr(dst)
+#     cdst[1] = 1
+
+#     iszero(α) ? fill!(ndst, zero(eltype(S))) : (α != 1 && α != I && rmul!(ndst, α))
+#     copy_structure!(dst, src)
+
+#     p´ = col´ = 0
+#     for col in 1:size(src, 2), j in 1:N
+#         col´ += 1
+#         for p in nzrange(src, col)
+#             nz = nonzeros(src)[p]
+#             row´ = (rowvals(src)[p] - 1) * N
+#             for i in 1:N
+#                 row´ += 1
+#                 p´ += 1
+#                 rdst[p´] = row´
+#                 ndst[p´] += nz[i, j]
+#             end
+#         end
+#         cdst[col´ + 1] = p´ + 1
+#     end
+#     return dst
+# end
+
+# function _flatten_copy!(dst::SparseMatrixCSC{T}, src::SparseMatrixCSC{S}) where {T<:Number,N,S<:SMatrix{N,N}}
+#     checkflattenaxes(dst, src)
+#     l = length(nonzeros(src))
+#     l´ = N * N * l
+#     rdst = resize!(rowvals(dst), l´)
+#     ndst = resize!(nonzeros(dst), l´)
+#     cdst = resize!(getcolptr(dst), size(src, 2) * N + 1)
+#     cdst[1] = 1
+
+#     fill!(ndst, zero(eltype(S)))
+
+#     p´ = col´ = 0
+#     for col in 1:size(src, 2), j in 1:N
+#         col´ += 1
+#         for p in nzrange(src, col)
+#             row´ = (rowvals(src)[p] - 1) * N
+#             nz = nonzeros(src)[p]
+#             for i in 1:N
+#                 row´ += 1
+#                 p´ += 1
+#                 rdst[p´] = row´
+#                 ndst[p´] = nz[i, j]
+#             end
+#         end
+#         cdst[col´ + 1] = p´ + 1
+#     end
+#     return dst
+# end
+
+# function _flatten_muladd!(dst::DenseMatrix{<:Number}, src::DenseMatrix{S}, α = zero(T)) where {T<:Number,N,S<:SMatrix{N,N}}
+#     checkflattenaxes(dst, src)
+#     iszero(α) ? fill!(dst, zero(eltype(S))) : (α != 1 && α != I && rmul!(dst, α))
+#     c = CartesianIndices(src)
+#     i0 = first(c)
+#     for i in c
+#         smatrix = src[i]
+#         ioffset = (i - i0) * N
+#         for j in 1:N, i in 1:N
+#             @inbounds dst[ioffset + CartesianIndex(i, j)] += smatrix[i, j]
+#         end
+#     end
+#     return dst
+# end
+
+# function checkflattenaxes(dst::AbstractMatrix{<:Number}, src::AbstractMatrix{S}) where {T,N,S<:SMatrix{N,N,T}}
+#     Base.require_one_based_indexing(src)
+#     axes(dst) == (1:(N * size(src, 1)), 1:(N * size(src, 2))) ||
+#         throw(ArgumentError( "arrays must have the same axes (after flattening) for copy!"))
+# end
+
+# checkflattenaxes(dst::AbstractMatrix{<:SMatrix}, src::AbstractMatrix{<:Number}) =
+#     throw(ArgumentError("unflattening not supported"))
+
+# function checkflattenaxes(dst::AbstractMatrix, src::AbstractMatrix)
+#     axes(dst) == axes(src) ||
+#         throw(ArgumentError( "arrays must have the same axes for copy!"))
+# end
+
+# function copy_structure!(dst::SparseMatrixCSC{T}, src::SparseMatrixCSC) where {T}
+#     @boundscheck checkflattenaxes(dst, src)
+#     if !samestructure(dst, src)
+#         N = blocksize(eltype(src))
+#         rdst = rowvals(dst)
+#         ndst = nonzeros(dst)
+#         for col in 1:size(src, 2), p in nzrange(src, col)
+#             row´ = (rowvals(src)[p] - 1) * N + 1
+#             col´ = (col - 1) * N + 1
+#             isstored(dst, row´, col´) || _sparse_insert!(dst, row´, col´, N)
+#         end
+#     end
+#     return dst
+# end
+
+# samestructure(a, b) =
+#     blocksize(eltype(a)) == blocksize(eltype(b)) && rowvals(a) == rowvals(b) && getcolptr(a) == getcolptr(b)
+
+
+# function _sparse_insert!(s::SparseMatrixCSC{T}, row, col, N) where {T}
+#     if N != 1         # Block insert
+#         v = view(s, (row):(row + N - 1), (col):(col + N - 1))
+#         v .= one(T)   # necessary to create new stored entries
+#         v .= zero(T)  # here they are not removed, see #17404
+#     else
+#         s[row, col] = one(T)
+#         s[row, col] = zero(T)
+#     end
+#     return s
+# end
+
+# # Taken fron Julialang/#33821
+# function isstored(A::SparseMatrixCSC, i::Integer, j::Integer)
+#     @boundscheck checkbounds(A, i, j)
+#     rows = rowvals(A)
+#     for istored in nzrange(A, j) # could do binary search if the row indices are sorted?
+#         i == rows[istored] && return true
+#     end
+#     return false
+# end
+
+# blocksize(s::Type{<:SMatrix{N,N}}) where {N} = N
+# blocksize(s::Type{<:Number}) = 1
+
+############################################################################################
+
+function pushapproxruns!(runs::AbstractVector{<:UnitRange}, list::AbstractVector{T},
+                         offset = 0, degtol = sqrt(eps(real(T)))) where {T}
+    len = length(list)
+    len < 2 && return runs
+    rmin = rmax = 1
+    prev = list[1]
+    @inbounds for i in 2:len
+        next = list[i]
+        if abs(next - prev) < degtol
+            rmax = i
+        else
+            rmin < rmax && push!(runs, (offset + rmin):(offset + rmax))
+            rmin = rmax = i
+        end
+        prev = next
+    end
+    rmin < rmax && push!(runs, (offset + rmin):(offset + rmax))
+    return runs
+end
+
+function hasapproxruns(list::AbstractVector{T}, degtol = sqrt(eps(real(T)))) where {T}
+    for i in 2:length(list)
+        abs(list[i] - list[i-1]) < degtol && return true
+    end
+    return false
+end
+
+eltypevec(::AbstractMatrix{T}) where {T<:Number} = T
+eltypevec(::AbstractMatrix{S}) where {N,T<:Number,S<:SMatrix{N,N,T}} = SVector{N,T}
+
+# pinverse(s::SMatrix) = (qrfact = qr(s); return inv(qrfact.R) * qrfact.Q')
+
+# padrightbottom(m::Matrix{T}, im, jm) where {T} = padrightbottom(m, zero(T), im, jm)
+
+# function padrightbottom(m::Matrix{T}, zeroT::T, im, jm) where T
+#     i0, j0 = size(m)
+#     [i <= i0 && j<= j0 ? m[i,j] : zeroT for i in 1:im, j in 1:jm]
+# end
+
+
+tuplesort((a,b)::Tuple{<:Number,<:Number}) = a > b ? (b, a) : (a, b)
+tuplesort(t::Tuple) = t
+tuplesort(::Missing) = missing
+
+# collectfirst(s::T, ss...) where {T} = _collectfirst((s,), ss...)
+# _collectfirst(ts::NTuple{N,T}, s::T, ss...) where {N,T} = _collectfirst((ts..., s), ss...)
+# _collectfirst(ts::Tuple, ss...) = (ts, ss)
+# _collectfirst(ts::NTuple{N,System}, s::System, ss...) where {N} = _collectfirst((ts..., s), ss...)
+# collectfirsttolast(ss...) = tuplejoin(reverse(collectfirst(ss...))...)
+
+
+
+# allorderedpairs(v) = [(i, j) for i in v, j in v if i >= j]
+
+# Like copyto! but with potentially different tensor orders (adapted from Base.copyto!)
+function copyslice!(dest::AbstractArray{T1,N1}, Rdest::CartesianIndices{N1},
+                    src::AbstractArray{T2,N2}, Rsrc::CartesianIndices{N2}, by = identity) where {T1,T2,N1,N2}
+    isempty(Rdest) && return dest
+    if length(Rdest) != length(Rsrc)
+        throw(ArgumentError("source and destination must have same length (got $(length(Rsrc)) and $(length(Rdest)))"))
+    end
+    checkbounds(dest, first(Rdest))
+    checkbounds(dest, last(Rdest))
+    checkbounds(src, first(Rsrc))
+    checkbounds(src, last(Rsrc))
+    src′ = Base.unalias(dest, src)
+    @inbounds for (Is, Id) in zip(Rsrc, Rdest)
+        @inbounds dest[Id] = by(src′[Is])
+    end
+    return dest
+end
+
+function appendslice!(dest::AbstractArray, src::AbstractArray{T,N}, Rsrc::CartesianIndices{N}) where {T,N}
+    checkbounds(src, first(Rsrc))
+    checkbounds(src, last(Rsrc))
+    Rdest = (length(dest) + 1):(length(dest) + length(Rsrc))
+    resize!(dest, last(Rdest))
+    src′ = Base.unalias(dest, src)
+    @inbounds for (Is, Id) in zip(Rsrc, Rdest)
+        @inbounds dest[Id] = src′[Is]
+    end
+    return dest
+end
+
+######################################################################
+# Permutations (taken from Combinatorics.jl)
+######################################################################
+
+struct Permutations{T}
+    a::T
+    t::Int
+end
+
+Base.eltype(::Type{Permutations{T}}) where {T} = Vector{eltype(T)}
+
+Base.length(p::Permutations) = (0 <= p.t <= length(p.a)) ? factorial(length(p.a), length(p.a)-p.t) : 0
+
+"""
+    permutations(a)
+Generate all permutations of an indexable object `a` in lexicographic order. Because the number of permutations
+can be very large, this function returns an iterator object.
+Use `collect(permutations(a))` to get an array of all permutations.
+"""
+permutations(a) = Permutations(a, length(a))
+
+"""
+    permutations(a, t)
+Generate all size `t` permutations of an indexable object `a`.
+"""
+function permutations(a, t::Integer)
+    if t < 0
+        t = length(a) + 1
+    end
+    Permutations(a, t)
+end
+
+function Base.iterate(p::Permutations, s = collect(1:length(p.a)))
+    (!isempty(s) && max(s[1], p.t) > length(p.a) || (isempty(s) && p.t > 0)) && return
+    nextpermutation(p.a, p.t ,s)
+end
+
+function nextpermutation(m, t, state)
+    perm = [m[state[i]] for i in 1:t]
+    n = length(state)
+    if t <= 0
+        return(perm, [n+1])
+    end
+    s = copy(state)
+    if t < n
+        j = t + 1
+        while j <= n &&  s[t] >= s[j]; j+=1; end
+    end
+    if t < n && j <= n
+        s[t], s[j] = s[j], s[t]
+    else
+        if t < n
+            reverse!(s, t+1)
+        end
+        i = t - 1
+        while i>=1 && s[i] >= s[i+1]; i -= 1; end
+        if i > 0
+            j = n
+            while j>i && s[i] >= s[j]; j -= 1; end
+            s[i], s[j] = s[j], s[i]
+            reverse!(s, i+1)
+        else
+            s[1] = n+1
+        end
+    end
+    return (perm, s)
+end
+
+# Taken from Combinatorics.jl
+# TODO: This should really live in Base, otherwise it's type piracy
+"""
+    factorial(n, k)
+
+Compute ``n!/k!``.
+"""
+function Base.factorial(n::T, k::T) where T<:Integer
+    if k < 0 || n < 0 || k > n
+        throw(DomainError((n, k), "n and k must be nonnegative with k ≤ n"))
+    end
+    f = one(T)
+    while n > k
+        f = Base.checked_mul(f, n)
+        n -= 1
+    end
+    return f
+end
+
+Base.factorial(n::Integer, k::Integer) = factorial(promote(n, k)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
-using Quantica
 using Test
+using Quantica
+using Random
 
 @testset "Quantica.jl" begin
-    # Write your tests here.
+    include("test_lattice.jl")
+    include("test_model.jl")
+    include("test_hamiltonian.jl")
+    include("test_mesh.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test
 using Quantica
-using Random
 
 @testset "Quantica.jl" begin
     include("test_lattice.jl")

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,0 +1,43 @@
+module HamiltonianTest
+
+using LinearAlgebra: diag
+
+@testset "basic hamiltonians" begin
+    presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
+               LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
+               LatticePresets.bcc)
+    ts = (1, 2.0, @SMatrix[1 2; 3 4])
+    orbs = (Val(1), Val(1), Val(2))
+    for preset in presets, lat in (preset(), unitcell(preset()))
+        E, L = dims(lat)
+        dn0 = ntuple(_ -> 1, Val(L))
+        for (t, o) in zip(ts, orbs)
+            @test hamiltonian(lat, onsite(t) + hopping(t; range = 1), orbitals = o) isa Hamiltonian
+            @test hamiltonian(lat, onsite(t) - hopping(t; dn = dn0), orbitals = o) isa Hamiltonian
+            @test hamiltonian(lat, onsite(t) + hopping(t; dn = dn0, forcehermitian = false), orbitals = o) isa Hamiltonian
+        end
+    end
+end
+
+@testset "orbitals and sublats" begin
+    orbs = (:a, (:a,), (:a, :b, 3), ((:a, :b), :c), ((:a, :b), (:c,)), (Val(2), Val(1)),
+            (:A => (:a, :b), :D => :c), :D => Val(4))
+    lat = LatticePresets.honeycomb()
+    for orb in orbs
+        @test hamiltonian(lat, onsite(1), orbitals = orb) isa Hamiltonian
+    end
+    @test hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
+                      orbitals = :B => Val(2)) isa Hamiltonian
+    h1 = hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
+                      orbitals = :B => Val(2))
+    h2 = hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
+                      orbitals = :B => Val(2))
+    @test bloch(h1, 1, 2) == bloch(h2, 1, 2)
+end
+
+@testset "fields" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)) |> unitcell(2, onsite! = (o, r) -> 1)
+    @test diag(bloch(h)) == ComplexF64[1, 1, 1, 1, 1, 1, 1, 1]
+end
+
+end # module

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,6 +1,5 @@
-module HamiltonianTest
-
 using LinearAlgebra: diag
+using Quantica: Hamiltonian
 
 @testset "basic hamiltonians" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
@@ -35,9 +34,7 @@ end
     @test bloch(h1, 1, 2) == bloch(h2, 1, 2)
 end
 
-@testset "fields" begin
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)) |> unitcell(2, onsite! = (o, r) -> 1)
+@testset "modifiers" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)) |> unitcell(2, modifiers = onsite!((o, r) -> 1))
     @test diag(bloch(h)) == ComplexF64[1, 1, 1, 1, 1, 1, 1, 1]
 end
-
-end # module

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,6 +1,5 @@
-module LatticeTest
-
 using Quantica: nsites, Sublat, Bravais, Lattice, Superlattice
+using Random
 
 @testset "bravais" begin
     @test bravais() isa Bravais{0,0,Float64,0}
@@ -77,5 +76,3 @@ end
     @test supercell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Superlattice{3,3}
     @test supercell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10)) isa Superlattice{3,3}
 end
-
-end # module

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,0 +1,81 @@
+module LatticeTest
+
+using Quantica: nsites, Sublat, Bravais, Lattice, Superlattice
+
+@testset "bravais" begin
+    @test bravais() isa Bravais{0,0,Float64,0}
+    @test bravais((1, 2), (3, 3)) isa Bravais{2,2,Int,4}
+    @test bravais(@SMatrix[1.0 2; 3 3]) isa Bravais{2,2,Float64,4}
+    @test bravais((1,0), semibounded = false) isa Bravais{2,1,Int,2}
+end
+
+@testset "sublat" begin
+    sitelist = [(3,3), (3,3.), [3,3.], @SVector[3, 3], @SVector[3, 3f0], @SVector[3f0, 3.]]
+    for site2 in sitelist, site1 in sitelist
+        @test sublat(site1, site2) isa
+            Sublat{2,promote_type(typeof.(site1)..., typeof.(site2)...)}
+    end
+    @test sublat((3,)) isa Sublat{1,Int}
+    @test sublat(()) isa Sublat{0,Float64}
+end
+
+@testset "lattice" begin
+    s = sublat((1, 2))
+    for t in (Float32, Float64), e in 1:4, l = 1:4
+        b = bravais(ntuple(_ -> (1,), l)...)
+        @test lattice(b, s, type = t, dim = Val(e)) isa Lattice{e,min(l,e),t}
+        @test lattice(b, s, type = t, dim = e) isa Lattice{e,min(l,e),t}
+    end
+end
+
+@testset "lattice presets" begin
+    a0s = (1, 2)
+    presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
+               LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
+               LatticePresets.bcc)
+    for a0 in a0s, s in (true, false), t in (Float32, Float64), e in 1:4, preset in presets
+        @test preset(; a0 = a0, semibounded = s, type = t, dim = e) isa Lattice{e,<:Any,t}
+    end
+end
+
+@testset "unitcell" begin
+    presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
+               LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
+               LatticePresets.bcc)
+    Random.seed!(1234)
+    for preset in presets
+        lat = preset()
+        E, L = dims(lat)
+        for l in 1:L
+            svecs = ntuple(i -> ntuple(j -> rand(1:5) , Val(E)), L-l)
+            @test unitcell(preset(), svecs...) isa Lattice{E,L-l}
+            @test unitcell(preset(), l) isa Lattice{E,L}
+        end
+    end
+    @test unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(10)) isa Lattice{2,0}
+    @test unitcell(LatticePresets.honeycomb(), (2,1), region = RegionPresets.circle(10)) isa Lattice{2,1}
+    @test unitcell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Lattice{3,1}
+    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10)) isa Lattice{3,1}
+end
+
+@testset "supercell" begin
+    presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
+               LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
+               LatticePresets.bcc)
+    Random.seed!(1234)
+    for preset in presets
+        lat = preset()
+        E, L = dims(lat)
+        for l in 1:L
+            svecs = ntuple(i -> ntuple(j -> rand(1:5) , Val(E)), L-l)
+            @test supercell(preset(), svecs...) isa Superlattice{E,<:Any,<:Any,L-l}
+            @test supercell(preset(), l) isa Superlattice{E,<:Any,<:Any,L}
+        end
+    end
+    @test supercell(LatticePresets.honeycomb(), region = RegionPresets.circle(10)) isa Superlattice{2,2}
+    @test supercell(LatticePresets.honeycomb(), (2,1), region = RegionPresets.circle(10)) isa Superlattice{2,2}
+    @test supercell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Superlattice{3,3}
+    @test supercell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10)) isa Superlattice{3,3}
+end
+
+end # module

--- a/test/test_mesh.jl
+++ b/test/test_mesh.jl
@@ -1,10 +1,6 @@
-module MeshTest
-
 using Quantica: nvertices, nedges, nsimplices
 
 @test begin
     mesh = marchingmesh(2, 3)
     nvertices(mesh) == 6 && nedges(mesh) == 9 && nsimplices(mesh) == 4
 end
-
-end # module

--- a/test/test_mesh.jl
+++ b/test/test_mesh.jl
@@ -1,0 +1,10 @@
+module MeshTest
+
+using Quantica: nvertices, nedges, nsimplices
+
+@test begin
+    mesh = marchingmesh(2, 3)
+    nvertices(mesh) == 6 && nedges(mesh) == 9 && nsimplices(mesh) == 4
+end
+
+end # module

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1,0 +1,53 @@
+module ModelTest
+
+using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector
+
+@testset "onsite" begin
+    r = SVector(0.0, 0.0)
+    os = (1, 1.0, @SMatrix[1 0; 0 1], I, r -> 1, r -> I, r -> SMatrix{3,3}(I))
+    ss = (missing, :A, (:A,), (:A, :B))
+    cs = (1, 1.0, 1.0f0)
+    ts = (Float32, Float64, SMatrix{3,3}, SMatrix{3,2,Float64}, SMatrix{1,4,Float32})
+    for o in os, s in ss, c in cs
+        ons = c * onsite(o, sublats = s)
+        @test ons isa
+            TightbindingModel{1,<:Tuple{OnsiteTerm{typeof(o)}}}
+        term = first(ons.terms)
+        for t in ts
+            @test padtotype(term(r, r), t) isa t
+        end
+    end
+end
+
+@testset "hopping" begin
+    r = SVector(0.0, 0.0)
+    hs = (1, 1.0, @SMatrix[1 0; 0 1], I, (r, dr) -> 1, (r, dr) -> I, (r, dr) -> SMatrix{3,3}(I))
+    ss = (missing, :A, (:A,), (:A, :B), ((:A,:B), :C), ((:A,:B), (:C,)), ((:A,:B), (:C, :D)))
+    cs = (1, 1.0, 1.0f0)
+    ts = (Float32, Float64, SMatrix{3,3}, SMatrix{3,2,Float64}, SMatrix{1,4,Float32})
+    dns = (missing, (1,), ((1,2), (3,4)))
+    rs = (1, 2.0, Inf)
+    for h in hs, s in ss, c in cs, d in dns, r in rs
+        hop = c * hopping(h, sublats = s, dn = d, range = r)
+        @test hop isa
+            TightbindingModel{1,<:Tuple{HoppingTerm{typeof(h)}}}
+        term = first(hop.terms)
+        for t in ts
+            @test padtotype(term(r, r), t) isa t
+        end
+    end
+end
+
+@testset "term algebra" begin
+    r = SVector(0, 0)
+    model = onsite(1) + hopping(2I)
+    @test (t -> t(r, r)).(model.terms) == (1, 2I)
+    model = onsite(1) - hopping(2I)
+    @test (t -> t(r, r)).(model.terms) == (1, -2I)
+    model = -onsite(@SMatrix[1 0; 1 1]) - 2hopping(2I)
+    @test (t -> t(r, r)).(model.terms) == (-@SMatrix[1 0; 1 1], -4I)
+    @test model(r, r) == @SMatrix[-5 0; -1 -5]
+end
+
+end # module
+

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1,5 +1,3 @@
-module ModelTest
-
 using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector
 
 @testset "onsite" begin
@@ -48,6 +46,3 @@ end
     @test (t -> t(r, r)).(model.terms) == (-@SMatrix[1 0; 1 1], -4I)
     @test model(r, r) == @SMatrix[-5 0; -1 -5]
 end
-
-end # module
-


### PR DESCRIPTION
This migrates the Elsa.jl codebase to Quantica.jl, with minor changes to adapt to the change of name