### PR TITLE
Strict model dimensions

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -25,9 +25,3 @@ Base.promote_rule(::Type{Sublat{E1,T1}}, ::Type{Sublat{E2,T2}}) where {E1,E2,T1,
 
 Bravais{E,L,T}(b::Bravais) where {E,L,T} =
     Bravais(padtotype(b.matrix, SMatrix{E,L,T}), padright(b.semibounded, Val(L)))
-
-# Promotion
-
-# promote_model(model::Model, sys::System{E,L,T,Tv}, systems...) where {E,L,T,Tv} = promote_model(Tv, model, systems...)
-# promote_model(::Type{Tv}, model::Model, sys::System{E,L,T,Tv2}, systems...) where {Tv,E,L,T,Tv2} = promote_model(promote_type(Tv, Tv2), model, systems...)
-# promote_model(::Type{Tv}, model::Model) where {Tv} = convert(Model{Tv}, model)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -511,7 +511,6 @@ function hamiltonian_sparse(Mtype, lat, orbs, model)
 end
 
 function hamiltonian_sparse!(builder::IJVBuilder{L,M}, lat::AbstractLattice{E,L}, orbs, model) where {E,L,M}
-    checkmodelorbs(model, orbs, lat)
     applyterms!(builder, terms(model)...)
     n = nsites(lat)
     HT = HamiltonianHarmonic{L,M,SparseMatrixCSC{M,Int}}

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -57,6 +57,8 @@ filltuple(x, ::Val{L}) where {L} = ntuple(_ -> x, Val(L))
 @inline padtotype(s::UniformScaling, st::Type{S}) where {S<:SMatrix} = S(s)
 @inline padtotype(s::UniformScaling, ::Type{T}) where {T<:Number} = T(s.λ)
 @inline padtotype(s::Number, ::Type{T}) where {T<:Number} = T(s)
+@inline padtotype(s::SMatrix{1,1}, ::Type{T}) where {T<:Number} = T(first(s))
+@inline padtotype(s::Number, ::Type{S}) where {S<:SMatrix{1,1}} = S(s)
 @inline padtotype(s, st::Type) =
     throw(DimensionMismatch("Dimension mismatch between model ($(typeof(s))) and Hamiltonian ($st). Did you correctly specify the `orbitals` in hamiltonian? Consider also using `I` to cover non-uniform orbital dimensions"))
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -49,13 +49,16 @@ padright(t::NTuple{N´,<:Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0
 
 filltuple(x, ::Val{L}) where {L} = ntuple(_ -> x, Val(L))
 
+# Pad element type to a larger type `st` that encompases all sublattices
 @inline padtotype(s::SMatrix{E,L}, st::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =
     S(SMatrix{E2,E}(I) * s * SMatrix{L,L2}(I))
-@inline padtotype(s::UniformScaling, st::Type{S}) where {S<:SMatrix} = S(s)
-@inline padtotype(s::Number, ::Type{S}) where {S<:SMatrix} = S(s*I)
-@inline padtotype(s::Number, ::Type{T}) where {T<:Number} = T(s)
+@inline padtotype(s::SMatrix{E,L}, st::Type{S}) where {E,L,S<:SMatrix{E,L}} = S(s)
 @inline padtotype(s::AbstractArray, ::Type{T}) where {T<:Number} = T(first(s))
+@inline padtotype(s::UniformScaling, st::Type{S}) where {S<:SMatrix} = S(s)
 @inline padtotype(s::UniformScaling, ::Type{T}) where {T<:Number} = T(s.λ)
+@inline padtotype(s::Number, ::Type{T}) where {T<:Number} = T(s)
+@inline padtotype(s, st::Type) =
+    throw(DimensionMismatch("Dimension mismatch between model ($(typeof(s))) and Hamiltonian ($st). Did you correctly specify the `orbitals` in hamiltonian? Consider also using `I` to cover non-uniform orbital dimensions"))
 
 ## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}
 negative(s::SVector{L,<:Number}) where {L} = -s

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -49,18 +49,14 @@ padright(t::NTuple{N´,<:Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0
 
 filltuple(x, ::Val{L}) where {L} = ntuple(_ -> x, Val(L))
 
-# Pad element type to a larger type `st` that encompases all sublattices
-@inline padtotype(s::SMatrix{E,L}, st::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =
+# Pad element type to a "larger" type
+@inline padtotype(s::SMatrix{E,L}, ::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =
     S(SMatrix{E2,E}(I) * s * SMatrix{L,L2}(I))
-@inline padtotype(s::SMatrix{E,L}, st::Type{S}) where {E,L,S<:SMatrix{E,L}} = S(s)
-@inline padtotype(s::AbstractArray, ::Type{T}) where {T<:Number} = T(first(s))
-@inline padtotype(s::UniformScaling, st::Type{S}) where {S<:SMatrix} = S(s)
-@inline padtotype(s::UniformScaling, ::Type{T}) where {T<:Number} = T(s.λ)
-@inline padtotype(s::Number, ::Type{T}) where {T<:Number} = T(s)
-@inline padtotype(s::SMatrix{1,1}, ::Type{T}) where {T<:Number} = T(first(s))
-@inline padtotype(s::Number, ::Type{S}) where {S<:SMatrix{1,1}} = S(s)
-@inline padtotype(s, st::Type) =
-    throw(DimensionMismatch("Dimension mismatch between model ($(typeof(s))) and Hamiltonian ($st). Did you correctly specify the `orbitals` in hamiltonian? Consider also using `I` to cover non-uniform orbital dimensions"))
+@inline padtotype(x::Number, ::Type{S}) where {E,L,S<:SMatrix{E,L}} =
+    S(x * (SMatrix{E,1}(I) * SMatrix{1,L}(I)))
+@inline padtotype(x::Number, ::Type{T}) where {T<:Number} = T(x)
+@inline padtotype(u::UniformScaling, ::Type{T}) where {T<:Number} = T(u.λ)
+@inline padtotype(u::UniformScaling, ::Type{S}) where {S<:SMatrix} = S(u)
 
 ## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}
 negative(s::SVector{L,<:Number}) where {L} = -s

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -5,7 +5,7 @@ using Quantica: Hamiltonian
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
                LatticePresets.bcc)
-    ts = (1, 2.0, @SMatrix[1 2; 3 4])
+    ts = (1I, 2.0I, @SMatrix[1 2; 3 4])
     orbs = (Val(1), Val(1), Val(2))
     for preset in presets, lat in (preset(), unitcell(preset()))
         E, L = dims(lat)
@@ -23,15 +23,17 @@ end
             (:A => (:a, :b), :D => :c), :D => Val(4))
     lat = LatticePresets.honeycomb()
     for orb in orbs
-        @test hamiltonian(lat, onsite(1), orbitals = orb) isa Hamiltonian
+        @test hamiltonian(lat, onsite(I), orbitals = orb) isa Hamiltonian
     end
-    @test hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
+    @test hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
                       orbitals = :B => Val(2)) isa Hamiltonian
-    h1 = hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
+    h1 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
                       orbitals = :B => Val(2))
-    h2 = hamiltonian(lat, onsite(1) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
+    h2 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
                       orbitals = :B => Val(2))
     @test bloch(h1, 1, 2) == bloch(h2, 1, 2)
+
+    @test_throws DimensionMismatch hamiltonian(lat, onsite(1), orbitals = Val(2))
 end
 
 @testset "modifiers" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -5,7 +5,7 @@ using Quantica: Hamiltonian
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
                LatticePresets.bcc)
-    ts = (1I, 2.0I, @SMatrix[1 2; 3 4])
+    ts = (1, 2.0I, @SMatrix[1 2; 3 4])
     orbs = (Val(1), Val(1), Val(2))
     for preset in presets, lat in (preset(), unitcell(preset()))
         E, L = dims(lat)
@@ -32,8 +32,52 @@ end
     h2 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
                       orbitals = :B => Val(2))
     @test bloch(h1, 1, 2) == bloch(h2, 1, 2)
+end
 
-    @test_throws DimensionMismatch hamiltonian(lat, onsite(1), orbitals = Val(2))
+@testset "onsite dimensions" begin
+    lat = LatticePresets.honeycomb()
+    ts = (@SMatrix[1 2; 3 4], r -> @SMatrix[r[1] 2; 3 4], 2, r -> 2r[1],
+          @SMatrix[1 2; 3 4], r -> @SMatrix[r[1] 2; 3 4])
+    os = (Val(1), Val(1), Val(2), Val(2), Val(3), Val(3))
+    for (t, o) in zip(ts, os)
+        model = onsite(t)
+        @test_throws DimensionMismatch hamiltonian(lat, model, orbitals = o)
+    end
+
+    ts = (@SMatrix[1 2; 3 4], r -> @SMatrix[r[1] 2; 3 4], 2, r -> 2r[1], 3I, r -> I, 3I)
+    os = (Val(2), Val(2), Val(1), Val(1), Val(3), Val(3), (Val(1), Val(3)))
+    for (t, o) in zip(ts, os)
+        model = onsite(t)
+        @test hamiltonian(lat, model, orbitals = o) isa Hamiltonian
+    end
+    @test bloch(hamiltonian(lat, onsite(3I), orbitals = (Val(1), Val(3))))[1,1] ==
+        @SMatrix[3 0 0; 0 0 0; 0 0 0]
+    @test bloch(hamiltonian(lat, onsite(3I), orbitals = (Val(1), Val(3))))[2,2] ==
+        SMatrix{3,3}(3I)
+end
+
+@testset "hopping dimensions" begin
+    lat = LatticePresets.honeycomb()
+    ts = (@SMatrix[1 2; 2 3], (r,dr) -> @SMatrix[r[1] 2; 3 4], 2, (r,dr) -> 2r[1],
+          @SMatrix[1 2], @SMatrix[1 ;2], @SMatrix[1 2], @SMatrix[1 2; 2 3])
+    os = (Val(1), Val(1), Val(2), Val(2), (Val(2), Val(1)), (Val(2), Val(1)),
+         (Val(2), Val(1)), (Val(2), Val(1)))
+    ss = (missing, missing, missing, missing, :B => :A, :A => :B, missing, missing)
+    for (t, o, s) in zip(ts, os, ss)
+        model = hopping(t, sublats = s)
+        @test_throws DimensionMismatch hamiltonian(lat, model, orbitals = o)
+    end
+    ts = (@SMatrix[1 2], @SMatrix[1 ;2])
+    os = ((Val(2), Val(1)), (Val(2), Val(1)))
+    ss = (:A => :B, :B => :A)
+    for (t, o, s) in zip(ts, os, ss)
+        model = hopping(t, sublats = s)
+        @test hamiltonian(lat, model, orbitals = o) isa Hamiltonian
+    end
+    @test bloch(hamiltonian(lat, hopping(3I, range = 1/√3), orbitals = (Val(1), Val(2))))[2,1] ==
+        @SMatrix[3 0; 0 0]
+    @test bloch(hamiltonian(lat, hopping(3I, range = 1/√3), orbitals = (Val(1), Val(2))))[1,2] ==
+        @SMatrix[3 0; 0 0]
 end
 
 @testset "modifiers" begin

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1,41 +1,5 @@
 using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector
 
-@testset "onsite" begin
-    r = SVector(0.0, 0.0)
-    os = (I, 2I, 2.0I,@SMatrix[1 0; 0 1], r -> 2.0I, r -> I, r -> SMatrix{3,3}(3I))
-    ss = (missing, :A, (:A,), (:A, :B))
-    cs = (1, 1.0, 1.0f0)
-    ts = (Float32, Float64, SMatrix{3,3}, SMatrix{3,2,Float64}, SMatrix{1,4,Float32})
-    for o in os, s in ss, c in cs
-        ons = c * onsite(o, sublats = s)
-        @test ons isa
-            TightbindingModel{1,<:Tuple{OnsiteTerm{typeof(o)}}}
-        term = first(ons.terms)
-        for t in ts
-            @test padtotype(term(r, r), t) isa t
-        end
-    end
-end
-
-@testset "hopping" begin
-    r = SVector(0.0, 0.0)
-    hs = (I, 2I, 2.0I, @SMatrix[1 0; 0 1], (r, dr) -> 2.0I, (r, dr) -> I, (r, dr) -> SMatrix{3,3}(3I))
-    ss = (missing, :A, (:A,), (:A, :B), ((:A,:B), :C), ((:A,:B), (:C,)), ((:A,:B), (:C, :D)))
-    cs = (1, 1.0, 1.0f0)
-    ts = (Float32, Float64, SMatrix{3,3}, SMatrix{3,2,Float64}, SMatrix{1,4,Float32})
-    dns = (missing, (1,), ((1,2), (3,4)))
-    rs = (1, 2.0, Inf)
-    for h in hs, s in ss, c in cs, d in dns, r in rs
-        hop = c * hopping(h, sublats = s, dn = d, range = r)
-        @test hop isa
-            TightbindingModel{1,<:Tuple{HoppingTerm{typeof(h)}}}
-        term = first(hop.terms)
-        for t in ts
-            @test padtotype(term(r, r), t) isa t
-        end
-    end
-end
-
 @testset "term algebra" begin
     r = SVector(0, 0)
     model = onsite(1) + hopping(2I)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -2,7 +2,7 @@ using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector
 
 @testset "onsite" begin
     r = SVector(0.0, 0.0)
-    os = (1, 1.0, @SMatrix[1 0; 0 1], I, r -> 1, r -> I, r -> SMatrix{3,3}(I))
+    os = (I, 2I, 2.0I,@SMatrix[1 0; 0 1], r -> 2.0I, r -> I, r -> SMatrix{3,3}(3I))
     ss = (missing, :A, (:A,), (:A, :B))
     cs = (1, 1.0, 1.0f0)
     ts = (Float32, Float64, SMatrix{3,3}, SMatrix{3,2,Float64}, SMatrix{1,4,Float32})
@@ -19,7 +19,7 @@ end
 
 @testset "hopping" begin
     r = SVector(0.0, 0.0)
-    hs = (1, 1.0, @SMatrix[1 0; 0 1], I, (r, dr) -> 1, (r, dr) -> I, (r, dr) -> SMatrix{3,3}(I))
+    hs = (I, 2I, 2.0I, @SMatrix[1 0; 0 1], (r, dr) -> 2.0I, (r, dr) -> I, (r, dr) -> SMatrix{3,3}(3I))
     ss = (missing, :A, (:A,), (:A, :B), ((:A,:B), :C), ((:A,:B), (:C,)), ((:A,:B), (:C, :D)))
     cs = (1, 1.0, 1.0f0)
     ts = (Float32, Float64, SMatrix{3,3}, SMatrix{3,2,Float64}, SMatrix{1,4,Float32})


### PR DESCRIPTION
Before, an `onsite(3)` would be applied (with a warning) to a sublattice of orbital dimension `N>1` as an identity `3I`. This was always a likely bug (inconsistent model with orbital dimensions). We now error instead of showing a warning, pointing the user to `onsite(3I)` if case she really intends to implement an identity matrix.

This check is done by static dispatch through `toeltype` when building the Hamiltonian. It should therefore have no runtime overhead. It also allows us to remove the `checkmodelorbs` check (that previously issued the warning), which was fragile and ugly (it relied on applying a model term to some random sites).