### PR TITLE
onsiteselector!(model) and hoppingselector!(model)

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -6,7 +6,8 @@ using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
 export sublat, bravais, lattice, dims, sites, supercell, unitcell,
-       hopping, onsite, onsiteselector, hoppingselector, onsite!, hopping!,
+       hopping, onsite, onsite!, hopping!,
+       onsiteselector, hoppingselector, onsiteselector!, hoppingselector!,
        hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
        flatten, wrap, transform!, combine,
        spectrum, bandstructure, marchingmesh, defaultmethod, bands, vertices,

--- a/src/model.jl
+++ b/src/model.jl
@@ -150,7 +150,7 @@ updateselector!(s::OnsiteSelector, s´::OnsiteSelector) =
     OnsiteSelector(updateselector!.((s.region, s.sublats),(s´.region, s´.sublats))...)
 updateselector!(s::HoppingSelector, s´::HoppingSelector) =
 HoppingSelector(updateselector!.((s.region, s.sublats, s.dns, s.range),
-                            (s´.region, s´.sublats, s´.dns, s´.range))...)
+                                 (s´.region, s´.sublats, s´.dns, s´.range))...)
 updateselector!(o, o´::Missing) = o
 updateselector!(o, o´) = o´
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -10,3 +10,35 @@ using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector
     @test (t -> t(r, r)).(model.terms) == (-@SMatrix[1 0; 1 1], -4I)
     @test model(r, r) == @SMatrix[-5 0; -1 -5]
 end
+
+@testset "onsiteselector!" begin
+    rs = (r->true, missing)
+    ss = (:A, missing)
+    for r in rs, s in ss
+        model0 = onsite(1, region = r, sublats = s) + hopping(1)
+        model1 = onsite(1) + hopping(1)
+        model2 = onsite(1, sublats = s) + hopping(1)
+        model3 = onsite(1, region = r) + hopping(1)
+        @test onsiteselector!(model1, region = r, sublats = s) === model0
+        @test onsiteselector!(model2, region = r, sublats = s) === model0
+        @test onsiteselector!(model3, region = r, sublats = s) === model0
+    end
+end
+
+@testset "hoppingselector!" begin
+    rs = (r->true, missing)
+    ss = (:A, missing)
+    dns = ((0,1), missing)
+    ranges = (Inf, 1)  # no missing here, because hopping range default is 1.0
+    for r in rs, s in ss, dn in dns, rn in ranges
+        model0 = hopping(1, region = r, sublats = s, dn = dn, range = rn) + onsite(1)
+        model1 = hopping(1, region = r, sublats = s, dn = dn) + onsite(1)
+        model2 = hopping(1, region = r, sublats = s) + onsite(1)
+        model3 = hopping(1, region = r, range = rn) + onsite(1)
+        model4 = hopping(1) + onsite(1)
+        @test hoppingselector!(model1, region = r, sublats = s, dn = dn, range = rn) === model0
+        @test hoppingselector!(model2, region = r, sublats = s, dn = dn, range = rn) === model0
+        @test hoppingselector!(model3, region = r, sublats = s, dn = dn, range = rn) === model0
+        @test hoppingselector!(model4, region = r, sublats = s, dn = dn, range = rn) === model0
+    end
+end


### PR DESCRIPTION
Closes #15 

This introduces `onsiteselector!(m::TightbindingModel; kw...)` and `hoppingselector!(m::TightbindingModel; kw...)` that overwrites the selectors of all onsite or hopping terms in model `m`, respectively, with the keywords `kw` corresponding to `onsiteselector` and `hoppingselector`