### PR TITLE
Simplify marchingmesh

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -130,12 +130,12 @@ Options passed to the `method` will be forwarded to the diagonalization function
 `method = ArpackPackage(nev = 8, sigma = 1im)` will use `Arpack.eigs(matrix; nev = 8,
 sigma = 1im)` to compute the bandstructure.
 
-    bandstructure(h::Hamiltonian; resolution = 13, shift = missing, kw...)
+    bandstructure(h::Hamiltonian; resolution = 13, kw...)
 
-Same as above with a  uniform `mesh = marchingmesh(h; npoints = resolution, shift = shift)`
-of marching tetrahedra (generalized to the lattice dimensions of the Hamiltonian). Note that
-`resolution` denotes the number of points along each Bloch axis, including endpoints (can be
-a tuple for axis-dependent points).
+Same as above with a uniform `mesh` of marching tetrahedra (generalized to the lattice
+dimensions of the Hamiltonian), with points `range(-π, π, length = resolution)` along each
+Bravais axis. Note that `resolution` denotes the number of points along each Bloch axis,
+including endpoints (can be a tuple for axis-dependent points).
 
 # Example
 ```
@@ -153,14 +153,12 @@ Bandstructure: bands for a 2D hamiltonian
 # See also
     marchingmesh
 """
-function bandstructure(h::Hamiltonian{<:Any,L,M}; resolution = 13, shift = missing, kw...) where {L,M}
-    checkfinitedim(h)
-    mesh = marchingmesh(h; npoints = resolution, shift = shift)
-    return bandstructure(h,  mesh; kw...)
+function bandstructure(h::Hamiltonian{<:Any,L,M}; resolution = 13, kw...) where {L,M}
+    mesh = marchingmesh(filltuple(range(-π, π, length = resolution), Val(L))...)
+    return bandstructure(h, mesh; kw...)
 end
 
-function bandstructure(h::Hamiltonian, mesh::Mesh; method = defaultmethod(h), minprojection = 0.5)
-    checkfinitedim(h)
+function bandstructure(h::Hamiltonian{<:Any,L}, mesh::Mesh{L}; method = defaultmethod(h), minprojection = 0.5) where {L}
     ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
     d = diagonalizer(h, mesh, method, minprojection)
     matrix = similarmatrix(h, method)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -99,9 +99,6 @@ blockdim(h::Hamiltonian) = blockdim(blocktype(h))
 blockdim(::Type{S}) where {N,S<:SMatrix{N,N}} = N
 blockdim(::Type{T}) where {T<:Number} = 1
 
-checkfinitedim(h::Hamiltonian{LA,L}) where {LA,L} =
-    L == 0 && throw(ArgumentError("A finite-dimensional Hamiltonian is required, not zero-dimensional"))
-
 function nhoppings(ham::Hamiltonian)
     count = 0
     for h in ham.harmonics

--- a/test/test_mesh.jl
+++ b/test/test_mesh.jl
@@ -1,6 +1,6 @@
 using Quantica: nvertices, nedges, nsimplices
 
 @test begin
-    mesh = marchingmesh(2, 3)
-    nvertices(mesh) == 6 && nedges(mesh) == 9 && nsimplices(mesh) == 4
+    mesh = marchingmesh(0:0.1:1, 1:0.1:2)
+    nvertices(mesh) == 121 && nedges(mesh) == 320 && nsimplices(mesh) == 200
 end


### PR DESCRIPTION
Closes #20

This PR removes the `marchingmesh(npoints...)` method, and only defaults to a `range(-π,π,length=resolution)`  when building a mesh by calling `bandstructure(h; resolution)`