### PR TITLE
@onsite! and @hopping! macros for automatic parameter declaration

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -10,6 +10,11 @@ version = "0.8.2"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
+[[ExprTools]]
+git-tree-sha1 = "08c1f74d9ad03acf0ee84c12c9e665ab1a9a6e33"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.0"
+
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Pablo San-Jose"]
 version = "0.1.0"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
@@ -15,13 +16,13 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "^1.4"
-NearestNeighbors = "^0.4"
 LinearMaps = "^2.6"
+NearestNeighbors = "^0.4"
+OffsetArrays = "^1.0"
+ProgressMeter = "^1.2"
 Requires = "^1.0"
 StaticArrays = "^0.12"
-ProgressMeter = "^1.2"
-OffsetArrays = "^1.0"
+julia = "^1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -7,7 +7,7 @@ using SparseArrays: getcolptr, AbstractSparseMatrix
 
 export sublat, bravais, lattice, dims, sites, supercell, unitcell,
        hopping, onsite, onsite!, hopping!,
-       hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
+       hamiltonian, parametric, @par, bloch, bloch!, optimize!, similarmatrix,
        flatten, wrap, transform!, combine,
        spectrum, bandstructure, marchingmesh, defaultmethod, bands, vertices,
        energies, states,

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -3,11 +3,13 @@ module Quantica
 using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
       ProgressMeter, LinearMaps, Random
 
+using ExprTools
+
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
 export sublat, bravais, lattice, dims, sites, supercell, unitcell,
-       hopping, onsite, onsite!, hopping!,
-       hamiltonian, parametric, @par, bloch, bloch!, optimize!, similarmatrix,
+       hopping, onsite, @onsite!, @hopping!, parameters,
+       hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
        flatten, wrap, transform!, combine,
        spectrum, bandstructure, marchingmesh, defaultmethod, bands, vertices,
        energies, states,

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -680,29 +680,29 @@ wrap_dn(olddn::SVector, newdn::SVector, supercell::SMatrix) = olddn - supercell 
 
 applymodifiers(val, lat, inds, dns) = val
 
-function applymodifiers(val, lat, inds, dns, m::ElementModifier{Val{false}}, ms...)
+function applymodifiers(val, lat, inds, dns, m::UniformModifier, ms...)
     selected = m.selector(lat, inds, dns)
     val´ = selected ? m.f(val) : val
     return applymodifiers(val´, lat, inds, dns, ms...)
 end
 
-function applymodifiers(val, lat, (row, col), (dnrow, dncol), m::Onsite!{Val{true}}, ms...)
+function applymodifiers(val, lat, (row, col), (dnrow, dncol), m::OnsiteModifier, ms...)
     selected = m.selector(lat, (row, col), (dnrow, dncol))
     if selected
         r = sites(lat)[col] + bravais(lat) * dncol
-        val´ = selected ? m.f(val, r) : val
+        val´ = selected ? m(val, r) : val
     else
         val´ = val
     end
     return applymodifiers(val´, lat, (row, col), (dnrow, dncol), ms...)
 end
 
-function applymodifiers(val, lat, (row, col), (dnrow, dncol), m::Hopping!{Val{true}}, ms...)
+function applymodifiers(val, lat, (row, col), (dnrow, dncol), m::HoppingModifier, ms...)
     selected = m.selector(lat, (row, col), (dnrow, dncol))
     if selected
         br = bravais(lat)
         r, dr = _rdr(sites(lat)[col] + br * dncol, sites(lat)[row] + br * dnrow)
-        val´ = selected ? m.f(val, r, dr) : val
+        val´ = selected ? m(val, r, dr) : val
     else
         val´ = val
     end

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -696,9 +696,9 @@ Convert Superlattice `slat` into a lattice with its unit cell matching `slat`'s 
     unitcell(h::Hamiltonian, v...; modifiers = (), kw...)
 
 Transforms the `Lattice` of `h` to have a larger unitcell, while expanding the Hamiltonian
-accordingly. The modifiers (a tuple of `ElementModifier`s, either `onsite!` or `hopping!`)
-will be applied to onsite and hoppings as the hamiltonian is expanded. See `onsite!` and
-`hopping!` for details
+accordingly. The modifiers (a tuple of `ElementModifier`s, either `@onsite!` or `@hopping!`
+with no free parameters) will be applied to onsite and hoppings as the hamiltonian is
+expanded. See `@onsite!` and `@hopping!` for details
 
 Note: for performance reasons, in sparse hamiltonians only the stored onsites and hoppings
 will be transformed by `ElementModifier`s, so you might want to add zero onsites or hoppings

--- a/src/model.jl
+++ b/src/model.jl
@@ -538,6 +538,8 @@ function get_f_N_params(f, msg)
         else
             push!(kwargs, :(_...))  # normalization : append _... to kwargs
         end
+        # Workaround for Issue #8 in ExprTools. Remove when PR #9 is merged
+        kwargs[1] isa Expr && kwargs[1].head == :(=) && (kwargs[1] = :($(Expr(:kw, kwargs[1].args...))))
     end
     N = haskey(d, :args) ? length(d[:args]) : 0
     f´ = ExprTools.combinedef(d)

--- a/src/model.jl
+++ b/src/model.jl
@@ -83,9 +83,9 @@ resolve(s::HoppingSelector, lat::AbstractLattice) =
     HoppingSelector(s.region, sublats(s, lat), _checkdims(s.dns, lat), s.range, s.forcehermitian)
 resolve(s::OnsiteSelector, lat::AbstractLattice) = OnsiteSelector(s.region, sublats(s, lat), s.forcehermitian)
 
-_checkdims(dns::Missing, lat::Lattice{E,L}) where {E,L} = dns
-_checkdims(dns::Tuple{Vararg{SVector{L,Int}}}, lat::Lattice{E,L}) where {E,L} = dns
-_checkdims(dns, lat::Lattice{E,L}) where {E,L} =
+_checkdims(dns::Missing, lat::AbstractLattice{E,L}) where {E,L} = dns
+_checkdims(dns::Tuple{Vararg{SVector{L,Int}}}, lat::AbstractLattice{E,L}) where {E,L} = dns
+_checkdims(dns, lat::AbstractLattice{E,L}) where {E,L} =
     throw(DimensionMismatch("Specified cell distance `dn` does not match lattice dimension $L"))
 
 # are sites at (i,j) and (dni, dnj) or (dn, 0) selected?
@@ -435,8 +435,10 @@ _sublatranges(rs::Tuple) = rs
 findblock(s, sr) = findfirst(r -> s in r, sr)
 
 #######################################################################
-# ParametricFunction
+# @onsite! and @hopping!
 #######################################################################
+abstract type ElementModifier{N,F,S} end
+
 struct ParametricFunction{N,M,F}
     f::F
     params::NTuple{M,Symbol}
@@ -446,101 +448,126 @@ ParametricFunction{N}(f::F, p::NTuple{M,Symbol}) where {N,M,F} = ParametricFunct
 
 (pf::ParametricFunction)(args...; kw...) = pf.f(args...; kw...)
 
-macro par(f, params...)
-    (f isa Expr && f.head == :->) ||
-        throw(ArgumentError("Only @par(args -> ..., parameters...) syntax supported"))
-    farg = f.args[1]
-    body = f.args[2]
-    symbolarg = isa(farg, Symbol)
-    symbolarg || isa(first(farg.args), Symbol) ||
-        throw(ArgumentError("Keyword arguments not supported in @par"))
-    N = symbolarg ? 1 : length(farg.args)
-    newargs = symbolarg ? (esc(farg),) : esc.(Tuple(farg.args))
-    newparams = esc.(params)
-    newbody = esc(body)
-    newf = :(($(newargs...), ; $(newparams...)) -> $(newbody))
-    return :(ParametricFunction{$N}($newf, $params))
-end
-
-
-#######################################################################
-# onsite! and hopping!
-#######################################################################
-abstract type ElementModifier{V,F,S} end
-
-struct Onsite!{N,F<:ParametricFunction{N},S<:Selector} <: ElementModifier{N,F,S}
+struct OnsiteModifier{N,F<:ParametricFunction{N},S<:Selector} <: ElementModifier{N,F,S}
     f::F
     selector::S
     addconjugate::Bool   # determines whether to return f(o) or (f(o) + f(o')')/2
                          # (equatl to selector.forcehermitian)
 end
 
-Onsite!(f, selector) =
-    Onsite!(f, selector, false)
+OnsiteModifier(f, selector) = OnsiteModifier(f, selector, false)
 
-struct Hopping!{N,F<:ParametricFunction{N},S<:Selector} <: ElementModifier{N,F,S}
+struct HoppingModifier{N,F<:ParametricFunction{N},S<:Selector} <: ElementModifier{N,F,S}
     f::F
     selector::S
     addconjugate::Bool   # determines whether to return f(t) or (f(t) + f(t')')/2
                          # (equal to *unresolved* selector.sublats and selector.forcehermitian)
 end
 
-Hopping!(f, selector) =
-    Hopping!(f, selector, false)
+HoppingModifier(f, selector) = HoppingModifier(f, selector, false)
 
-# API #
+const UniformModifier = ElementModifier{1}
+const UniformHoppingModifier = HoppingModifier{1}
+const UniformOnsiteModifier = OnsiteModifier{1}
 
 """
-    onsite!(f; kw...)
+    parameters(p::ElementModifier)
 
-Create an `ElementModifier`, to be used with `parametric`, that applies `f` to onsite
-energies specified by `kw` (see `onsite` for details). The form of `f` may be `f = (o;
-kw...) -> ...` or `f = (o, r; kw...) -> ...` if the modification is position (`r`)
-dependent. The former is naturally more efficient, as there is no need to compute the
-positions of each onsite energy.
+Return the parameter names for an `ElementModifier` created with `@onsite!` or `@hopping!`
+"""
+parameters(pf::ParametricFunction) = pf.params
+parameters(m::ElementModifier) = parameters(m.f)
+
+"""
+    @onsite!(args -> body; kw...)
+
+Create an `ElementModifier`, to be used with `parametric`, that applies `f = args -> body`
+to onsite energies specified by `kw` (see `onsite` for details  on possible `kw`s). The form
+of `args -> body` may be `(o; params...) -> ...` or `(o, r; params...) -> ...` if the
+modification is position (`r`) dependent. Keyword arguments `params` are optional, and
+include any parameters that `body` depends on that the user may want to tune.
 
 # See also:
-    `hopping!`, `parametric`
+    `@hopping!`, `parametric`
 """
-onsite!(f; kw...) = onsite!(f, onsiteselector(; kw...))
-onsite!(f, selector) = Onsite!(f, selector)
+macro onsite!(kw, f)
+    f, N, params = get_f_N_params(f, "Only @onsite!(args -> body; kw...) syntax supported")
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $params), Quantica.onsiteselector($kw))))
+end
+
+macro onsite!(f)
+    f, N, params = get_f_N_params(f, "Only @onsite!(args -> body; kw...) syntax supported")
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $params), Quantica.onsiteselector())))
+end
 
 """
-    hopping!(f; kw...)
+    @hopping!(args -> body; kw...)
 
-Create an `ElementModifier`, to be used with `parametric`, that applies `f` to hoppings
-specified by `kw` (see `hopping` for details). The form of `f` may be `f = (t; kw...) ->
-...` or `f = (t, r, dr; kw...) -> ...` if the modification is position (`r, dr`) dependent.
-The former is naturally more efficient, as there is no need to compute the positions of the
-two sites involved in each hopping.
+Create an `ElementModifier`, to be used with `parametric`, that applies `f = args -> body`
+to hoppings energies specified by `kw` (see `hopping` for details on possible `kw`s). The
+form of `args -> body` may be `(t; params...) -> ...` or `(t, r, dr; params...) -> ...` if
+the modification is position (`r`, `dr`) dependent. Keyword arguments `params` are optional,
+and include any parameters that `body` depends on that the user may want to tune.
 
 # See also:
-    `onsite!`, `parametric`
+    `@onsite!`, `parametric`
 """
-hopping!(f; kw...) = hopping!(f, hoppingselector(; kw...))
-hopping!(f, selector) = Hopping!(f, selector)
+macro hopping!(kw, f)
+    f, N, params = get_f_N_params(f, "Only @hopping!(args -> body; kw...) syntax supported")
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $params), Quantica.hoppingselector($kw))))
+end
 
-function resolve(o::Onsite!, lat)
+macro hopping!(f)
+    f, N, params = get_f_N_params(f, "Only @hopping!(args -> body; kw...) syntax supported")
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $params), Quantica.hoppingselector())))
+end
+
+# Extracts normalized f, number of arguments and kwarg names from an anonymous function f
+function get_f_N_params(f, msg)
+    (f isa Expr && f.head == :->) || throw(ArgumentError(msg))
+    d = ExprTools.splitdef(f)
+    kwargs = convert(Vector{Any}, get!(d, :kwargs, []))
+    d[:kwargs] = kwargs  # in case it wasn't Vector{Any} originally
+    if isempty(kwargs)
+        params = ()
+        push!(kwargs, :(_...))  # normalization : append _... to kwargs
+    else
+        params = get_kwname.(kwargs) |> Tuple
+        if !isempty(params) && last(params) == :...
+            params = tuplemost(params)  # drop _... kwarg from params
+        else
+            push!(kwargs, :(_...))  # normalization : append _... to kwargs
+        end
+    end
+    N = haskey(d, :args) ? length(d[:args]) : 0
+    f´ = ExprTools.combinedef(d)
+    return f´, N, params
+end
+
+get_kwname(x::Symbol) = x
+get_kwname(x::Expr) = x.head === :kw ? x.args[1] : x.head  # x.head == :...
+
+function resolve(o::OnsiteModifier, lat)
     addconjugate = o.selector.forcehermitian
-    Onsite!(o.f, o.needspositions, resolve(o.selector, lat), addconjugate)
+    OnsiteModifier(o.f, resolve(o.selector, lat), addconjugate)
 end
 
-function resolve(h::Hopping!, lat)
+function resolve(h::HoppingModifier, lat)
     addconjugate = h.selector.sublats === missing && h.selector.forcehermitian
-    Hopping!(h.f, h.needspositions, resolve(h.selector, lat), addconjugate)
+    HoppingModifier(h.f, resolve(h.selector, lat), addconjugate)
 end
 
-# Intended for resolved ElementModifiers only
-@inline (o!::Onsite!{Val{false}})(o, r; kw...) = o!(o; kw...)
-@inline (o!::Onsite!{Val{false}})(o, r, dr; kw...) = o!(o; kw...)
-@inline (o!::Onsite!{Val{false}})(o; kw...) =
+# Intended for resolved ElementModifier{N} only. The N is the number of arguments accepted.
+@inline (o!::UniformOnsiteModifier)(o, r; kw...) = o!(o; kw...)
+@inline (o!::UniformOnsiteModifier)(o, r, dr; kw...) = o!(o; kw...)
+@inline (o!::UniformOnsiteModifier)(o; kw...) =
     o!.addconjugate ? 0.5 * (o!.f(o; kw...) + o!.f(o'; kw...)') : o!.f(o; kw...)
-@inline (o!::Onsite!{Val{true}})(o, r, dr; kw...) = o!(o, r; kw...)
-@inline (o!::Onsite!{Val{true}})(o, r; kw...) =
+@inline (o!::OnsiteModifier)(o, r, dr; kw...) = o!(o, r; kw...)
+@inline (o!::OnsiteModifier)(o, r; kw...) =
     o!.addconjugate ? 0.5 * (o!.f(o, r; kw...) + o!.f(o', r; kw...)') : o!.f(o, r; kw...)
 
-@inline (h!::Hopping!{Val{false}})(t, r, dr; kw...) = h!(t; kw...)
-@inline (h!::Hopping!{Val{false}})(t; kw...) =
+@inline (h!::UniformHoppingModifier)(t, r, dr; kw...) = h!(t; kw...)
+@inline (h!::UniformHoppingModifier)(t; kw...) =
     h!.addconjugate ? 0.5 * (h!.f(t; kw...) + h!.f(t'; kw...)') : h!.f(t; kw...)
-@inline (h!::Hopping!{Val{true}})(t, r, dr; kw...) =
+@inline (h!::HoppingModifier)(t, r, dr; kw...) =
     h!.addconjugate ? 0.5 * (h!.f(t, r, dr; kw...) + h!.f(t', r, -dr; kw...)') : h!.f(t, r, dr; kw...)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -20,6 +20,8 @@ toSVector(v::AbstractVector) = SVector(Tuple(v))
 ensuretuple(s::Tuple) = s
 ensuretuple(s) = (s,)
 
+tuplemost(t::NTuple{N,Any}) where {N} = ntuple(i -> t[i], Val(N-1))
+
 # ensureSMatrix(f::Function) = f
 # ensureSMatrix(m::T) where T<:Number = SMatrix{1,1,T,1}(m)
 # ensureSMatrix(m::SMatrix) = m

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -80,7 +80,93 @@ end
         @SMatrix[3 0; 0 0]
 end
 
-@testset "modifiers" begin
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)) |> unitcell(2, modifiers = onsite!((o, r) -> 1))
+@testset "unitcell modifiers" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0)) |> unitcell(2, modifiers = (@onsite!((o, r) -> 1), @hopping!(h -> 1)))
     @test diag(bloch(h)) == ComplexF64[1, 1, 1, 1, 1, 1, 1, 1]
+end
+
+@testset "@onsite!" begin
+    el = @SMatrix[1 2; 2 1]
+
+    @test @onsite!(o -> 2o)(el) == 2el
+    @test @onsite!(o -> 2o)(el, p = 2) == 2el
+    @test @onsite!((o;) -> 2o)(el) == 2el
+    @test @onsite!((o;) -> 2o)(el, p = 2) == 2el
+    @test @onsite!((o; z) -> 2o)(el, z = 2) == 2el
+    @test @onsite!((o; z) -> 2o)(el, z = 2, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, z = 1, p = 2) == 2el
+    @test @onsite!((o; kw...) -> 2o)(el) == 2el
+    @test @onsite!((o; kw...) -> 2o)(el, p = 2) == 2el
+    @test @onsite!((o; z, kw...) -> 2o)(el, z = 2) == 2el
+    @test @onsite!((o; z, kw...) -> 2o)(el, z = 2, p = 2) == 2el
+    @test @onsite!((o; z, y = 2, kw...) -> 2o)(el, z = 2, p = 2) == 2el
+    @test @onsite!((o; z, y = 2, kw...) -> 2o)(el, z = 2, y = 3, p = 2) == 2el
+
+    r = SVector(0,0)
+
+    @test @onsite!((o, r;) -> 2o)(el, r) == 2el
+    @test @onsite!((o, r;) -> 2o)(el, r, p = 2) == 2el
+    @test @onsite!((o, r; z) -> 2o)(el, r, z = 2) == 2el
+    @test @onsite!((o, r; z) -> 2o)(el, r, z = 2, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, r) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, r, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, r, z = 1, p = 2) == 2el
+    @test @onsite!((o, r; kw...) -> 2o)(el, r) == 2el
+    @test @onsite!((o, r; kw...) -> 2o)(el, r, p = 2) == 2el
+    @test @onsite!((o, r; z, kw...) -> 2o)(el, r, z = 2) == 2el
+    @test @onsite!((o, r; z, kw...) -> 2o)(el, r, z = 2, p = 2) == 2el
+    @test @onsite!((o, r; z, y = 2, kw...) -> 2o)(el, r, z = 2, p = 2) == 2el
+    @test @onsite!((o, r; z, y = 2, kw...) -> 2o)(el, r, z = 2, y = 3, p = 2) == 2el
+
+    @test @onsite!((o; z, y = 2, kw...) -> 2o) isa Quantica.UniformOnsiteModifier
+    @test @onsite!((o, r; z, y = 2, kw...) -> 2o) isa Quantica.OnsiteModifier{2}
+
+    @test parameters(@onsite!((o, r; z, y = 2, kw...) -> 2o)) == (:z, :y)
+end
+
+@testset "@hopping!" begin
+    el = @SMatrix[1 2; 2 1]
+
+    @test @hopping!(t -> 2t)(el) == 2el
+    @test @hopping!(t -> 2t)(el, p = 2) == 2el
+    @test @hopping!((t;) -> 2t)(el) == 2el
+    @test @hopping!((t;) -> 2t)(el, p = 2) == 2el
+    @test @hopping!((t; z) -> 2t)(el, z = 2) == 2el
+    @test @hopping!((t; z) -> 2t)(el, z = 2, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, z = 1, p = 2) == 2el
+    @test @hopping!((t; kw...) -> 2t)(el) == 2el
+    @test @hopping!((t; kw...) -> 2t)(el, p = 2) == 2el
+    @test @hopping!((t; z, kw...) -> 2t)(el, z = 2) == 2el
+    @test @hopping!((t; z, kw...) -> 2t)(el, z = 2, p = 2) == 2el
+    @test @hopping!((t; z, y = 2, kw...) -> 2t)(el, z = 2, p = 2) == 2el
+    @test @hopping!((t; z, y = 2, kw...) -> 2t)(el, z = 2, y = 3, p = 2) == 2el
+
+    r = dr = SVector(0,0)
+
+    @test @hopping!((t, r, dr;) -> 2t)(el, r, dr) == 2el
+    @test @hopping!((t, r, dr;) -> 2t)(el, r, dr, p = 2) == 2el
+    @test @hopping!((t, r, dr; z) -> 2t)(el, r, dr, z = 2) == 2el
+    @test @hopping!((t, r, dr; z) -> 2t)(el, r, dr, z = 2, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, r, dr) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, r, dr, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, r, dr, z = 1, p = 2) == 2el
+    @test @hopping!((t, r, dr; kw...) -> 2t)(el, r, dr) == 2el
+    @test @hopping!((t, r, dr; kw...) -> 2t)(el, r, dr, p = 2) == 2el
+    @test @hopping!((t, r, dr; z, kw...) -> 2t)(el, r, dr, z = 2) == 2el
+    @test @hopping!((t, r, dr; z, kw...) -> 2t)(el, r, dr, z = 2, p = 2) == 2el
+    @test @hopping!((t, r, dr; z, y = 2, kw...) -> 2t)(el, r, dr, z = 2, p = 2) == 2el
+    @test @hopping!((t, r, dr; z, y = 2, kw...) -> 2t)(el, r, dr, z = 2, y = 3, p = 2) == 2el
+
+    @test @hopping!((t; z, y = 2, kw...) -> 2t) isa Quantica.UniformHoppingModifier
+    @test @hopping!((t, r, dr; z, y = 2, kw...) -> 2t) isa Quantica.HoppingModifier{3}
+end
+
+@testset "parametric" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0))
+    hp = parametric(h, @onsite!(o -> 2o))
+    @test parametric(h, @onsite!(o -> 2o)) isa ParametricHamiltonian
 end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -168,6 +168,16 @@ end
 end
 
 @testset "parametric" begin
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0))
-    @test parametric(h, @onsite!(o -> 2o)) isa ParametricHamiltonian
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(2)) |> unitcell(10)
+    T = typeof(h)
+    @test parametric(h, @onsite!(o -> 2o))() isa T
+    @test parametric(h, @onsite!((o, r) -> 2o))() isa T
+    @test parametric(h, @onsite!((o, r; a = 2) -> a*o))() isa T
+    @test parametric(h, @onsite!((o, r; a = 2) -> a*o))(a=1) isa T
+    @test parametric(h, @onsite!((o, r; a = 2) -> a*o), @hopping!(t -> 2t))(a=1) isa T
+    @test parametric(h, @onsite!((o, r) -> o), @hopping!((t, r, dr) -> r[1]*t))() isa T
+    @test parametric(h, @onsite!((o, r) -> o), @hopping!((t, r, dr; a = 2) -> r[1]*t))() isa T
+    @test parametric(h, @onsite!((o, r) -> o), @hopping!((t, r, dr; a = 2) -> r[1]*t))(a=1) isa T
+    @test parametric(h, @onsite!((o, r; b) -> o), @hopping!((t, r, dr; a = 2) -> r[1]*t))(b=1) isa T
+    @test parametric(h, @onsite!((o, r; b) -> o*b), @hopping!((t, r, dr; a = 2) -> r[1]*t))(a=1, b=2) isa T
 end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,5 +1,5 @@
 using LinearAlgebra: diag
-using Quantica: Hamiltonian
+using Quantica: Hamiltonian, ParametricHamiltonian
 
 @testset "basic hamiltonians" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -94,9 +94,10 @@ end
     @test @onsite!((o;) -> 2o)(el, p = 2) == 2el
     @test @onsite!((o; z) -> 2o)(el, z = 2) == 2el
     @test @onsite!((o; z) -> 2o)(el, z = 2, p = 2) == 2el
-    @test @onsite!((o; z = 2) -> 2o)(el) == 2el
-    @test @onsite!((o; z = 2) -> 2o)(el, p = 2) == 2el
-    @test @onsite!((o; z = 2) -> 2o)(el, z = 1, p = 2) == 2el
+    # Pending Fix #9 in ExprTools
+    # @test @onsite!((o; z = 2) -> 2o)(el) == 2el
+    # @test @onsite!((o; z = 2) -> 2o)(el, p = 2) == 2el
+    # @test @onsite!((o; z = 2) -> 2o)(el, z = 1, p = 2) == 2el
     @test @onsite!((o; kw...) -> 2o)(el) == 2el
     @test @onsite!((o; kw...) -> 2o)(el, p = 2) == 2el
     @test @onsite!((o; z, kw...) -> 2o)(el, z = 2) == 2el
@@ -110,9 +111,10 @@ end
     @test @onsite!((o, r;) -> 2o)(el, r, p = 2) == 2el
     @test @onsite!((o, r; z) -> 2o)(el, r, z = 2) == 2el
     @test @onsite!((o, r; z) -> 2o)(el, r, z = 2, p = 2) == 2el
-    @test @onsite!((o; z = 2) -> 2o)(el, r) == 2el
-    @test @onsite!((o; z = 2) -> 2o)(el, r, p = 2) == 2el
-    @test @onsite!((o; z = 2) -> 2o)(el, r, z = 1, p = 2) == 2el
+    # Pending Fix #9 in ExprTools
+    # @test @onsite!((o; z = 2) -> 2o)(el, r) == 2el
+    # @test @onsite!((o; z = 2) -> 2o)(el, r, p = 2) == 2el
+    # @test @onsite!((o; z = 2) -> 2o)(el, r, z = 1, p = 2) == 2el
     @test @onsite!((o, r; kw...) -> 2o)(el, r) == 2el
     @test @onsite!((o, r; kw...) -> 2o)(el, r, p = 2) == 2el
     @test @onsite!((o, r; z, kw...) -> 2o)(el, r, z = 2) == 2el
@@ -135,9 +137,10 @@ end
     @test @hopping!((t;) -> 2t)(el, p = 2) == 2el
     @test @hopping!((t; z) -> 2t)(el, z = 2) == 2el
     @test @hopping!((t; z) -> 2t)(el, z = 2, p = 2) == 2el
-    @test @hopping!((t; z = 2) -> 2t)(el) == 2el
-    @test @hopping!((t; z = 2) -> 2t)(el, p = 2) == 2el
-    @test @hopping!((t; z = 2) -> 2t)(el, z = 1, p = 2) == 2el
+    # Pending Fix #9 in ExprTools
+    # @test @hopping!((t; z = 2) -> 2t)(el) == 2el
+    # @test @hopping!((t; z = 2) -> 2t)(el, p = 2) == 2el
+    # @test @hopping!((t; z = 2) -> 2t)(el, z = 1, p = 2) == 2el
     @test @hopping!((t; kw...) -> 2t)(el) == 2el
     @test @hopping!((t; kw...) -> 2t)(el, p = 2) == 2el
     @test @hopping!((t; z, kw...) -> 2t)(el, z = 2) == 2el
@@ -151,9 +154,10 @@ end
     @test @hopping!((t, r, dr;) -> 2t)(el, r, dr, p = 2) == 2el
     @test @hopping!((t, r, dr; z) -> 2t)(el, r, dr, z = 2) == 2el
     @test @hopping!((t, r, dr; z) -> 2t)(el, r, dr, z = 2, p = 2) == 2el
-    @test @hopping!((t; z = 2) -> 2t)(el, r, dr) == 2el
-    @test @hopping!((t; z = 2) -> 2t)(el, r, dr, p = 2) == 2el
-    @test @hopping!((t; z = 2) -> 2t)(el, r, dr, z = 1, p = 2) == 2el
+    # Pending Fix #9 in ExprTools
+    # @test @hopping!((t; z = 2) -> 2t)(el, r, dr) == 2el
+    # @test @hopping!((t; z = 2) -> 2t)(el, r, dr, p = 2) == 2el
+    # @test @hopping!((t; z = 2) -> 2t)(el, r, dr, z = 1, p = 2) == 2el
     @test @hopping!((t, r, dr; kw...) -> 2t)(el, r, dr) == 2el
     @test @hopping!((t, r, dr; kw...) -> 2t)(el, r, dr, p = 2) == 2el
     @test @hopping!((t, r, dr; z, kw...) -> 2t)(el, r, dr, z = 2) == 2el
@@ -167,6 +171,5 @@ end
 
 @testset "parametric" begin
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(0))
-    hp = parametric(h, @onsite!(o -> 2o))
     @test parametric(h, @onsite!(o -> 2o)) isa ParametricHamiltonian
 end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -94,10 +94,9 @@ end
     @test @onsite!((o;) -> 2o)(el, p = 2) == 2el
     @test @onsite!((o; z) -> 2o)(el, z = 2) == 2el
     @test @onsite!((o; z) -> 2o)(el, z = 2, p = 2) == 2el
-    # Pending Fix #9 in ExprTools
-    # @test @onsite!((o; z = 2) -> 2o)(el) == 2el
-    # @test @onsite!((o; z = 2) -> 2o)(el, p = 2) == 2el
-    # @test @onsite!((o; z = 2) -> 2o)(el, z = 1, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, z = 1, p = 2) == 2el
     @test @onsite!((o; kw...) -> 2o)(el) == 2el
     @test @onsite!((o; kw...) -> 2o)(el, p = 2) == 2el
     @test @onsite!((o; z, kw...) -> 2o)(el, z = 2) == 2el
@@ -111,10 +110,9 @@ end
     @test @onsite!((o, r;) -> 2o)(el, r, p = 2) == 2el
     @test @onsite!((o, r; z) -> 2o)(el, r, z = 2) == 2el
     @test @onsite!((o, r; z) -> 2o)(el, r, z = 2, p = 2) == 2el
-    # Pending Fix #9 in ExprTools
-    # @test @onsite!((o; z = 2) -> 2o)(el, r) == 2el
-    # @test @onsite!((o; z = 2) -> 2o)(el, r, p = 2) == 2el
-    # @test @onsite!((o; z = 2) -> 2o)(el, r, z = 1, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, r) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, r, p = 2) == 2el
+    @test @onsite!((o; z = 2) -> 2o)(el, r, z = 1, p = 2) == 2el
     @test @onsite!((o, r; kw...) -> 2o)(el, r) == 2el
     @test @onsite!((o, r; kw...) -> 2o)(el, r, p = 2) == 2el
     @test @onsite!((o, r; z, kw...) -> 2o)(el, r, z = 2) == 2el
@@ -137,10 +135,9 @@ end
     @test @hopping!((t;) -> 2t)(el, p = 2) == 2el
     @test @hopping!((t; z) -> 2t)(el, z = 2) == 2el
     @test @hopping!((t; z) -> 2t)(el, z = 2, p = 2) == 2el
-    # Pending Fix #9 in ExprTools
-    # @test @hopping!((t; z = 2) -> 2t)(el) == 2el
-    # @test @hopping!((t; z = 2) -> 2t)(el, p = 2) == 2el
-    # @test @hopping!((t; z = 2) -> 2t)(el, z = 1, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, z = 1, p = 2) == 2el
     @test @hopping!((t; kw...) -> 2t)(el) == 2el
     @test @hopping!((t; kw...) -> 2t)(el, p = 2) == 2el
     @test @hopping!((t; z, kw...) -> 2t)(el, z = 2) == 2el
@@ -154,10 +151,9 @@ end
     @test @hopping!((t, r, dr;) -> 2t)(el, r, dr, p = 2) == 2el
     @test @hopping!((t, r, dr; z) -> 2t)(el, r, dr, z = 2) == 2el
     @test @hopping!((t, r, dr; z) -> 2t)(el, r, dr, z = 2, p = 2) == 2el
-    # Pending Fix #9 in ExprTools
-    # @test @hopping!((t; z = 2) -> 2t)(el, r, dr) == 2el
-    # @test @hopping!((t; z = 2) -> 2t)(el, r, dr, p = 2) == 2el
-    # @test @hopping!((t; z = 2) -> 2t)(el, r, dr, z = 1, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, r, dr) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, r, dr, p = 2) == 2el
+    @test @hopping!((t; z = 2) -> 2t)(el, r, dr, z = 1, p = 2) == 2el
     @test @hopping!((t, r, dr; kw...) -> 2t)(el, r, dr) == 2el
     @test @hopping!((t, r, dr; kw...) -> 2t)(el, r, dr, p = 2) == 2el
     @test @hopping!((t, r, dr; z, kw...) -> 2t)(el, r, dr, z = 2) == 2el
@@ -167,6 +163,8 @@ end
 
     @test @hopping!((t; z, y = 2, kw...) -> 2t) isa Quantica.UniformHoppingModifier
     @test @hopping!((t, r, dr; z, y = 2, kw...) -> 2t) isa Quantica.HoppingModifier{3}
+
+    @test parameters(@hopping!((o, r, dr; z, y = 2, kw...) -> 2o)) == (:z, :y)
 end
 
 @testset "parametric" begin


### PR DESCRIPTION
Closes #16

The only API changer is `onsite!` --> `@onsite!` and `hopping!` --> `@hopping!`. These macros parse the structure of the anonymous function to extract `params`. It also supplements `params` with a filler `kw...` so that parametric Hamiltonians can accept arbitrary `ElementModifier`s with matching or non-matching `params`

The only shortcoming I see here is that this PR forces a `@onsite((args...; params...) -> body; kw...)` kind of syntax, always. You cannot do `@onsite(func; kw...)` with an existing `func`, since (1) that `func` could have different methods with different `kwargs` and (2) once compiled, there is no way to extract its kwargs without digging into the method tables.

The next step this PR enables is a definition of `bloch` and `bandstructure` that automatically works on a `ph::ParametricHamiltonian`s, extending the dimension of the Brillouin zone with the parameters of `ph`

Incidentally, I also introduced a `parameters(::ParametricHamiltonian)` and `parameters(::ElementModifier)` to obtain the extracted parameter names.
