### PR TITLE
Remove bloch(h, ϕs...), leave only bloch(h, ϕs)

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -114,7 +114,7 @@ states(b::Band) = reshape(b.states, b.dimstates)
 """
     bandstructure(h::Hamiltonian, mesh::Mesh; minprojection = 0.5, method = defaultmethod(h))
 
-Compute the bandstructure of Bloch Hamiltonian `bloch(h, ϕs...)` with `ϕs` evaluated on the
+Compute the bandstructure of Bloch Hamiltonian `bloch(h, ϕs)` with `ϕs` evaluated on the
 vertices of `mesh`. It is assumed that `h` is hermitian.
 
 The option `minprojection` determines the minimum projection between eigenstates to connect
@@ -151,7 +151,7 @@ Bandstructure: bands for a 2D hamiltonian
 ```
 
 # See also
-    marchingmesh
+    `marchingmesh`
 """
 function bandstructure(h::Hamiltonian{<:Any,L,M}; resolution = 13, kw...) where {L,M}
     mesh = marchingmesh(filltuple(range(-π, π, length = resolution), Val(L))...)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -97,7 +97,7 @@ Bravais{2,2,Float64} : set of 2 Bravais vectors in 2D space.
 ```
 
 # See also:
-    semibounded
+    `semibounded`
 """
 bravais(vs::Union{Tuple,AbstractVector,AbstractMatrix}...; semibounded = false, kw...) =
     (s = toSMatrix(vs...); Bravais(s, sanitize_semibounded(semibounded, s)))
@@ -260,7 +260,7 @@ Lattice{2,2,Float64} : 2D lattice in 2D space
 ```
 
 # See also:
-    LatticePresets, bravais, sublat, supercell, intracell
+    `LatticePresets`, `bravais`, `sublat`, `supercell`, `intracell`
 """
 lattice(s::Sublat, ss::Sublat...; kw...) = _lattice(Unitcell(s, ss...; kw...))
 _lattice(u::Unitcell{E,T}) where {E,T} = Lattice(Bravais{E,T}(), u)
@@ -550,7 +550,7 @@ Superlattice{2,2,Float64,2} : 2D lattice in 2D space, filling a 2D supercell
 ```
 
 # See also:
-    unitcell
+    `unitcell`
 """
 supercell(v::Union{SMatrix,Tuple,SVector,Integer}...; kw...) = lat -> supercell(lat, v...; kw...)
 
@@ -746,7 +746,7 @@ Lattice{2,2,Float64} : 2D lattice in 2D space
 ```
 
 # See also:
-    supercell
+    `supercell`
 """
 unitcell(v::Union{SMatrix,Tuple,SVector,Integer}...; kw...) = lat -> unitcell(lat, v...; kw...)
 unitcell(lat::Lattice, args...; kw...) = unitcell(supercell(lat, args...; kw...))

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -16,6 +16,8 @@ using Quantica: Hamiltonian, ParametricHamiltonian
             @test hamiltonian(lat, onsite(t) + hopping(t; dn = dn0, forcehermitian = false), orbitals = o) isa Hamiltonian
         end
     end
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = 1/√3))
+    @test bloch(h) == h.harmonics[1].h
 end
 
 @testset "orbitals and sublats" begin
@@ -31,7 +33,7 @@ end
                       orbitals = :B => Val(2))
     h2 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
                       orbitals = :B => Val(2))
-    @test bloch(h1, 1, 2) == bloch(h2, 1, 2)
+    @test bloch(h1, (1, 2)) == bloch(h2, (1, 2))
 end
 
 @testset "onsite dimensions" begin


### PR DESCRIPTION
This PR leave only the `bloch(h, ϕs)`/`bloch!(matrix, h, ϕs)` syntax to obtain the Bloch Hamiltonian of `h`. The `bloch(h)` syntax for the unit cell Hamiltonian remains. However the `h(ϕs)` and `h(ϕs...)` forms are *also* removed.