### PR TITLE
Unified Pair syntax for sublats kwarg in hopping

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -524,7 +524,7 @@ function applyterm!(builder::IJVBuilder{L}, term::HoppingTerm, termsublats) wher
     selector = term.selector
     checkinfinite(selector)
     lat = builder.lat
-    for (s1, s2) in termsublats
+    for (s2, s1) in termsublats  # Each is a Pair s2 => s1
         is, js = siterange(lat, s1), siterange(lat, s2)
         dns = dniter(selector.dns, Val(L))
         for dn in dns

--- a/src/model.jl
+++ b/src/model.jl
@@ -307,7 +307,6 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
   Onsites          : 2
   Hoppings         : 0
   Coordination     : 0.0
-
 ```
 
 # See also:

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -27,12 +27,12 @@ end
     for orb in orbs
         @test hamiltonian(lat, onsite(I), orbitals = orb) isa Hamiltonian
     end
-    @test hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
-                      orbitals = :B => Val(2)) isa Hamiltonian
-    h1 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = (:A,:B)),
-                      orbitals = :B => Val(2))
-    h2 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = ((:A,:B),)),
-                      orbitals = :B => Val(2))
+    @test hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = :A =>:B),
+                      orbitals = :A => Val(2)) isa Hamiltonian
+    h1 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = :A =>:B),
+                      orbitals = :A => Val(2))
+    h2 = hamiltonian(lat, onsite(I) + hopping(@SMatrix[1 2], sublats = (:A =>:B,)),
+                      orbitals = :A => Val(2))
     @test bloch(h1, (1, 2)) == bloch(h2, (1, 2))
 end
 


### PR DESCRIPTION
Addresses one of the points in #19

This simplifies and extends the `sublats` keyword in `hopping`. A hoppings from sublat `:A` to sublat `:B` is now always denoted with `:A => :B`. The PR also allows for broadcasting between two groups of sublattices `(:A, :B) .=> (:A, :B)` (equivalent to `(:A => :A, :B => :B)`), and even direct product, `(:A, :B) => (:C, :D)` (equivalent to `(:A=>:C,:A=>:D,:B=>:C,:B=>:D)`).

Updated and extended also the docstrings for `hopping` and `onsite`, and added an internal method `Quantica.sublats(model)` that returns the sublats of each term in `model`.