### PR TITLE
Allow SVectors and Vectors in hopping's dn kwarg

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -43,6 +43,8 @@ sanitize_sublatpairs(s) = throw(ErrorException(
 ensurenametype((s1, s2)::Pair) = nametype(s1) => nametype(s2)
 
 sanitize_dn(dn::Missing) = missing
+sanitize_dn(dn::SVector{N}) where {N} = (SVector{N,Int}(dn),)
+sanitize_dn(dn::Tuple{Vararg{SVector{N}}}) where {N} = SVector{N,Int}.(dn)
 sanitize_dn(dn::Tuple{Vararg{NTuple{N}}}) where {N} = SVector{N,Int}.(dn)
 sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = (SVector{N,Int}(dn),)
 sanitize_dn(dn::Tuple{}) = ()

--- a/src/model.jl
+++ b/src/model.jl
@@ -44,7 +44,7 @@ ensurenametype((s1, s2)::Pair) = nametype(s1) => nametype(s2)
 
 sanitize_dn(dn::Missing) = missing
 sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = (_sanitize_dn(dn),)
-sanitize_dn(dn::Vector) = (_sanitize_dn(dn),)
+sanitize_dn(dn) = (_sanitize_dn(dn),)
 sanitize_dn(dn::Tuple) = _sanitize_dn.(dn)
 _sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = SVector{N,Int}(dn)
 _sanitize_dn(dn::SVector{N}) where {N} = SVector{N,Int}(dn)

--- a/src/model.jl
+++ b/src/model.jl
@@ -43,11 +43,12 @@ sanitize_sublatpairs(s) = throw(ErrorException(
 ensurenametype((s1, s2)::Pair) = nametype(s1) => nametype(s2)
 
 sanitize_dn(dn::Missing) = missing
-sanitize_dn(dn::SVector{N}) where {N} = (SVector{N,Int}(dn),)
-sanitize_dn(dn::Tuple{Vararg{SVector{N}}}) where {N} = SVector{N,Int}.(dn)
-sanitize_dn(dn::Tuple{Vararg{NTuple{N}}}) where {N} = SVector{N,Int}.(dn)
-sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = (SVector{N,Int}(dn),)
-sanitize_dn(dn::Tuple{}) = ()
+sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = (_sanitize_dn(dn),)
+sanitize_dn(dn::Vector) = (_sanitize_dn(dn),)
+sanitize_dn(dn::Tuple) = _sanitize_dn.(dn)
+_sanitize_dn(dn::Tuple{Vararg{Number,N}}) where {N} = SVector{N,Int}(dn)
+_sanitize_dn(dn::SVector{N}) where {N} = SVector{N,Int}(dn)
+_sanitize_dn(dn::Vector) = SVector{length(dn),Int}(dn)
 
 sanitize_range(::Missing) = missing
 sanitize_range(range::Real) = isfinite(range) ? float(range) + sqrt(eps(float(range))) : float(range)
@@ -368,8 +369,9 @@ unit cells at integer distance `dn´` and to sublattices `s₁` and `s₂` will 
 `missing` it will not be used to constraint the selection. Note that the default `range` is
 1, not `missing`.
 
-The keyword `forcehermitian` specifies whether the `HoppingTerm` applied to a selected
-hopping should be made hermitian. The keyword `sublats` allows the following formats:
+The keyword `dn` can be a `Tuple`/`Vector`/`SVector` of `Int`s, or a tuple thereof. The
+keyword `forcehermitian` specifies whether the `HoppingTerm` applied to a selected hopping
+should be made hermitian. The keyword `sublats` allows the following formats:
 
     sublats = :A => :B                 # Hopping from :A to :B sublattices
     sublats = (:A => :B,)              # Same as above

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -28,7 +28,7 @@ end
 @testset "hopping terms" begin
     rs = (r->true, missing)
     ss = (:A => :B, :A => (:A,:B), (:A,:B) .=> (:A,:B), (:A,:B) => (:A,:B), missing)
-    dns = ((0,1), ((0,1),(1,0)), missing)
+    dns = ((0,1), ((0,1),(1,0)), SVector(0,1), (SVector(0,1), (0,3)), [1, 2], ([1.0,2], (0,4.0)), missing)
     ranges = (Inf, 1)  # no missing here, because hopping range default is 1.0
     for r in rs, s in ss, dn in dns, rn in ranges
         model0 = hopping(1, region = r, sublats = s, dn = dn, range = rn) + onsite(1)


### PR DESCRIPTION
Until now, the dn kwarg allowed tuples of integers. Since `dn` can easily be the result of a linear algebra computation, it makes sense to allow also Vectors or SVectors. This is implemented by this PR.