### PR TITLE
Upgrade to ExprTools 0.1.1

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -17,9 +17,9 @@ deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[ExprTools]]
-git-tree-sha1 = "08c1f74d9ad03acf0ee84c12c9e665ab1a9a6e33"
+git-tree-sha1 = "6f0517056812fd6aa3af23d4b70d5325a2ae4e95"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.0"
+version = "0.1.1"
 
 [[FixedPointNumbers]]
 git-tree-sha1 = "3ba9ea634d4c8b289d590403b4a06f8e227a6238"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ExprTools = "^0.1"
+ExprTools = "^0.1.1"
 GeometryTypes = "^0.8"
 LinearMaps = "^2.6"
 NearestNeighbors = "^0.4"

--- a/src/model.jl
+++ b/src/model.jl
@@ -584,8 +584,6 @@ function get_f_N_params(f, msg)
         else
             push!(kwargs, :(_...))  # normalization : append _... to kwargs
         end
-        # Workaround for Issue #8 in ExprTools. Remove when PR #9 is merged
-        kwargs[1] isa Expr && kwargs[1].head == :(=) && (kwargs[1] = :($(Expr(:kw, kwargs[1].args...))))
     end
     N = haskey(d, :args) ? length(d[:args]) : 0
     f´ = ExprTools.combinedef(d)


### PR DESCRIPTION
As the issue [#8](https://github.com/invenia/ExprTools.jl/issues/8) in ExprTools is now fixed and tagged (0.1.1), this ups the compat and removes the workaround we had for this issue