### PR TITLE
Documenter: module-level DocTestSetup

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,8 @@
 using Quantica
 using Documenter
 
+DocMeta.setdocmeta!(Quantica, :DocTestSetup, :(using Quantica); recursive=true)
+
 makedocs(;
     modules=[Quantica],
     authors="Pablo San-Jose",

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -257,11 +257,7 @@ To add an empty harmonic with a given `dn::NTuple{L,Int}`, do `push!(h, dn)`. To
 do `deleteat!(h, dn)`.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> h = hamiltonian(LatticePresets.honeycomb(), hopping(@SMatrix[1 2; 3 4], range = 1/√3), orbitals = Val(2))
 Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
@@ -291,9 +287,6 @@ julia> h[(3,3)][[1,2],[1,2]] .= Ref(@SMatrix[1 2; 2 1])
 2×2 view(::SparseArrays.SparseMatrixCSC{StaticArrays.SArray{Tuple{2,2},Complex{Float64},2,4},Int64}, [1, 2], [1, 2]) with eltype StaticArrays.SArray{Tuple{2,2},Complex{Float64},2,4}:
  [1.0+0.0im 2.0+0.0im; 2.0+0.0im 1.0+0.0im]  [1.0+0.0im 2.0+0.0im; 2.0+0.0im 1.0+0.0im]
  [1.0+0.0im 2.0+0.0im; 2.0+0.0im 1.0+0.0im]  [1.0+0.0im 2.0+0.0im; 2.0+0.0im 1.0+0.0im]```
-```@meta
-DocTestSetup = nothing
-```
 
 # See also:
     `onsite`, `hopping`, `bloch`, `bloch!`
@@ -709,11 +702,7 @@ flux Φ through the loop, if `factor = exp(im * 2π * Φ/Φ₀)`.
 Functional form equivalent to `wrap(h, axis; kw...)`.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = 1/√3)) |>
        unitcell((1,-1), (10, 10)) |> wrap(2)
@@ -725,9 +714,6 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 1D Lattice in 2D space
   Onsites          : 0
   Hoppings         : 120
   Coordination     : 3.0
-```
-```@meta
-DocTestSetup = nothing
 ```
 """
 function wrap(h::Hamiltonian{<:Lattice,L}, axis; factor = 1) where {L}
@@ -805,11 +791,7 @@ conventient way to obtain a `matrix` is to use `similarmatrix(h)`, which will re
 be of the same type (e.g. it can be dense, while `h` is sparse).
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> h = LatticePresets.honeycomb() |> hamiltonian(onsite(1) + hopping(2));
 
@@ -819,9 +801,6 @@ julia> bloch!(similarmatrix(h), h, (.2,.3))
   [2, 1]  =  5.87081+0.988379im
   [1, 2]  =  5.87081-0.988379im
   [2, 2]  =  12.7216+0.0im
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:
@@ -903,11 +882,7 @@ Functional forms of `bloch`, equivalent to `bloch(h, ϕs, ...)`
 `bloch!`.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> h = LatticePresets.honeycomb() |> hamiltonian(onsite(1) + hopping(2)) |> bloch((.2,.3))
 2×2 SparseArrays.SparseMatrixCSC{Complex{Float64},Int64} with 4 stored entries:
@@ -915,9 +890,6 @@ julia> h = LatticePresets.honeycomb() |> hamiltonian(onsite(1) + hopping(2)) |> 
   [2, 1]  =  5.87081+0.988379im
   [1, 2]  =  5.87081-0.988379im
   [2, 2]  =  12.7216+0.0im
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:
@@ -1010,11 +982,7 @@ Functional form equivalent to `flatten(h)` of `h |> flatten` (included for consi
 the rest of the API).
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(@SMatrix[1; 2], range = 1/√3, sublats = :A =>:B), orbitals = (Val(1), Val(2)))
 Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
@@ -1035,9 +1003,6 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
   Onsites          : 0
   Hoppings         : 12
   Coordination     : 4.0
-```
-```@meta
-DocTestSetup = nothing
 ```
 """
 flatten() = h -> flatten(h)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -31,19 +31,12 @@ Create a `Sublat{E,T,D}` that adds a sublattice, of name `name`, with sites at p
 `sites` in `E` dimensional space. Sites can be entered as tuples or `SVectors`.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> sublat((0.0, 0), (1, 1), (1, -1), name = :A)
 Sublat{2,Float64} : sublattice of Float64-typed sites in 2D space
   Sites    : 3
   Name     : :A
-```
-```@meta
-DocTestSetup = nothing
 ```
 """
 sublat(sites::Vector{<:SVector}; name = :_, kw...) =
@@ -95,20 +88,13 @@ We can scale a `b::Bravais` simply by multiplying it with a factor `a`, like `a 
 Obtain the Bravais matrix of lattice `lat` or Hamiltonian `h`
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> bravais((1.0, 2), (3, 4))
 Bravais{2,2,Float64} : set of 2 Bravais vectors in 2D space.
   Vectors     : ((1.0, 2.0), (3.0, 4.0))
   Matrix      : [1.0 3.0; 2.0 4.0],
   Semibounded : none
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:
@@ -257,11 +243,7 @@ that all sublattice names are unique.
 See also `LatticePresets` for built-in lattices.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> lattice(bravais((1, 0)), sublat((0, 0)), sublat((0, Float32(1))); dim = Val(3))
 Lattice{3,1,Float32} : 1D lattice in 3D space
@@ -277,9 +259,6 @@ Lattice{2,2,Float64} : 2D lattice in 2D space
   Sublattices     : 2
     Names         : (:C, :D)
     Sites         : (1, 1) --> 2 total per unit cell
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:
@@ -537,11 +516,7 @@ Promotes the `Lattice` of `h` to a `Superlattice` without changing the Hamiltoni
 which always refers to the unitcell of the lattice.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> supercell(LatticePresets.honeycomb(), region = RegionPresets.circle(300))
 Superlattice{2,2,Float64,0} : 2D lattice in 2D space, filling a 0D supercell
@@ -572,9 +547,6 @@ Superlattice{2,2,Float64,2} : 2D lattice in 2D space, filling a 2D supercell
   Supercell{2,2} for 2D superlattice of the base 2D lattice
     Supervectors  : ((3, 0), (0, 3))
     Supersites    : 9
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:
@@ -739,11 +711,7 @@ the first time.
 Functional syntax, equivalent to `unitcell(lat_or_h, v...; kw...)
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(300))
 Lattice{2,0,Float64} : 0D lattice in 2D space
@@ -772,9 +740,6 @@ Lattice{2,2,Float64} : 2D lattice in 2D space
   Sublattices     : 1
     Names         : (:A)
     Sites         : (9) --> 9 total per unit cell
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:

--- a/src/model.jl
+++ b/src/model.jl
@@ -274,11 +274,7 @@ together or be multiplied by scalars to build more complicated `TightbindingMode
 `onsite(1) - 3 * hopping(2)`
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> model = onsite(1, sublats = (:A,:B)) - 2 * hopping(2, sublats = :A=>:A)
 TightbindingModel{2}: model with 2 terms
@@ -315,9 +311,6 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
   Onsites          : 2
   Hoppings         : 0
   Coordination     : 0.0
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:
@@ -386,11 +379,7 @@ together or be multiplied by scalars to build more complicated `TightbindingMode
 `onsite(1) - 3 * hopping(2)`
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> model = 3 * onsite(1) - hopping(2, dn = ((1,2), (0,0)), sublats = :A=>:B)
 TightbindingModel{2}: model with 2 terms
@@ -427,9 +416,6 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
   Onsites          : 0
   Hoppings         : 18
   Coordination     : 9.0
-```
-```@meta
-DocTestSetup = nothing
 ```
 
 # See also:

--- a/src/parametric.jl
+++ b/src/parametric.jl
@@ -37,11 +37,7 @@ to extra zero onsites and hoppings being stored in sparse `h`s.
 Function form of `parametric`, equivalent to `parametric(h, modifiers...)`.
 
 # Examples
-```@meta
-DocTestSetup = quote
-    using Quantica
-end
-```
+
 ```jldoctest
 julia> ph = LatticePresets.honeycomb() |> hamiltonian(onsite(0) + hopping(1, range = 1/√3)) |>
        unitcell(10) |> parametric(@onsite!((o; μ) -> o - μ))
@@ -64,9 +60,6 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
   Onsites          : 200
   Hoppings         : 640
   Coordination     : 3.2
-```
-```@meta
-DocTestSetup = nothing
 ```
 # See also
     `@onsite!`, `@hopping!`


### PR DESCRIPTION
Docstrings with doctests that include @meta sections for setup display the @meta code in the REPL. Since Documenter 0.23 it is [recommended](https://juliadocs.github.io/Documenter.jl/stable/man/doctests/index.html#Module-level-metadata-1) to set up the environment for doctests in the make.jl file

This PR does that.