### PR TITLE
Boolean masks

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -14,7 +14,7 @@ HamiltonianHarmonic{L,M,A}(dn::SVector{L,Int}, n::Int, m::Int) where {L,M,A<:Mat
 
 struct Hamiltonian{LA<:AbstractLattice,L,M,A<:AbstractMatrix,
                    H<:HamiltonianHarmonic{L,M,A},
-                   O<:Tuple{Vararg{Tuple{Vararg{NameType}}}}} <: AbstractMatrix{M}
+                   O<:Tuple{Vararg{Tuple{Vararg{NameType}}}}} # <: AbstractMatrix{M}
     lattice::LA
     harmonics::Vector{H}
     orbitals::O
@@ -50,6 +50,9 @@ Base.summary(::Hamiltonian{LA}) where {E,L,T,L´,LA<:Superlattice{E,L,T,L´}} =
     "Hamiltonian{<:Superlattice} : $(L)D Hamiltonian on a $(L´)D Superlattice in $(E)D space"
 
 Base.eltype(::Hamiltonian{<:Any,<:Any,M}) where {M} = M
+
+Base.isequal(h1::HamiltonianHarmonic, h2::HamiltonianHarmonic) =
+    h1.dn == h2.dn && h1.h == h2.h
 
 displaymatrixtype(h::Hamiltonian) = displaymatrixtype(matrixtype(h))
 displaymatrixtype(::Type{<:SparseMatrixCSC}) = "SparseMatrixCSC, sparse"
@@ -212,6 +215,10 @@ Base.IteratorSize(::EachIndexNonzeros) = Base.SizeUnknown()
 Base.IteratorEltype(::EachIndexNonzeros) = Base.HasEltype()
 Base.eltype(s::EachIndexNonzeros{<:Hamiltonian}) = Tuple{Int, Int, typeof(first(s.h.harmonics).dn)}
 Base.eltype(s::EachIndexNonzeros{<:HamiltonianHarmonic}) = Tuple{Int, Int}
+
+Base.isequal(h1::Hamiltonian, h2::Hamiltonian) =
+    isequal(h1.lattice, h2.lattice) && isequal(h1.harmonics, h2.harmonics) &&
+    isequal(h1.orbitals, h2.orbitals)
 
 # stored_indices(h::Hamiltonian) = ((har.dn, rowvals(har.h)[ptr], col) for har in h.harmonics
 #                                   for col in 1:size(har.h, 2) for ptr in nzrange(har.h, col))
@@ -409,6 +416,55 @@ Base.isassigned(h::Hamiltonian, dn::Vararg{Int}) = isassigned(h, SVector(dn))
 Base.isassigned(h::Hamiltonian, dn::NTuple) = isassigned(h, SVector(dn))
 Base.isassigned(h::Hamiltonian{<:Any,L}, dn::SVector{L,Int}) where {L} =
     findfirst(hh -> hh.dn == dn, h.harmonics) != nothing
+
+## Boolean masking
+"""
+    &(h1::Hamiltonian{<:Superlattice}, h2::Hamiltonian{<:Superlattice})
+
+Construct a new `Hamiltonian{<:Superlattice}` using an `and` boolean mask, i.e. with a
+supercell that contains cells that are both in the supercell of `h1` and `h2`
+
+# See also:
+    `|`, `xor`
+"""
+(Base.:&)(s1::Hamiltonian{<:Superlattice}, s2::Hamiltonian{<:Superlattice}) =
+    boolean_mask_hamiltonian(Base.:&, s1, s2)
+
+"""
+    |(h1::Hamiltonian{<:Superlattice}, h2::Hamiltonian{<:Superlattice})
+
+Construct a new `Hamiltonian{<:Superlattice}` using an `or` boolean mask, i.e. with a
+supercell that contains cells that are either in the supercell of `h1` or `h2`
+
+# See also:
+    `&`, `xor`
+"""
+(Base.:|)(s1::Hamiltonian{<:Superlattice}, s2::Hamiltonian{<:Superlattice}) =
+    boolean_mask_hamiltonian(Base.:|, s1, s2)
+
+"""
+    xor(h1::Hamiltonian{<:Superlattice}, h2::Hamiltonian{<:Superlattice})
+
+Construct a new `Hamiltonian{<:Superlattice}` using a `xor` boolean mask, i.e. with a
+supercell that contains cells that are either in the supercell of `h1` or `h2` but not in
+both
+
+# See also:
+    `&`, `|`
+"""
+(Base.xor)(s1::Hamiltonian{<:Superlattice}, s2::Hamiltonian{<:Superlattice}) =
+    boolean_mask_hamiltonian(Base.xor, s1, s2)
+
+function boolean_mask_hamiltonian(f, s1::Hamiltonian{<:Superlattice}, s2::Hamiltonian{<:Superlattice})
+    check_compatible_hsuper(s1, s2)
+    return Hamiltonian(f(s1.lattice, s2.lattice), s1.harmonics, s1.orbitals)
+end
+
+function check_compatible_hsuper(s1, s2)
+    compatible = isequal(s1.harmonics, s2.harmonics) && isequal(s1.orbitals, s2.orbitals)
+    compatible || throw(ArgumentError("Hamiltonians are incompatible for boolean masking"))
+    return nothing
+end
 
 #######################################################################
 # auxiliary types

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -183,3 +183,36 @@ end
     @test parametric(h, @onsite!((o, r; b) -> o), @hopping!((t, r, dr; a = 2) -> r[1]*t))(b=1) isa T
     @test parametric(h, @onsite!((o, r; b) -> o*b), @hopping!((t, r, dr; a = 2) -> r[1]*t))(a=1, b=2) isa T
 end
+
+@testset "boolean masks" begin
+    for b in ((), (1,1), 4)
+        @show b
+        h1 = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(2)) |>
+             supercell(b, region = RegionPresets.circle(10))
+        h2 = LatticePresets.honeycomb() |> hamiltonian(hopping(1) + onsite(2)) |>
+             supercell(b, region = RegionPresets.circle(20))
+
+        @test isequal(h1 & h2, h1)
+        @test isequal(h1, h2) || !isequal(h1 & h2, h2)
+        @test isequal(h1, h2) || !isequal(h1 | h2, h1)
+        @test  isequal(h1 | h2, h2)
+
+        @test isequal(unitcell(h1 & h2), unitcell(h1))
+        @test isequal(h1, h2) || !isequal(unitcell(h1 & h2), unitcell(h2))
+        @test isequal(h1, h2) || !isequal(unitcell(h1 | h2), unitcell(h1))
+        @test isequal(unitcell(h1 | h2), unitcell(h2))
+
+        h1 = h1.lattice
+        h2 = h2.lattice
+
+        @test isequal(h1 & h2, h1)
+        @test isequal(h1, h2) || !isequal(h1 & h2, h2)
+        @test isequal(h1, h2) || !isequal(h1 | h2, h1)
+        @test  isequal(h1 | h2, h2)
+
+        @test isequal(unitcell(h1 & h2), unitcell(h1))
+        @test isequal(h1, h2) || !isequal(unitcell(h1 & h2), unitcell(h2))
+        @test isequal(h1, h2) || !isequal(unitcell(h1 | h2), unitcell(h1))
+        @test isequal(unitcell(h1 | h2), unitcell(h2))
+    end
+end


### PR DESCRIPTION
In this PR we introduce a Superlattice-specific feature: boolean masks

A `Superlattice` is a combination of a `Lattice` (typically periodic) and a `Supercell` (a region of space that is filled by the lattice along some axes). Likewise, a `Hamiltonian{<:Superlattice}` is a Hamiltonian defined on a `Lattice` plus a `Supercell` for that `Lattice.

When you do `unitcell(h, ...)`, where `h` is a `Lattice` or a `Hamiltonian`, what happens behind the scenes is that `supercell(h,...)` is called first, which produces a `s::Superlattice` or `s::Hamiltonian{<:Superlattice}`, respectively. Only then the superlattice's supercell is expanded into a unitcell via a call to `unitcell(s)`.

This PR allows combining two or more `Superlattice` or `Hamiltonian{<:Superlattice}` using boolean operators, `&`, `|` and `xor`. You can thus do e.g. `h1 & h2` with two `Hamiltonian{<:Superlattice}` to obtain another with a `Supercell` that is their *intersection*. Then, doing `unitcell(h1 & h2)` gives you a regular `Hamiltonian{<:Lattice}` with the intersected unitcell. Similarly, `h1 | h2` gives you the union of the two `Supercell`s, and `xor(h1, h2)` gives you the union-minus-intersection.

The idea of this advanced functionality is to provide greater flexibility when efficiently constructing complex geometries from simpler ones.