### PR TITLE
Issue#35, cumulative application of modifiers in ParametricHamiltonian

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -118,7 +118,7 @@ function nonsites(ham::Hamiltonian)
     return count
 end
 
-_nnz(h::AbstractSparseMatrix) = nnz(h)
+_nnz(h::AbstractSparseMatrix) = count(!iszero, nonzeros(h)) # Does not include stored zeros
 _nnz(h::DenseMatrix) = count(!iszero, h)
 
 function _nnzdiag(s::SparseMatrixCSC)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -182,6 +182,14 @@ end
     @test parametric(h, @onsite!((o, r) -> o), @hopping!((t, r, dr; a = 2) -> r[1]*t))(a=1) isa T
     @test parametric(h, @onsite!((o, r; b) -> o), @hopping!((t, r, dr; a = 2) -> r[1]*t))(b=1) isa T
     @test parametric(h, @onsite!((o, r; b) -> o*b), @hopping!((t, r, dr; a = 2) -> r[1]*t))(a=1, b=2) isa T
+
+    # Issue #35
+    for orb in (Val(1), Val(2))
+        h = LatticePresets.triangular() |> hamiltonian(hopping(I) + onsite(I), orbitals = orb) |> unitcell(10)
+        ph = parametric(h, @onsite!((o, r; b) -> o+b*I), @hopping!((t, r, dr; a = 2) -> t+r[1]*I),
+                       @onsite!((o, r; b) -> o-b*I), @hopping!((t, r, dr; a = 2) -> t-r[1]*I))
+        @test isapprox(bloch(ph(a=1, b=2), (1, 2)), bloch(h, (1, 2)))
+    end
 end
 
 @testset "boolean masks" begin


### PR DESCRIPTION
Closes #35 

The fix resets the modified elements of a ParametricHamiltonian to the values in the base Hamiltonian before applying the modifiers. To do this efficiently the complete list of modified nonzeros are computed at build time. Then, modifiers are applied cumulatively one after the other, instead of being applied always to the base values as before.

This PR also includes a fix for the computation of number of hoppings in a Hamiltonian, so that only non-zero hoppings are computed in the sparse case (like in the dense case). Otherwise an `optimize!`d Hamiltonian (such as a ParametricHamiltonian) misreports its coordination.