### PR TITLE
Remove `forcehermitian`, add `plusadjoint`

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -114,7 +114,7 @@ function ispositive(ndist)
     return result
 end
 
-isnonnegative(ndist) = iszero(ndist) || ispositive(ndist)
+# isnonnegative(ndist) = iszero(ndist) || ispositive(ndist)
 
 ############################################################################################
 ######## _copy! and _add! #  Revise after #33589 is merged #################################

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -15,14 +15,14 @@
 end
 
 @testset "functional bandstructures" begin
-    hc = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, sublats = :A => :B))
+    hc = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, sublats = :A=>:B, plusadjoint = true))
     matrix = similarmatrix(hc, LinearAlgebraPackage())
     hf(x) = bloch!(matrix, hc, (x, -x))
     mesh = marchingmesh(range(0, 1, length = 13))
     b = bandstructure(hf, mesh)
     @test length(bands(b)) == 2
 
-    hc2 = LatticePresets.honeycomb() |> hamiltonian(hopping(-1)) 
+    hc2 = LatticePresets.honeycomb() |> hamiltonian(hopping(-1))
     hp2 = parametric(hc2, @hopping!((t; s) -> s*t))
     matrix2 = similarmatrix(hc2, LinearAlgebraPackage())
     hf2(s, x) = bloch!(matrix2, hp2(s = s), (x, x))


### PR DESCRIPTION
Closes #37 

Settled on `plusadjoint` instead of `addadjoint`

The performance drop is exactly as expected. When `plusadjoint=true` there are two hoppings to process, so `applyterm!` for those two terms take almost twice as long as the single `forcehermitian=true` term before the PR, that processed elements and their adjoints in the same loop.