### PR TITLE
Add optional centers to RegionPresets

### DIFF
--- a/src/presets.jl
+++ b/src/presets.jl
@@ -106,39 +106,39 @@ Base.show(io::IO, ::Region{E}) where {E} =
 
 extended_eps(T = Float64) = sqrt(eps(T))
 
-circle(radius = 10.0) = Region{2}(_region_ellipse((radius, radius)))
+circle(radius = 10.0, c...) = Region{2}(_region_ellipse((radius, radius), c...))
 
-ellipse(radii = (10.0, 15.0)) = Region{2}(_region_ellipse(radii))
+ellipse(radii = (10.0, 15.0), c...) = Region{2}(_region_ellipse(radii, c...))
 
-square(side = 10.0) = Region{2}(_region_rectangle((side, side)))
+square(side = 10.0, c...) = Region{2}(_region_rectangle((side, side), c...))
 
-rectangle(sides = (10.0, 15.0)) = Region{2}(_region_rectangle(sides))
+rectangle(sides = (10.0, 15.0), c...) = Region{2}(_region_rectangle(sides, c...))
 
-sphere(radius = 10.0) = Region{3}(_region_ellipsoid((radius, radius, radius)))
+sphere(radius = 10.0, c...) = Region{3}(_region_ellipsoid((radius, radius, radius), c...))
 
-spheroid(radii = (10.0, 15.0, 20.0)) = Region{3}(_region_ellipsoid(radii))
+spheroid(radii = (10.0, 15.0, 20.0), c...) = Region{3}(_region_ellipsoid(radii, c...))
 
-cube(side = 10.0) = Region{3}(_region_cuboid((side, side, side)))
+cube(side = 10.0, c...) = Region{3}(_region_cuboid((side, side, side), c...))
 
-cuboid(sides = (10.0, 15.0, 20.0)) = Region{3}(_region_cuboid(sides))
+cuboid(sides = (10.0, 15.0, 20.0), c...) = Region{3}(_region_cuboid(sides, c...))
 
-function _region_ellipse((rx, ry))
-    return r -> (r[1]/rx)^2 + (r[2]/ry)^2 <= 1 + extended_eps(Float64)
+function _region_ellipse((rx, ry), (cx, cy) = (0, 0))
+    return r -> ((r[1]-cx)/rx)^2 + ((r[2]-cy)/ry)^2 <= 1 + extended_eps(Float64)
 end
 
-function _region_rectangle((lx, ly))
-    return r -> abs(2*r[1]) <= lx * (1 + extended_eps()) &&
-                abs(2*r[2]) <= ly * (1 + extended_eps())
+function _region_rectangle((lx, ly), (cx, cy) = (0, 0))
+    return r -> abs(2*(r[1]-cx)) <= lx * (1 + extended_eps()) &&
+                abs(2*(r[2]-cy)) <= ly * (1 + extended_eps())
 end
 
-function _region_ellipsoid((rx, ry, rz))
-    return r -> (r[1]/rx)^2 + (r[2]/ry)^2 + (r[3]/rz)^2 <= 1 + eps()
+function _region_ellipsoid((rx, ry, rz), (cx, cy, cz) = (0, 0, 0))
+    return r -> ((r[1]-cx)/rx)^2 + ((r[2]-cy)/ry)^2 + ((r[3]-cz)/rz)^2 <= 1 + eps()
 end
 
-function _region_cuboid((lx, ly, lz))
-    return r -> abs(2*r[1]) <= lx * (1 + extended_eps()) &&
-                abs(2*r[2]) <= ly * (1 + extended_eps()) &&
-                abs(2*r[3]) <= lz * (1 + extended_eps())
+function _region_cuboid((lx, ly, lz), (cx, cy, cz) = (0, 0, 0))
+    return r -> abs(2*(r[1]-cx)) <= lx * (1 + extended_eps()) &&
+                abs(2*(r[2]-cy)) <= ly * (1 + extended_eps()) &&
+                abs(2*(r[3]-cy)) <= lz * (1 + extended_eps())
 end
 
 end # module

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -51,10 +51,10 @@ end
             @test unitcell(preset(), l) isa Lattice{E,L}
         end
     end
-    @test unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(10)) isa Lattice{2,0}
+    @test unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(10, (10,0))) isa Lattice{2,0}
     @test unitcell(LatticePresets.honeycomb(), (2,1), region = RegionPresets.circle(10)) isa Lattice{2,1}
     @test unitcell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Lattice{3,1}
-    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10)) isa Lattice{3,1}
+    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10, , (10,20,30))) isa Lattice{3,1}
 end
 
 @testset "supercell" begin
@@ -71,8 +71,8 @@ end
             @test supercell(preset(), l) isa Superlattice{E,<:Any,<:Any,L}
         end
     end
-    @test supercell(LatticePresets.honeycomb(), region = RegionPresets.circle(10)) isa Superlattice{2,2}
+    @test supercell(LatticePresets.honeycomb(), region = RegionPresets.circle(10, (0,2))) isa Superlattice{2,2}
     @test supercell(LatticePresets.honeycomb(), (2,1), region = RegionPresets.circle(10)) isa Superlattice{2,2}
-    @test supercell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Superlattice{3,3}
+    @test supercell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10, (1,0))) isa Superlattice{3,3}
     @test supercell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10)) isa Superlattice{3,3}
 end

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -54,7 +54,7 @@ end
     @test unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(10, (10,0))) isa Lattice{2,0}
     @test unitcell(LatticePresets.honeycomb(), (2,1), region = RegionPresets.circle(10)) isa Lattice{2,1}
     @test unitcell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Lattice{3,1}
-    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10, , (10,20,30))) isa Lattice{3,1}
+    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10, (10,20,30))) isa Lattice{3,1}
 end
 
 @testset "supercell" begin


### PR DESCRIPTION
E.g. `RegionPresets.circle(3, (1,0))` is a circle centered at `(1,0)` of radius 3. If unspecified (e.g. `RegionPresets.sphere(3)`), the center is at the origin.