### PR TITLE
Export SA from StaticArrays

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -28,7 +28,7 @@ export LatticePresets, RegionPresets, HamiltonianPresets
 
 export LinearAlgebraPackage, ArpackPackage, KrylovKitPackage
 
-export @SMatrix, @SVector, SMatrix, SVector
+export @SMatrix, @SVector, SMatrix, SVector, SA
 
 export ishermitian, I
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -254,8 +254,8 @@ end
 end
 
 @testset "unitcell seeds" begin
-    p1 = @SVector[100,0]
-    p2 = @SVector[0,20]
+    p1 = SA[100,0]
+    p2 = SA[0,20]
     lat = LatticePresets.honeycomb()
     model = hopping(1, range = 1/√3) + onsite(2)
     h1 = lat |> hamiltonian(model) |> supercell(region = r -> norm(r-p1)<3, seed = p1)

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -9,7 +9,7 @@ using Random
 end
 
 @testset "sublat" begin
-    sitelist = [(3,3), (3,3.), [3,3.], @SVector[3, 3], @SVector[3, 3f0], @SVector[3f0, 3.]]
+    sitelist = [(3,3), (3,3.), [3,3.], SA[3, 3], SA[3, 3f0], SA[3f0, 3.]]
     for site2 in sitelist, site1 in sitelist
         @test sublat(site1, site2) isa
             Sublat{2,promote_type(typeof.(site1)..., typeof.(site2)...)}


### PR DESCRIPTION
We add `SA` to the other StaticArrays exports. Although `SA` would be enough for everything, we don't unexport the old ones, as they can be preferred in some situations (more explicit)