### PR TITLE
Remove workaround for ExprTools#8

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -583,8 +583,6 @@ function get_f_N_params(f, msg)
         else
             push!(kwargs, :(_...))  # normalization : append _... to kwargs
         end
-        # Workaround for Issue #8 in ExprTools. Remove when PR #9 is merged
-        kwargs[1] isa Expr && kwargs[1].head == :(=) && (kwargs[1] = :($(Expr(:kw, kwargs[1].args...))))
     end
     N = haskey(d, :args) ? length(d[:args]) : 0
     f´ = ExprTools.combinedef(d)


### PR DESCRIPTION
This PR removes a workaround for issue [ExprTools#8](https://github.com/invenia/ExprTools.jl/issues/8) now that the fix is merged. I think old PRs #31 and #32 were failing tests because of the Manifest.toml pinning the version of ExprTools used (not 100% sure).