### PR TITLE
Parametric bandstructures with cuts

### DIFF
--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -67,7 +67,7 @@ Furthermore, the trace over a specific set of kets can also be computed; in this
 The order of the Chebyshev expansion is `order`. The `bandbrange = (ϵmin, ϵmax)` should completely encompass
 the full bandwidth of `hamiltonian`. If `missing` it is computed automatically using `ArnoldiMethods` (must be loaded).
 
-# Example
+# Examples
 ```
 julia> h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(region = RegionPresets.sphere(10));
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -74,7 +74,7 @@ end
 function Base.show(io::IO, b::Bandstructure{D,M}) where {D,M}
     ioindent = IOContext(io, :indent => string("  "))
     print(io,
-"Bandstructure: bands for a $(D)D hamiltonian
+"Bandstructure{$D}: collection of $(D)D bands
   Bands        : $(length(b.bands))
   Element type : $(displayelements(M))")
     print(ioindent, "\n", b.kmesh)
@@ -112,10 +112,10 @@ states(b::Band) = reshape(b.states, b.dimstates)
 # bandstructure
 #######################################################################
 """
-    bandstructure(h::Hamiltonian, mesh::Mesh; minprojection = 0.5, method = defaultmethod(h))
+    bandstructure(h::Hamiltonian, mesh::Mesh; cut = missing, minprojection = 0.5, method = defaultmethod(h))
 
 Compute the bandstructure of Bloch Hamiltonian `bloch(h, ϕs)`, with `ϕs` evaluated on the
-vertices of `mesh`. It is assumed that `h` is hermitian.
+vertices of `mesh`.
 
     bandstructure(h::Hamiltonian; resolution = 13, kw...)
 
@@ -124,15 +124,30 @@ dimensions of the Hamiltonian), with points `range(-π, π, length = resolution)
 Bravais axis. Note that `resolution` denotes the number of points along each Bloch axis,
 including endpoints (can be a tuple for axis-dependent points).
 
+    bandstructure(ph::ParametricHamiltonian, mesh; kw...)
+
+Compute the bandstructure of a `ph` with `i` parameters `p₁,..., pᵢ`, where `mesh` is
+interpreted as a discretization of parameter space ⊗ Brillouin zone, so that each vertex
+reads `v = (p₁,..., pᵢ, ϕ₁,..., ϕⱼ)`.
+
     bandstructure(matrixf::Function, mesh::Mesh; kw...)
 
-Compute the bandstructure of the Hamiltonian matrix `m = matrixf(ϕs...)`, with `ϕs`
-evaluated on the vertices of `mesh`. It is assumed that `m` is hermitian for all `ϕs`.
+Compute the bandstructure of the Hamiltonian matrix `m = matrixf(ϕs)`, with `ϕs` evaluated
+on the vertices of `mesh`. No `cut` option is allowed in this case. If needed, include it in
+the definition of `matrixf`.
 
 # Options
 
+The option `cut`, when not `missing`, is a function `cut = (mesh_coordinates...) -> φs`,
+where `φs` are Bloch phases if sampling a `h::Hamiltonian`, or `(params..., φs...)` if
+sampling a `ph::ParametricHamiltonian`, and `params` are values for `parameters(ph)`. This
+allows to compute a bandstructure along a cut in the Brillouin zone/parameter space, see
+below for examples.
+
 The option `minprojection` determines the minimum projection between eigenstates to connect
-them into a common subband. The option `method` is chosen automatically if unspecified, and
+them into a common subband.
+
+The option `method` is chosen automatically if unspecified, and
 can be one of the following
 
     method                    diagonalization function
@@ -144,17 +159,26 @@ Options passed to the `method` will be forwarded to the diagonalization function
 `method = ArpackPackage(nev = 8, sigma = 1im)` will use `Arpack.eigs(matrix; nev = 8,
 sigma = 1im)` to compute the bandstructure.
 
-# Example
+# Examples
 ```
 julia> h = LatticePresets.honeycomb() |> unitcell(3) |> hamiltonian(hopping(-1, range = 1/√3));
 
-julia> bandstructure(h; npoints = 25, method = LinearAlgebraPackage())
+julia> bandstructure(h; resolution = 25, method = LinearAlgebraPackage())
 Bandstructure: bands for a 2D hamiltonian
   Bands        : 8
   Element type : scalar (Complex{Float64})
   Mesh{2}: mesh of a 2-dimensional manifold
     Vertices   : 625
     Edges      : 3552
+
+julia> bandstructure(h, marchingmesh(range(0, 2π, length = 11)); cut = φ -> (φ, 0))
+       ## Computes a `Γ-X` cut of the bandstructure
+Bandstructure{1}: collection of 1D bands
+  Bands        : 18
+  Element type : scalar (Complex{Float64})
+  Mesh{1}: mesh of a 1-dimensional manifold
+    Vertices   : 11
+    Edges      : 10
 ```
 
 # See also
@@ -165,24 +189,27 @@ function bandstructure(h::Hamiltonian{<:Any,L,M}; resolution = 13, kw...) where 
     return bandstructure(h, mesh; kw...)
 end
 
-function bandstructure(h::Hamiltonian{<:Any,L}, mesh::Mesh{L}; method = defaultmethod(h), minprojection = 0.5) where {L}
+function bandstructure(h::Union{Hamiltonian,ParametricHamiltonian}, mesh::Mesh;
+                       method = defaultmethod(h), cut = missing, kw...)
     # ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
     matrix = similarmatrix(h, method)
-    d = Diagonalizer(method, codiagonalizer(h, matrix, mesh), minprojection)
-    matrixf(φs...) = bloch!(matrix, h, φs)
+    codiag = codiagonalizer(h, matrix, mesh, cut)
+    d = DiagonalizeHelper(method, codiag; kw...)
+    matrixf(φs) = bloch!(matrix, applycut(cut, h, φs)...)
     return _bandstructure(matrixf, matrix, mesh, d)
 end
 
 function bandstructure(matrixf::Function, mesh::Mesh;
                        matrix = _samplematrix(matrixf, mesh),
-                       method = defaultmethod(matrix), minprojection = 0.5)
-    d = Diagonalizer(method, codiagonalizer(matrixf, matrix, mesh), minprojection)
+                       method = defaultmethod(matrix), kw...)
+    codiag = codiagonalizer(matrixf, matrix, mesh)
+    d = DiagonalizeHelper(method, codiag; kw...)
     return _bandstructure(matrixf, matrix, mesh, d)
 end
 
-_samplematrix(matrixf, mesh) = matrixf(Tuple(first(vertices(mesh)))...)
+_samplematrix(matrixf, mesh) = matrixf(Tuple(first(vertices(mesh))))
 
-function _bandstructure(matrixf::Function, matrix´::AbstractMatrix{M}, mesh::MD, d::Diagonalizer) where {M,D,T,MD<:Mesh{D,T}}
+function _bandstructure(matrixf::Function, matrix´::AbstractMatrix{M}, mesh::MD, d::DiagonalizeHelper) where {M,D,T,MD<:Mesh{D,T}}
     nϵ = 0                           # Temporary, to be reassigned
     ϵks = Matrix{T}(undef, 0, 0)     # Temporary, to be reassigned
     ψks = Array{M,3}(undef, 0, 0, 0) # Temporary, to be reassigned
@@ -194,7 +221,7 @@ function _bandstructure(matrixf::Function, matrix´::AbstractMatrix{M}, mesh::MD
 
     p = Progress(nk, "Step 1/2 - Diagonalising: ")
     for (n, ϕs) in enumerate(vertices(mesh))
-        matrix = matrixf(Tuple(ϕs)...)
+        matrix = matrixf(Tuple(ϕs))
         # (ϵk, ψk) = diagonalize(Hermitian(matrix), d)  ## This is faster (!)
         (ϵk, ψk) = diagonalize(matrix, d.method)
         resolve_degeneracies!(ϵk, ψk, ϕs, matrix, d.codiag)
@@ -286,3 +313,26 @@ function findmostparallel(ψks::Array{M,3}, destk, srcb, srck) where {M}
     end
     return maxproj, destb
 end
+
+#######################################################################
+# Brillouin zone cuts
+#######################################################################
+
+applycut(cut::Missing, h, ϕs) = _h_phases(h, toSVector(ϕs))
+
+applycut(cut::Function, h, ϕs) = _h_phases(h, toSVector(cut(ϕs...)))
+
+@inline _h_phases(h::Hamiltonian{LA,L}, ϕs::SVector{L}) where {LA,L} = (h, ϕs)
+
+# @inline _h_phases(h::Hamiltonian{LA,L}, ϕs::SVector{L´}) where {LA,L,L´} =
+#     (h, ϕs[SVector{L}((L´-L+1):L´)])  # selects the last L elements of ϕs
+
+@inline function _h_phases(ph::ParametricHamiltonian, pϕs)
+    pnames = parameters(ph)
+    ps, ϕs = extract_parameters_phases(pnames, pϕs)
+    h = ph(; ps...)
+    return (h, ϕs)
+end
+
+extract_parameters_phases(pnames::NTuple{N,NameType}, ϕs::SVector{M}) where {N,M} =
+    (NamedTuple{pnames}(ntuple(i->ϕs[i], Val(N))), ntuple(i->ϕs[i+N], Val(M-N)))

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -126,9 +126,10 @@ including endpoints (can be a tuple for axis-dependent points).
 
     bandstructure(ph::ParametricHamiltonian, mesh; kw...)
 
-Compute the bandstructure of a `ph` with `i` parameters `p₁,..., pᵢ`, where `mesh` is
-interpreted as a discretization of parameter space ⊗ Brillouin zone, so that each vertex
-reads `v = (p₁,..., pᵢ, ϕ₁,..., ϕⱼ)`.
+Compute the bandstructure of a `ph` with `i` parameters (see `parameters(ph)`), where `mesh`
+is interpreted as a discretization of parameter space ⊗ Brillouin zone, so that each vertex
+reads `v = (p₁,..., pᵢ, ϕ₁,..., ϕⱼ)`, with `p` the values assigned to `parameters(ph)` and
+`ϕ` the Bloch phases.
 
     bandstructure(matrixf::Function, mesh::Mesh; kw...)
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -134,7 +134,9 @@ reads `v = (p₁,..., pᵢ, ϕ₁,..., ϕⱼ)`.
 
 Compute the bandstructure of the Hamiltonian matrix `m = matrixf(ϕs)`, with `ϕs` evaluated
 on the vertices of `mesh`. No `cut` option is allowed in this case. If needed, include it in
-the definition of `matrixf`.
+the definition of `matrixf`. Note that `ϕs` is either a `Tuple` or an `SVector`, but it is
+not splatted into `matrixf`, i.e. `matrixf(x) = ...` or `matrixf(x, y) = ...` will not work,
+use `matrixf((x,)) = ...` or `matrixf((x, y)) = ...` instead.
 
 # Options
 

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -4,15 +4,18 @@
 #######################################################################
 abstract type AbstractDiagonalizeMethod end
 
-struct Diagonalizer{S<:AbstractDiagonalizeMethod,C}
+struct DiagonalizeHelper{S<:AbstractDiagonalizeMethod,C}
     method::S
     codiag::C
     minprojection::Float64
 end
 
+DiagonalizeHelper(method, codiag; minprojection = 0.5) =
+    DiagonalizeHelper(method, codiag, minprojection)
+
 ## Diagonalize methods ##
 
-defaultmethod(h::Union{Hamiltonian,AbstractMatrix}) = LinearAlgebraPackage()
+defaultmethod(h::Union{Hamiltonian,ParametricHamiltonian,AbstractMatrix}) = LinearAlgebraPackage()
 
 checkloaded(package::Symbol) = isdefined(Main, package) ||
     throw(ArgumentError("Package $package not loaded, need to be `using $package`."))
@@ -161,51 +164,56 @@ end
 
 ## Codiagonalizer
 ## Uses velocity operators along different directions. If not enough, use finite differences
-struct Codiagonalizer{S,T,F<:Function}
+## along mesh directions
+struct Codiagonalizer{T,F<:Function}
     cmatrixf::F
     matrixindices::UnitRange{Int}
-    directions::Vector{S}
     degtol::T
     rangesA::Vector{UnitRange{Int}} # Prealloc buffer for degeneray ranges
     rangesB::Vector{UnitRange{Int}} # Prealloc buffer for degeneray ranges
     perm::Vector{Int}               # Prealloc for sortperm!
 end
 
-function codiagonalizer(h::Hamiltonian, matrix, mesh::Mesh{L}; kw...) where {L}
-    directions = velocitydirections(Val(L); kw...)
-    ndirs = length(directions)
-    matrixindices = 1:(2 * ndirs + 1)
+function codiagonalizer(h::Union{Hamiltonian,ParametricHamiltonian}, matrix, mesh, cut; kw...)
+    veldirs = velocitydirections(parent(h); kw...)
+    meshdirs = meshdirections(mesh; kw...)
+    nv = length(veldirs)
+    nm = length(meshdirs)
+    matrixindices = 1:(nv + nm + 1)
     degtol = sqrt(eps(real(blockeltype(h))))
     delta = meshdelta(mesh)
     delta = iszero(delta) ? degtol : delta
-    cmatrixf(ϕs, n) =
-        if n <= ndirs
-            bloch!(matrix, h, ϕs, dn -> im * directions[n]' * dn)
-        elseif n <= 2ndirs # resort to finite differences
-            bloch!(matrix, h, ϕs + delta * directions[n - ndirs])
+    cmatrixf(meshϕs, n) =
+        if n <= nv
+            bloch!(matrix, applycut(cut, h, meshϕs)..., dn -> im * veldirs[n]' * dn)
+        elseif n - nv <= nm # resort to finite differences
+            bloch!(matrix, applycut(cut, h, meshϕs + delta * meshdirs[n - nv])...)
         else # use a fixed random matrix
             randomfill!(matrix)
         end
-    return Codiagonalizer(cmatrixf, matrixindices, directions, degtol, UnitRange{Int}[], UnitRange{Int}[], Int[])
+    return Codiagonalizer(cmatrixf, matrixindices, degtol, UnitRange{Int}[], UnitRange{Int}[], Int[])
 end
 
-function codiagonalizer(matrixf::Function, matrix::AbstractMatrix{T}, mesh::Mesh{L}; kw...) where {L,T}
-    directions = velocitydirections(Val(L); kw...)
-    ndirs = length(directions)
-    matrixindices = 1:(ndirs + 1)
+function codiagonalizer(matrixf::Function, matrix::AbstractMatrix{T}, mesh; kw...) where {T}
+    meshdirs = meshdirections(mesh; kw...)
+    nm = length(meshdirs)
+    matrixindices = 1:(nm + 1)
     degtol = sqrt(eps(real(eltype(T))))
     delta = meshdelta(mesh)
     delta = iszero(delta) ? degtol : delta
-    cmatrixf(ϕs, n) =
-        if n <= ndirs # finite differences
-            matrixf((ϕs + delta * directions[n])...)
+    cmatrixf(meshϕs, n) =
+        if n <= nm # finite differences
+            matrixf(meshϕs + delta * meshdirs[n])
         else # use a fixed random matrix
             randomfill!(matrix)
         end
-    return Codiagonalizer(cmatrixf, matrixindices, directions, degtol, UnitRange{Int}[], UnitRange{Int}[], Int[])
+    return Codiagonalizer(cmatrixf, matrixindices, degtol, UnitRange{Int}[], UnitRange{Int}[], Int[])
 end
 
-function velocitydirections(::Val{L}; direlements = 0:1, onlypositive = true) where {L}
+velocitydirections(::Hamiltonian{LA,L}; kw...) where {LA,L} = _directions(Val(L); kw...)
+meshdirections(::Mesh{L}; kw...) where {L} = _directions(Val(L); kw...)
+
+function _directions(::Val{L}; direlements = 0:1, onlypositive = true) where {L}
     directions = vec(SVector{L,Int}.(Iterators.product(ntuple(_ -> direlements, Val(L))...)))
     onlypositive && filter!(ispositive, directions)
     unique!(normalize, directions)

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -185,9 +185,9 @@ function codiagonalizer(h::Union{Hamiltonian,ParametricHamiltonian}, matrix, mes
     delta = iszero(delta) ? degtol : delta
     cmatrixf(meshϕs, n) =
         if n <= nv
-            bloch!(matrix, applycut(cut, h, meshϕs)..., dn -> im * veldirs[n]' * dn)
+            bloch!(matrix, h, applycut(cut, meshϕs), dn -> im * veldirs[n]' * dn)
         elseif n - nv <= nm # resort to finite differences
-            bloch!(matrix, applycut(cut, h, meshϕs + delta * meshdirs[n - nv])...)
+            bloch!(matrix, h, applycut(cut, meshϕs + delta * meshdirs[n - nv]))
         else # use a fixed random matrix
             randomfill!(matrix)
         end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -67,6 +67,8 @@ displayorbitals(h::Hamiltonian) =
 SparseArrays.issparse(h::Hamiltonian{LA,L,M,A}) where {LA,L,M,A<:AbstractSparseMatrix} = true
 SparseArrays.issparse(h::Hamiltonian{LA,L,M,A}) where {LA,L,M,A} = false
 
+Base.parent(h::Hamiltonian) = h
+
 # Internal API #
 
 latdim(h::Hamiltonian{LA}) where {E,L,LA<:AbstractLattice{E,L}} = L
@@ -813,12 +815,12 @@ Specifies the desired type `T` of the uninitialized matrix.
 
 Adapts the type of the matrix (e.g. dense/sparse) to the specified `method`
 """
-function similarmatrix(h::Hamiltonian, ::Type{A´} = matrixtype(h)) where {A´<:AbstractMatrix}
+function similarmatrix(h, ::Type{A´} = matrixtype(h)) where {A´<:AbstractMatrix}
     optimize!(h)
-    return _similarmatrix(h, matrixtype(h), A´)
+    return _similarmatrix(parent(h), matrixtype(h), A´)
 end
 
-# We only provide the type combinations that make sense
+# We only provide the type combinastions that make sense
 _similarmatrix(h, ::Type{A}, ::Type{A´}) where {A´,A<:A´} =
     similar(h.harmonics[1].h)
 

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -1,11 +1,11 @@
 @testset "basic bandstructures" begin
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, sublats = :A => :B))
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, range = 1/√3))
     b = bandstructure(h, resolution = 13)
     @test length(bands(b)) == 1
 
     h = LatticePresets.honeycomb() |>
         hamiltonian(onsite(0.5, sublats = :A) + onsite(-0.5, sublats = :B) +
-                    hopping(-1, sublats = :A => :B))
+                    hopping(-1, range = 1/√3))
     b = bandstructure(h, resolution = 13)
     @test length(bands(b)) == 2
 
@@ -17,7 +17,7 @@ end
 @testset "functional bandstructures" begin
     hc = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, sublats = :A=>:B, plusadjoint = true))
     matrix = similarmatrix(hc, LinearAlgebraPackage())
-    hf(x) = bloch!(matrix, hc, (x, -x))
+    hf((x,)) = bloch!(matrix, hc, (x, -x))
     mesh = marchingmesh(range(0, 1, length = 13))
     b = bandstructure(hf, mesh)
     @test length(bands(b)) == 2
@@ -25,8 +25,35 @@ end
     hc2 = LatticePresets.honeycomb() |> hamiltonian(hopping(-1))
     hp2 = parametric(hc2, @hopping!((t; s) -> s*t))
     matrix2 = similarmatrix(hc2, LinearAlgebraPackage())
-    hf2(s, x) = bloch!(matrix2, hp2(s = s), (x, x))
+    hf2((s, x)) = bloch!(matrix2, hp2(s = s), (x, x))
     mesh2 = marchingmesh(range(0, 1, length = 13), range(0, 1, length = 13))
     b = bandstructure(hf2, mesh2)
     @test length(bands(b)) == 2
+end
+
+@testset "bandstructures cuts" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, range = 1/√3))
+    mesh1D = marchingmesh(range(0, 2π, length = 13))
+    b = bandstructure(h, mesh1D, cut = φ -> (φ, 0))
+    @test length(bands(b)) == 2
+    b = bandstructure(h, mesh1D, cut = φ -> (φ, -φ))
+    @test length(bands(b)) == 2
+end
+
+
+@testset "parametric bandstructures" begin
+    ph = LatticePresets.linear() |> hamiltonian(hopping(-I), orbitals = Val(2)) |> unitcell(2) |>
+         parametric(@onsite!((o; k) -> o + k*I), @hopping!((t; k)-> t - k*I))
+    mesh2D = marchingmesh(range(0, 1, length = 13), range(0, 2π, length = 13))
+    mesh1D = marchingmesh(range(0, 2π, length = 13))
+    b = bandstructure(ph, mesh2D)
+    @test length(bands(b)) == 4
+    b = bandstructure(ph, mesh2D, cut = (k, φ) -> (k + φ/2π, φ))
+    @test length(bands(b)) == 4
+    b = bandstructure(ph, mesh2D, cut = (k, φ) -> (k + φ/2π, φ))
+    @test length(bands(b)) == 4
+    b = bandstructure(ph, mesh1D, cut = k -> (k, 2π*k))
+    @test length(bands(b)) == 4
+    b = bandstructure(ph, mesh1D, cut = φ -> (φ, -φ))
+    @test length(bands(b)) == 4
 end


### PR DESCRIPTION
Closes #28 

This implements the `bandstructure(::ParametricHamiltonian, mesh)` and the `bandstructure(::Union{Hamiltonian,ParametricHamiltonian}, mesh; cut =...)` functionality. 

This new feature is quite powerful. It allows to treat parameters in a `ParametricHamiltonian` as equivalent to Bloch phases when computing `bandstructure(ph::ParametricHamiltonian, mesh)`. The `mesh` should be a discretization of the parameter space ⊗ Brillouin zone for `ph`. Each vertex `v` of `mesh` is interpreted as `v = (p₁,..., pᵢ, ϕ₁,..., ϕⱼ)`, with parameter values `p` coming before Bloch phases `ϕ`.

A possible application: obtain the bandstructure of a planar Josephson junction as a function of parallel momentum and superconductor phase difference. In general, this is useful when needing to compute the bandstructure of a system (or any associated observable) as a function of external parameters.

When providing a `cut` of the form `cut = (mesh_coordinates...) -> v`, with `mesh_coordinates` a Tuple of coordinates of `mesh` and `v` the corresponding Bloch phases in the full Brillouin zone `v = (ϕ₁,..., ϕⱼ)` (or `v = (p₁,..., pᵢ, ϕ₁,..., ϕⱼ)` in parameter space ⊗ Brillouin zone for `ParametricHamiltonian`s), a section of the bandstructure in the target space of `cut` is constructed.

The machinery of degeneracy resolution and band reconnection has been generalized to work with cuts and parametric spaces, resulting in clean reconnected bands even when mixing Bloch phases and parameters in an arbitrary way.

There is a rather small performance penalty for using cuts or parameter sampling. Essentially, the user should not have to worry about performance when using this feature. Example:
```
julia> h = LatticePresets.square() |> hamiltonian(hopping(1)+onsite(0)) |> unitcell(2);

julia> ph = parametric(h, @onsite!((o; μ) -> o - μ));

julia> mesh1D = marchingmesh(0:0.1:1);

julia> cut12 = k -> (k, k)

julia> cut13 = k -> (k, k, k);

julia> @btime bandstructure(h, mesh1D, cut = cut12);
  144.948 μs (876 allocations: 130.44 KiB)

julia> @btime bandstructure(ph, mesh1D, cut = cut13);
  184.907 μs (1161 allocations: 141.66 KiB)
```