### PR TITLE
Allow toSVector(::NTuple{N,Any})

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1227,7 +1227,7 @@ end
 flatten(h::HamiltonianHarmonic, orbs, lat) =
     HamiltonianHarmonic(h.dn, _flatten(h.h, length.(orbs), lat))
 
-function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, norbs::NTuple{S,<:Any}, lat, ::Type{T´} = T) where {N,T,S,T´}
+function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, norbs::NTuple{S,Any}, lat, ::Type{T´} = T) where {N,T,S,T´}
     offsets´ = flatoffsets(lat.unitcell.offsets, norbs)
     dim´ = last(offsets´)
 
@@ -1252,7 +1252,7 @@ function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, norbs::NTuple{S,<:Any}
     return matrix
 end
 
-function _flatten(src::DenseMatrix{<:SMatrix{N,N,T}}, norbs::NTuple{S,<:Any}, lat, ::Type{T´} = T) where {N,T,S,T´}
+function _flatten(src::DenseMatrix{<:SMatrix{N,N,T}}, norbs::NTuple{S,Any}, lat, ::Type{T´} = T) where {N,T,S,T´}
     offsets´ = flatoffsets(lat.unitcell.offsets, norbs)
     dim´ = last(offsets´)
     matrix = similar(src, T´, dim´, dim´)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -43,7 +43,7 @@ sublat(sites::Vector{<:SVector}; name = :_, kw...) =
     Sublat(sites, nametype(name))
 sublat(vs::Union{Tuple,AbstractVector{<:Number}}...; kw...) = sublat(toSVectors(vs...); kw...)
 
-# transform!(s::S, f::F) where {S <: Sublat,F <: Function} = (s.sites .= f.(s.sites); s)
+toSVectors(vs...) = [promote(toSVector.(vs)...)...]
 
 #######################################################################
 # Bravais

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -8,9 +8,8 @@ toSMatrix(ss::AbstractVector...) = toSMatrix(Tuple.(ss)...)
 toSMatrix(s::AbstractMatrix) = SMatrix{size(s,1), size(s,2)}(s)
 
 toSVector(::Tuple{}) = SVector{0,Float64}()
-toSVectors(vs...) = [promote(toSVector.(vs)...)...]
 toSVector(v::SVector) = v
-toSVector(v::NTuple{N,Number}) where {N} = SVector(v)
+toSVector(v::NTuple{N,Any}) where {N} = SVector(v)
 toSVector(x::Number) = SVector{1}(x)
 toSVector(::Type{T}, v) where {T} = T.(toSVector(v))
 toSVector(::Type{T}, ::Tuple{}) where {T} = SVector{0,T}()
@@ -57,8 +56,8 @@ padright(sv::StaticVector{E1,T1}, x::T2, ::Val{E2}) where {E1,T1,E2,T2} =
     (T = promote_type(T1,T2); SVector{E2, T}(ntuple(i -> i > E1 ? x : convert(T, sv[i]), Val(E2))))
 padright(sv::StaticVector{E,T}, ::Val{E2}) where {E,T,E2} = padright(sv, zero(T), Val(E2))
 padright(sv::StaticVector{E,T}, ::Val{E}) where {E,T} = sv
-padright(t::NTuple{N´,<:Any}, x, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? x : t[i], Val(N))
-padright(t::NTuple{N´,<:Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 : t[i], Val(N))
+padright(t::NTuple{N´,Any}, x, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? x : t[i], Val(N))
+padright(t::NTuple{N´,Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 : t[i], Val(N))
 
 # Pad element type to a "larger" type
 @inline padtotype(s::SMatrix{E,L}, ::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -255,7 +255,12 @@ end
     ph = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |>
          parametric(@hopping!((t, r, dr; λ) ->  λ*im*sK(dr); sublats = :A=>:A),
                     @hopping!((t, r, dr; λ) -> -λ*im*sK(dr); sublats = :B=>:B))
-    @test bloch(ph(λ=1), (π/2, -π/2)) ≈ [4 1; 1 -4]
+    @test bloch(ph(λ=1), (π/2, -π/2)) == bloch(ph, (1, π/2, -π/2)) ≈ [4 1; 1 -4]
+    # Non-numeric parameters
+    ph = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |>
+         parametric(@hopping!((t, r, dr; λ, k) ->  λ*im*sK(dr+k); sublats = :A=>:A),
+                    @hopping!((t, r, dr; λ, k) -> -λ*im*sK(dr+k); sublats = :B=>:B))
+    @test bloch(ph(λ=1, k=SA[1,0]), (π/2, -π/2)) == bloch(ph, (1, SA[1,0], π/2, -π/2)) ≈ [-4 1; 1 4]
 end
 
 @testset "boolean masks" begin


### PR DESCRIPTION
This is a subtle one. In the old times, a `ϕs::Tuple` passed to `bloch!`, say, had to be converted to an `SVector`. This was done by the `toSVector` helper function. It assumed, however, that all elements of `ϕs` were `::Number`s. However, since `bloch!` was extended to support `ParametricHamiltonian`s, the elements of `ϕs` can be anything (e.g. an `SVector` or `SMatrix` parameter). In such a case, `toSVector` had no convenient dispatch. 

This PR simply changes `toSVector(::NTuple{N,Number})` to `toSVector(::NTuple{N,Any})` to enable this more general case. 

[It also expands some other `NTuple{N,<:Any}` (uniform but arbitrary types) to `NTuple{N,Any}` (completely arbitrary types), which was the intended meaning.]

Let's see if tests pass...