### PR TITLE
WIP: Green's functions from bandstructures  (generalized tetrahedron method)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
@@ -24,6 +25,7 @@ NearestNeighbors = "0.4"
 OffsetArrays = "1.0"
 ProgressMeter = "1.2"
 Requires = "1.0"
+SpecialFunctions = "0.10"
 StaticArrays = "0.12.3, 0.13"
 julia = "1.4"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 # Exported API
 - `lattice`, `sublat`, `bravais`: build lattices
 - `dims`, `sites`: inspect lattices
-- `hopping`, `onsite`: build tightbinding models
+- `hopping`, `onsite`, `siteselector`, `hopselector`: build tightbinding models
 - `hamiltonian`: build a Hamiltonian from tightbinding model and a lattice
 - `parametric`, `@onsite!`, `@hopping!`, `parameters`: build a parametric Hamiltonian
 - `supercell`, `unitcell`, `flatten`, `wrap`, `transform!`, `combine`: build derived lattices or Hamiltonians
@@ -25,6 +25,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 - `bandstructure`, `spectrum`: compute the generalized bandstructure of a Hamiltonian or a ParametricHamiltonian
 - `bands`, `energies`, `states`: inspect spectrum and bandstructure objects
 - `momentaKPM`, `dosKPM`, `averageKPM`, `densityKPM`, `bandrangeKPM`: Kernel Polynomial Method
+- `greens`, `greensolver`: build Green's functions of a Hamiltonian
 
 Some of this functionality require loading one or more third-party packages, which include the following:
 - KPM: `FFTW`, `ArnoldiMethod`

--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -71,11 +71,12 @@ The order of the Chebyshev expansion is `order`. The `bandbrange = (ϵmin, ϵmax
 the full bandwidth of `hamiltonian`. If `missing` it is computed automatically using `ArnoldiMethods` (must be loaded).
 
 # Examples
+
 ```
 julia> h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(region = RegionPresets.sphere(10));
 
 julia> momentaKPM(bloch(h), bandrange = (-6,6))
-Quantica.MomentaKPM{Float64}([0.9594929736144973, -0.005881595972403821, -0.4933354572913581, 0.00359537502632597, 0.09759451291347333, -0.0008081453185250322, -0.00896262538765363, 0.00048205637037715177, -0.0003705198310034668, 9.64901673962623e-20, 9.110915988898614e-18], (0.0, 6.030150753768845))
+Quantica.MomentaKPM{Complex{Float64},Tuple{Float64,Float64}}(Complex{Float64}[0.9594929736144989 + 0.0im, 0.00651662540445511 - 1.3684099632763213e-18im, 0.4271615999695687 + 0.0im, 0.011401934070884771 - 8.805365601448575e-19im, 0.2759482493684239 + 0.0im, 0.001128522288518446 + 4.914851192831956e-19im, 0.08738420162067032 + 0.0im, 0.0007921516166325597 + 2.0605151351830466e-19im, 0.00908824008889868 + 0.0im, -5.638793856739318e-20 - 2.2295921941414733e-35im, 1.2112238859024637e-16 + 0.0im], (0.0, 6.030150753768845))
 ```
 """
 function momentaKPM(h::Hamiltonian, A = _defaultA(eltype(h)); bandrange = missing, kw...)

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -11,20 +11,21 @@ function __init__()
 end
 
 using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
-      ProgressMeter, LinearMaps, Random
+      ProgressMeter, LinearMaps, Random, SpecialFunctions
 
 using ExprTools
 
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
 export sublat, bravais, lattice, dims, sites, supercell, unitcell,
-       hopping, onsite, @onsite!, @hopping!, parameters,
+       hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector,
        hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
        flatten, wrap, transform!, combine,
        spectrum, bandstructure, marchingmesh, linearmesh, buildmesh, buildlift,
        defaultmethod, bands, vertices,
        energies, states,
-       momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM
+       momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM,
+       greens, greensolver
 
 export LatticePresets, RegionPresets, HamiltonianPresets
 
@@ -52,6 +53,7 @@ include("mesh.jl")
 include("diagonalizer.jl")
 include("bandstructure.jl")
 include("KPM.jl")
+include("greens.jl")
 include("convert.jl")
 
 end

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -264,11 +264,11 @@ function bandstructure(h::Union{Hamiltonian,ParametricHamiltonian}, spec::MeshSp
 end
 
 function bandstructure(h::Union{Hamiltonian,ParametricHamiltonian}, mesh::Mesh;
-                       method = defaultmethod(h), lift = missing, transform = missing, kw...)
+                       method = defaultmethod(h), lift = missing, minoverlap = 0.5, transform = missing)
     # ishermitian(h) || throw(ArgumentError("Hamiltonian must be hermitian"))
     matrix = similarmatrix(h, method)
     codiag = codiagonalizer(h, matrix, mesh, lift)
-    d = DiagonalizeHelper(method, codiag; kw...)
+    d = DiagonalizeHelper(method, codiag, minoverlap)
     matrixf(ϕs) = bloch!(matrix, h, applylift(lift, ϕs))
     b = _bandstructure(matrixf, matrix, mesh, d)
     transform === missing || transform!(transform, b)
@@ -276,12 +276,12 @@ function bandstructure(h::Union{Hamiltonian,ParametricHamiltonian}, mesh::Mesh;
 end
 
 function bandstructure(matrixf::Function, mesh::Mesh;
-                       method = missing, lift = missing, minoverlap = 0.5, transform = missing, kw...)
+                       method = missing, lift = missing, minoverlap = 0.5, transform = missing)
     matrixf´ = _wraplift(matrixf, lift)
     matrix = _samplematrix(matrixf´, mesh)
     method´ = method === missing ? defaultmethod(matrix) : method
     codiag = codiagonalizer(matrixf´, matrix, mesh)
-    d = DiagonalizeHelper(method´, codiag; kw...)
+    d = DiagonalizeHelper(method´, codiag, minoverlap)
     b = _bandstructure(matrixf´, matrix, mesh, d)
     transform === missing || transform!(transform, b)
     return b

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -7,11 +7,8 @@ abstract type AbstractDiagonalizeMethod end
 struct DiagonalizeHelper{S<:AbstractDiagonalizeMethod,C}
     method::S
     codiag::C
-    minprojection::Float64
+    minoverlap::Float64
 end
-
-DiagonalizeHelper(method, codiag; minprojection = 0.5) =
-    DiagonalizeHelper(method, codiag, minprojection)
 
 ## Diagonalize methods ##
 

--- a/src/greens.jl
+++ b/src/greens.jl
@@ -1,0 +1,271 @@
+#######################################################################
+# Green's function
+#######################################################################
+abstract type GreenSolver end
+
+struct GreensFunction{S<:GreenSolver,H}
+    h::H
+    solver::S
+end
+
+"""
+    greens(h::Hamiltonian, solveobject)
+
+Construct the Green's function `g::GreensFunction` of `h` using the provided `solveobject`.
+Currently valid `solveobject`s are
+
+- the `Bandstructure` of `h` (for an unbounded `h` or an `Hamiltonian{<:Superlattice}}`)
+- the `Spectrum` of `h` (for a bounded `h`)
+
+    h |> greens(h -> solveobject(h))
+
+Curried form equivalent to the above, giving `greens(h, solveobject(h))` (see
+example below).
+
+    g([m,] ω, cells::Pair = missing)
+
+From a constructed `g::GreensFunction`, obtain the retarded Green's function
+matrix at frequency `ω` between unit cells `src` and `dst` by calling `g(ω, src
+=> dst)`, where `src, dst` are `::NTuple{L,Int}` or `SVector{L,Int}`. If
+`cells` is missing, `src` and `dst` are assumed to be zero vectors. For
+performance, one can use a preallocated matrix `m` (e.g. `m =
+similarmatrix(h)`) by calling `g(m, ω, cells)`.
+
+# Examples
+
+```jldoctest
+julia> g = LatticePresets.square() |> hamiltonian(hopping(-1)) |> greens(bandstructure(resolution = 17))
+GreensFunction{Bandstructure}: Green's function from a 2D bandstructure
+  Matrix size    : 1 × 1
+  Element type   : scalar (Complex{Float64})
+  Band simplices : 512
+
+julia> g(0.2)
+1×1 Array{Complex{Float64},2}:
+ 6.663377810046025 - 24.472789025006396im
+
+julia> m = similarmatrix(g); g(m, 0.2)
+1×1 Array{Complex{Float64},2}:
+ 6.663377810046025 - 24.472789025006396im
+```
+
+"""
+greens(h, solver) = GreensFunction(h, greensolver(solver))
+greens(solver::Function) = h -> greens(h, solver(h))
+
+# Needed to make similarmatrix work with GreensFunction
+matrixtype(g::GreensFunction) = Matrix{eltype(g.h)}
+Base.parent(g::GreensFunction) = g.h
+optimize!(g::GreensFunction) = g
+
+#######################################################################
+# BandGreenSolver
+#######################################################################
+struct SimplexData{D,E,T,C<:SMatrix,DD,SA<:SubArray}
+    ε0::T
+    εmin::T
+    εmax::T
+    k0::SVector{D,T}
+    Δks::SMatrix{D,D,T,DD}     # k - k0 = Δks * z
+    volume::T
+    zvelocity::SVector{D,T}
+    edgecoeffs::NTuple{E,Tuple{T,C}} # s*det(Λ)/w.w and Λc for each edge
+    dωzs::NTuple{E,NTuple{2,SVector{D,T}}}
+    defaultdη::SVector{D,T}
+    φ0::SA
+    φs::NTuple{D,SA}
+end
+
+struct BandGreenSolver{P<:SimplexData,E} <: GreenSolver
+    simplexdata::Vector{P}
+    indsedges::NTuple{E,Tuple{Int,Int}} # all distinct pairs of 1:V, where V=D+1=num verts
+end
+
+function Base.show(io::IO, g::GreensFunction{<:BandGreenSolver})
+    print(io, summary(g), "\n",
+"  Matrix size    : $(size(g.h, 1)) × $(size(g.h, 2))
+  Element type   : $(displayelements(g.h))
+  Band simplices : $(length(g.solver.simplexdata))")
+end
+
+Base.summary(g::GreensFunction{<:BandGreenSolver}) =
+    "GreensFunction{Bandstructure}: Green's function from a $(latdim(g.h))D bandstructure"
+
+function greensolver(b::Bandstructure{D}) where {D}
+    V = D + 1
+    indsedges = tuplepairs(Val(D+1)) # not inferred for D>2
+    v = [SimplexData(simplex, band, indsedges) for band in bands(b) for simplex in band.simplices]
+    return BandGreenSolver(v,  indsedges)
+end
+
+edges_per_simplex(L) = binomial(L,2)
+
+function SimplexData(simplex::NTuple{V}, band, indsedges) where {V}
+    D = V - 1
+    vs = ntuple(i -> vertices(band)[simplex[i]], Val(V))
+    ks = ntuple(i -> SVector(Base.front(Tuple(vs[i]))), Val(V))
+    εs = ntuple(i -> last(vs[i]), Val(V))
+    εmin, εmax = extrema(εs)
+    ε0 = first(εs)
+    k0 = first(ks)
+    Δks = hcat(tuple_diff_first(ks)...)
+    zvelocity = SVector(tuple_diff_first(εs))
+    volume = abs(det(Δks))
+    edgecoeffs = edgecoeff.(indsedges, Ref(zvelocity))
+    dωzs = sectionpoint.(indsedges, Ref(zvelocity))
+    defaultdη = dummydη(zvelocity)
+    φ0 = vertexstate(first(simplex), band)
+    φs = vertexstate.(Base.tail(simplex), Ref(band))
+    return SimplexData(ε0, εmin, εmax, k0, Δks, volume, zvelocity, edgecoeffs, dωzs, defaultdη, φ0, φs)
+end
+
+# Base.tail(t) .- first(t) but avoiding rounding errors in difference
+tuple_diff_first(t::Tuple{T,Vararg{T,D}}) where {D,T} =
+    ntuple(i -> ifelse(t[i+1] ≈ t[1], zero(T), t[i+1] - t[1]), Val(D))
+
+function edgecoeff(indsedge, zvelocity::SVector{D}) where {D}
+    basis = edgebasis(indsedge, Val(D))
+    othervecs = Base.tail(basis)
+    edgevec = first(basis)
+    cutvecs = (v -> dot(zvelocity, edgevec) * v - dot(zvelocity, v) * edgevec).(othervecs)
+    Λc = hcat(cutvecs...)
+    Λ = hcat(zvelocity, Λc)
+    s = sign(det(hcat(basis...)))
+    coeff = s * (det(Λ)/dot(zvelocity, zvelocity))
+    return coeff, Λc
+end
+
+function edgebasis(indsedge, ::Val{D}) where {D}
+    inds = ntuple(identity, Val(D+1))
+    swappedinds = tupleswapfront(inds, indsedge) # places the two edge vertindices first
+    zverts = (i->unitvector(SVector{D,Int}, i-1)).(swappedinds)
+    basis = (z -> z - first(zverts)).(Base.tail(zverts)) # first of basis is edge vector
+    return basis
+end
+
+function sectionpoint((i, j), zvelocity::SVector{D,T}) where {D,T}
+    z0, z1 = unitvector(SVector{D,Int}, i-1), unitvector(SVector{D,Int}, j-1)
+    z10 = z1 - z0
+    # avoid numerical cancellation errors due to zvelocity perpendicular to edge
+    d = chop(dot(zvelocity, z10), maximum(abs.(zvelocity)))
+    dzdω = z10 / d
+    dz0 = z0 - z10 * dot(zvelocity, z0) / d
+    return dzdω, dz0   # The section z is dω * dzdω + dz0
+end
+
+# A vector, not parallel to zvelocity, and with all nonzero components and none equal
+function dummydη(zvelocity::SVector{D,T}) where {D,T}
+    (D == 1 || iszero(zvelocity)) && return SVector(ntuple(i->T(i), Val(D)))
+    rng = MersenneTwister(0)
+    while true
+        dη = rand(rng, SVector{D,T})
+        isparallel = dot(dη, zvelocity)^2 ≈ dot(zvelocity, zvelocity) * dot(dη, dη)
+        isvalid = allunique(dη) && !isparallel
+        isvalid && return dη
+    end
+    throw(error("Unexpected error finding dummy dη"))
+end
+
+function vertexstate(ind, band)
+    ϕind = 1 + band.dimstates*(ind - 1)
+    state = view(band.states, ϕind:(ϕind+band.dimstates-1))
+    return state
+end
+
+## Call API
+
+(g::GreensFunction{<:BandGreenSolver})(ω::Number, cells = missing) = g(similarmatrix(g), ω, cells)
+
+function (g::GreensFunction{<:BandGreenSolver})(matrix::AbstractMatrix, ω::Number, cells = missing)
+    fill!(matrix, zero(eltype(matrix)))
+    cells´ = sanitize_dn(cells, g.h)
+    for simplexdata in g.solver.simplexdata
+        g0, gjs = green_simplex(ω, cells´, simplexdata, g.solver.indsedges)
+        addsimplex!(matrix, g0, gjs, simplexdata)
+    end
+    return matrix
+end
+
+sanitize_dn((src, dst)::Pair, ::Hamiltonian{LA,L}) where {LA,L} =
+    SVector{L}(dst) - SVector{L}(src)
+
+sanitize_dn(::Missing, ::Hamiltonian{LA,L}) where {LA,L} =
+    zero(SVector{L,Int})
+
+function green_simplex(ω, dn, data::SimplexData{L}, indsedges) where {L}
+    dη = data.Δks' * dn
+    phase = cis(dot(dn, data.k0))
+    dω = ω - data.ε0
+    gz = simplexterm.(dω, Ref(dη), Ref(data), data.edgecoeffs, data.dωzs, indsedges)
+    g0z, gjz = first.(gz), last.(gz)
+    g0 = im^(L-1) * phase * sum(g0z)
+    gj = -im^L * phase * sum(gjz)
+    return g0, gj
+end
+
+function simplexterm(dω, dη::SVector{D,T}, data, coeffs, (dzdω, dz0), (i, j)) where {D,T}
+    bailout = Complex(zero(T)), Complex.(zero(dη))
+    z = dω * dzdω + dz0
+    # Edges with divergent sections do not contribute
+    all(isfinite, z) || return bailout
+    z0 = unitvector(SVector{D,T},i-1)
+    z1 = unitvector(SVector{D,T},j-1)
+    coeff, Λc = coeffs
+    # If dη is zero (DOS) use a precomputed (non-problematic) simplex-constant vector
+    dη´ = iszero(dη) ? data.defaultdη : dη
+    d = dot(dη´, z)
+    d0 = dot(dη´, z0)
+    d1 = dot(dη´, z1)
+    # Skip if singularity in formula
+    (d ≈ d0 || d ≈ d1) && return bailout
+    s = sign(dot(dη´, dzdω))
+    coeff0 = coeff / prod(Λc' * dη´)
+    coeffj = isempty(Λc) ? zero(dη) : (Λc ./ ((dη´)' * Λc)) * sumvec(Λc)
+    params = s, d, d0, d1
+    zs = z, z0, z1
+    g0z = iszero(dη) ? g0z_asymptotic(D, coeff0, params) : g0z_general(coeff0, params)
+    gjz = iszero(dη) ? gjz_asymptotic(D, g0z, coeffj, coeff0, zs, params) :
+                       gjz_general(g0z, coeffj, coeff0, zs, params)
+    return g0z, gjz
+end
+
+sumvec(::SMatrix{N,M,T}) where {N,M,T} = SVector(ntuple(_->one(T),Val(M)))
+
+g0z_general(coeff0, (s, d, d0, d1)) =
+    coeff0 * cis(d) * ((cosint_c(-s*(d0-d)) + im*sinint(d0-d)) - (cosint_c(-s*(d1-d)) + im*sinint(d1-d)))
+
+gjz_general(g0z, coeffj, coeff0, (z, z0, z1), (s, d, d0, d1)) =
+    g0z * (im * z - coeffj) + coeff0 * ((z0-z) * cis(d0) / (d0-d) - (z1-z) * cis(d1) / (d1-d))
+
+g0z_asymptotic(D, coeff0, (s, d, d0, d1)) =
+    coeff0 * (cosint_a(-s*(d0-d)) - cosint_a(-s*(d1-d))) * (im*d)^(D-1)/factorial(D-1)
+
+function gjz_asymptotic(D, g0z, coeffj, coeff0, (z, z0, z1), (s, d, d0, d1))
+    g0z´ = g0z
+    for n in 1:(D-1)
+        g0z´ += coeff0 * im^n * (im*d)^(D-1-n)/factorial(D-1-n) *
+                ((d0-d)^n - (d1-d)^n)/(n*factorial(n))
+    end
+    gjz = g0z´ * (im * z - im * coeffj * d / D) +
+        coeff0 * ((z0-z) * (im*d0)^D / (d0-d) - (z1-z) * (im*d1)^D / (d1-d)) / factorial(D)
+    return gjz
+end
+
+cosint_c(x::Real) = ifelse(iszero(abs(x)), zero(x), cosint(abs(x))) + im*pi*(x<=0)
+
+cosint_a(x::Real) = ifelse(iszero(abs(x)), zero(x), log(abs(x))) + im*pi*(x<=0)
+
+function addsimplex!(matrix, g0, gjs, simplexdata)
+    φ0 = simplexdata.φ0
+    φs = simplexdata.φs
+    vol = simplexdata.volume
+    for c in CartesianIndices(matrix)
+        (row, col) = Tuple(c)
+        x = g0 * (φ0[row] * φ0[col]')
+        for (φ, gj) in zip(φs, gjs)
+            x += (φ[row]*φ[col]' - φ0[row]*φ0[col]') * gj
+        end
+        matrix[row, col] += vol * x
+    end
+    return matrix
+end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -212,7 +212,7 @@ where `T` is the number type of `lat`.
 
     lat |> hamiltonian(model; kw...)
 
-Functional `hamiltonian` form equivalent to `hamiltonian(lat, model[, funcmodel]; kw...)`.
+Curried form of `hamiltonian` equivalent to `hamiltonian(lat, model[, funcmodel]; kw...)`.
 
 # Indexing
 
@@ -736,7 +736,7 @@ flux Φ through the loop, if `factor = exp(im * 2π * Φ/Φ₀)`.
 
     h |> wrap(axis; kw...)
 
-Functional form equivalent to `wrap(h, axis; kw...)`.
+Curried form equivalent to `wrap(h, axis; kw...)`.
 
 # Examples
 
@@ -821,7 +821,7 @@ end
 """
     similarmatrix(h::Hamiltonian)
 
-Create an uninitialized matrix of the same type and size    of the Hamiltonian's matrix,
+Create an uninitialized matrix of the same type and size of the Hamiltonian's matrix,
 calling `optimize!(h)` first to produce an optimal work matrix in the sparse case.
 
     similarmatrix(h::Hamiltonian, T::Type{<:AbstractMatrix})
@@ -831,6 +831,10 @@ Specifies the desired type `T` of the uninitialized matrix.
     similarmatrix(h::Hamiltonian, method::AbstractDiagonalizeMethod)
 
 Adapts the type of the matrix (e.g. dense/sparse) to the specified `method`
+
+    similarmatrix(x::Union{ParametricHamiltonian, GreensFunction}, ...)
+
+Equivalent to the above, but adapted to the more general type of `x`.
 """
 function similarmatrix(h, ::Type{A´} = matrixtype(h)) where {A´<:AbstractMatrix}
     optimize!(h)
@@ -944,7 +948,7 @@ Same as above, but with `pϕs = (p₁,...,pᵢ, ϕ₁, ..., ϕⱼ)`, with `p` va
 
     h |> bloch(ϕs, ...)
 
-Functional forms of `bloch`, equivalent to `bloch(h, ϕs, ...)`
+Curried forms of `bloch`, equivalent to `bloch(h, ϕs, ...)`
 
 # Notes
 
@@ -1187,7 +1191,7 @@ hopping/onsite matrices are preserved as structural zeros upon flattening.
 
     h |> flatten()
 
-Functional form equivalent to `flatten(h)` of `h |> flatten` (included for consistency with
+Curried form equivalent to `flatten(h)` of `h |> flatten` (included for consistency with
 the rest of the API).
 
 # Examples

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -608,7 +608,7 @@ with factors along the diagonal)
 
     lat |> supercell(v...; kw...)
 
-Functional syntax, equivalent to `supercell(lat, v...; kw...)
+Curried syntax, equivalent to `supercell(lat, v...; kw...)
 
     supercell(h::Hamiltonian, v...; kw...)
 
@@ -814,7 +814,7 @@ the first time.
 
     lat_or_h |> unitcell(v...; kw...)
 
-Functional syntax, equivalent to `unitcell(lat_or_h, v...; kw...)
+Curried syntax, equivalent to `unitcell(lat_or_h, v...; kw...)
 
 # Examples
 

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -53,6 +53,8 @@ function minmax_edge(m::Mesh{D,T}) where {D,T<:Real}
     return minedge, maxedge
 end
 
+transform!(f::Function, m::Mesh) = (map!(f, vertices(m), vertices(m)); m)
+
 ######################################################################
 # Compute N-simplices (N = number of vertices)
 ######################################################################
@@ -86,15 +88,13 @@ function _simplices(buffer::Tuple{P,P,V}, mesh, src) where {N,P<:AbstractArray{<
             for edge in edges(mesh, nextsrc)
                 dest = edgedest(mesh, edge)
                 dest > nextsrc || continue # If not directed, no need to check
-                dest in srcneighs && push!(partials´, modifyat(partial, pass, dest))
+                dest in srcneighs && push!(partials´, tuplesplice(partial, pass, dest))
             end
         end
         partials, partials´ = partials´, partials
     end
     return partials
 end
-
-modifyat(s::NTuple{N,T}, ind, el) where {N,T} = ntuple(i -> i === ind ? el : s[i], Val(N))
 
 function alignnormals!(simplices, vertices)
     for (i, s) in enumerate(simplices)

--- a/src/model.jl
+++ b/src/model.jl
@@ -574,12 +574,12 @@ include any parameters that `body` depends on that the user may want to tune.
 """
 macro onsite!(kw, f)
     f, N, params = get_f_N_params(f, "Only @onsite!(args -> body; kw...) syntax supported")
-    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.onsiteselector($kw))))
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.siteselector($kw))))
 end
 
 macro onsite!(f)
     f, N, params = get_f_N_params(f, "Only @onsite!(args -> body; kw...) syntax supported")
-    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.onsiteselector())))
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.siteselector())))
 end
 
 """
@@ -596,12 +596,12 @@ and include any parameters that `body` depends on that the user may want to tune
 """
 macro hopping!(kw, f)
     f, N, params = get_f_N_params(f, "Only @hopping!(args -> body; kw...) syntax supported")
-    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.hoppingselector($kw))))
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.hopselector($kw))))
 end
 
 macro hopping!(f)
     f, N, params = get_f_N_params(f, "Only @hopping!(args -> body; kw...) syntax supported")
-    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.hoppingselector())))
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(Val(params))), Quantica.hopselector())))
 end
 
 # Extracts normalized f, number of arguments and kwarg names from an anonymous function f

--- a/src/model.jl
+++ b/src/model.jl
@@ -3,23 +3,55 @@
 #######################################################################
 abstract type Selector{M,S} end
 
-struct OnsiteSelector{M,S} <: Selector{M,S}
+struct SiteSelector{M,S} <: Selector{M,S}
     region::M
     sublats::S  # NTuple{N,NameType} (unresolved) or Vector{Int} (resolved on a lattice)
 end
 
-struct HoppingSelector{M,S,D,T} <: Selector{M,S}
+struct HopSelector{M,S,D,T} <: Selector{M,S}
     region::M
     sublats::S  # NTuple{N,Pair{NameType,NameType}} (unres) or Vector{Pair{Int,Int}} (res)
     dns::D
     range::T
 end
 
-onsiteselector(; region = missing, sublats = missing) =
-    OnsiteSelector(region, sanitize_sublats(sublats))
+"""
+    siteselector(; region = missing, sublats = missing)
 
-hoppingselector(; region = missing, sublats = missing, dn = missing, range = missing) =
-    HoppingSelector(region, sanitize_sublatpairs(sublats), sanitize_dn(dn), sanitize_range(range))
+Return a `SiteSelector` object that can be used to select sites in a lattice contained
+within the specified region and sublattices. Only sites at position `r` in sublattice with
+name `s::NameType` will be selected if `region(r) && s in sublats` is true. Any missing
+`region` or `sublat` will not be used to constraint the selection.
+
+The keyword `sublats` allows the following formats:
+
+    sublats = :A           # Onsite on sublat :A only
+    sublats = (:A,)        # Same as above
+    sublats = (:A, :B)     # Onsite on sublat :A and :B
+"""
+siteselector(; region = missing, sublats = missing) =
+    SiteSelector(region, sanitize_sublats(sublats))
+
+"""
+    hopselector(; region = missing, sublats = missing, dn = missing, range = missing)
+
+Return a `HopSelector` object that can be used to select hops between two sites in a
+lattice. Only hops between two sites at positions `r₁ = r - dr/2` and `r₂ = r + dr`,
+belonging to unit cells at integer distance `dn´` and to sublattices `s₁` and `s₂` will be
+selected if: `region(r, dr) && s in sublats && dn´ in dn && norm(dr) <= range`. If any of
+these is `missing` it will not be used to constraint the selection.
+
+The keyword `dn` can be a `Tuple`/`Vector`/`SVector` of `Int`s, or a tuple thereof. The
+keyword `sublats` allows the following formats:
+
+    sublats = :A => :B                 # Hopping from :A to :B sublattices
+    sublats = (:A => :B,)              # Same as above
+    sublats = (:A => :B, :C => :D)     # Hopping from :A to :B or :C to :D
+    sublats = (:A, :C) .=> (:B, :D)    # Broadcasted pairs, same as above
+    sublats = (:A, :C) => (:B, :D)     # Direct product, (:A=>:B, :A=:D, :C=>:B, :C=>D)
+"""
+hopselector(; region = missing, sublats = missing, dn = missing, range = missing) =
+    HopSelector(region, sanitize_sublatpairs(sublats), sanitize_dn(dn), sanitize_range(range))
 
 sanitize_sublats(s::Missing) = missing
 sanitize_sublats(s::Integer) = (nametype(s),)
@@ -51,9 +83,9 @@ _sanitize_dn(dn::Vector) = SVector{length(dn),Int}(dn)
 sanitize_range(::Missing) = missing
 sanitize_range(range::Real) = isfinite(range) ? float(range) + sqrt(eps(float(range))) : float(range)
 
-sublats(s::OnsiteSelector{<:Any,Missing}, lat::AbstractLattice) = collect(1:nsublats(lat))
+sublats(lat::AbstractLattice, s::SiteSelector{<:Any,Missing}) = collect(1:nsublats(lat))
 
-function sublats(s::OnsiteSelector{<:Any,<:Tuple}, lat::AbstractLattice)
+function sublats(lat::AbstractLattice, s::SiteSelector{<:Any,<:Tuple})
     names = lat.unitcell.names
     ss = Int[]
     for name in s.sublats
@@ -63,7 +95,7 @@ function sublats(s::OnsiteSelector{<:Any,<:Tuple}, lat::AbstractLattice)
     return ss
 end
 
-function sublats(s::HoppingSelector{<:Any,<:Tuple}, lat::AbstractLattice)
+function sublats(lat::AbstractLattice, s::HopSelector{<:Any,<:Tuple})
     names = lat.unitcell.names
     ss = Pair{Int,Int}[]
     for (nsrc, ndst) in s.sublats
@@ -74,17 +106,17 @@ function sublats(s::HoppingSelector{<:Any,<:Tuple}, lat::AbstractLattice)
     return ss
 end
 
-sublats(s::HoppingSelector{<:Any,Missing}, lat::AbstractLattice) =
+sublats(lat::AbstractLattice, s::HopSelector{<:Any,Missing}) =
     tupletopair.(vec(collect(Iterators.product(1:nsublats(lat), 1:nsublats(lat)))))
 
 # selector already resolved for a lattice
-sublats(s::Selector{<:Any,<:Vector}, lat) = s.sublats
+sublats(lat, s::Selector{<:Any,<:Vector}) = s.sublats
 
 # API
 
-resolve(s::HoppingSelector, lat::AbstractLattice) =
-    HoppingSelector(s.region, sublats(s, lat), _checkdims(s.dns, lat), s.range)
-resolve(s::OnsiteSelector, lat::AbstractLattice) = OnsiteSelector(s.region, sublats(s, lat))
+resolve(s::HopSelector, lat::AbstractLattice) =
+    HopSelector(s.region, sublats(lat, s), _checkdims(s.dns, lat), s.range)
+resolve(s::SiteSelector, lat::AbstractLattice) = SiteSelector(s.region, sublats(lat, s))
 
 _checkdims(dns::Missing, lat::AbstractLattice{E,L}) where {E,L} = dns
 _checkdims(dns::Tuple{Vararg{SVector{L,Int}}}, lat::AbstractLattice{E,L}) where {E,L} = dns
@@ -92,16 +124,18 @@ _checkdims(dns, lat::AbstractLattice{E,L}) where {E,L} =
     throw(DimensionMismatch("Specified cell distance `dn` does not match lattice dimension $L"))
 
 # are sites at (i,j) and (dni, dnj) or (dn, 0) selected?
-(s::OnsiteSelector)(lat::AbstractLattice, (i, j)::Tuple, (dni, dnj)::Tuple{SVector, SVector}) =
+(s::SiteSelector)(lat::AbstractLattice, (i, j)::Tuple, (dni, dnj)::Tuple{SVector, SVector}) =
     isonsite((i, j), (dni, dnj)) && isinregion(i, dni, s.region, lat) && isinsublats(sublat(lat, i), s.sublats)
 
-(s::HoppingSelector)(lat::AbstractLattice, inds, dns) =
+(s::HopSelector)(lat::AbstractLattice, inds, dns) =
     !isonsite(inds, dns) && isinregion(inds, dns, s.region, lat) && isindns(dns, s.dns) &&
     isinrange(inds, s.range, lat) && isinsublats(tupletopair(sublat.(Ref(lat), inds)), s.sublats)
 
 isonsite((i, j), (dni, dnj)) = i == j && dni == dnj
 
+isinregion(i::Int, ::Missing, lat) = true
 isinregion(i::Int, dn, ::Missing, lat) = true
+isinregion(i::Int, region::Function, lat) = region(sites(lat)[i])
 isinregion(i::Int, dn, region::Function, lat) = region(sites(lat)[i] + bravais(lat) * dn)
 
 isinregion(is::Tuple{Int,Int}, dns, ::Missing, lat) = true
@@ -129,26 +163,26 @@ isinrange((row, col)::Tuple{Int,Int}, range::Number, lat) =
     norm(sites(lat)[col] - sites(lat)[row]) <= range
 
 # merge non-missing fields of s´ into s
-merge_non_missing(s::OnsiteSelector, s´::OnsiteSelector) =
-    OnsiteSelector(merge_non_missing.(
+merge_non_missing(s::SiteSelector, s´::SiteSelector) =
+    SiteSelector(merge_non_missing.(
         (s.region,  s.sublats),
         (s´.region, s´.sublats))...)
-merge_non_missing(s::HoppingSelector, s´::HoppingSelector) =
-    HoppingSelector(merge_non_missing.(
+merge_non_missing(s::HopSelector, s´::HopSelector) =
+    HopSelector(merge_non_missing.(
         (s.region,  s.sublats,  s.dns,  s.range),
         (s´.region, s´.sublats, s´.dns, s´.range))...)
 merge_non_missing(o, o´::Missing) = o
 merge_non_missing(o, o´) = o´
 
-Base.adjoint(s::OnsiteSelector) = s
-function Base.adjoint(s::HoppingSelector)
+Base.adjoint(s::SiteSelector) = s
+function Base.adjoint(s::HopSelector)
     # is_unconstrained_selector(s) &&
     #     @warn("Taking the adjoint of an unconstrained hopping is likely unintended")
     region´ = _adjoint(s.region)
     sublats´ = _adjoint.(s.sublats)
     dns´ = _adjoint.(s.dns)
     range = s.range
-    return HoppingSelector(region´, sublats´, dns´, range)
+    return HopSelector(region´, sublats´, dns´, range)
 end
 
 _adjoint(::Missing) = missing
@@ -156,8 +190,8 @@ _adjoint(f::Function) = (r, dr) -> f(r, -dr)
 _adjoint(t::Pair) = reverse(t)
 _adjoint(t::SVector) = -t
 
-# is_unconstrained_selector(s::HoppingSelector{Missing,Missing,Missing}) = true
-# is_unconstrained_selector(s::HoppingSelector) = false
+# is_unconstrained_selector(s::HopSelector{Missing,Missing,Missing}) = true
+# is_unconstrained_selector(s::HopSelector) = false
 
 #######################################################################
 # Tightbinding types
@@ -170,13 +204,13 @@ struct TightbindingModel{N,T<:Tuple{Vararg{TightbindingModelTerm,N}}}
     terms::T
 end
 
-struct OnsiteTerm{F,S<:OnsiteSelector,C} <: AbstractOnsiteTerm
+struct OnsiteTerm{F,S<:SiteSelector,C} <: AbstractOnsiteTerm
     o::F
     selector::S
     coefficient::C
 end
 
-struct HoppingTerm{F,S<:HoppingSelector,C} <: AbstractHoppingTerm
+struct HoppingTerm{F,S<:HopSelector,C} <: AbstractHoppingTerm
     t::F
     selector::S
     coefficient::C
@@ -209,19 +243,19 @@ end
 #######################################################################
 # TightbindingModelTerm API
 #######################################################################
-OnsiteTerm(t::OnsiteTerm, os::OnsiteSelector) =
+OnsiteTerm(t::OnsiteTerm, os::SiteSelector) =
     OnsiteTerm(t.o, os, t.coefficient)
 
 (o::OnsiteTerm{<:Function})(r,dr) = o.coefficient * o.o(r)
 (o::OnsiteTerm)(r,dr) = o.coefficient * o.o
 
-HoppingTerm(t::HoppingTerm, os::HoppingSelector) =
+HoppingTerm(t::HoppingTerm, os::HopSelector) =
     HoppingTerm(t.t, os, t.coefficient)
 
 (h::HoppingTerm{<:Function})(r, dr) = h.coefficient * h.t(r, dr)
 (h::HoppingTerm)(r, dr) = h.coefficient * h.t
 
-sublats(t::TightbindingModelTerm, lat) = sublats(t.selector, lat)
+sublats(t::TightbindingModelTerm, lat) = sublats(lat, t.selector)
 
 sublats(m::TightbindingModel) = (t -> t.selector.sublats).(terms(m))
 
@@ -269,9 +303,9 @@ applied to all such terms.
 
 # Keyword arguments
 
-Only sites at position `r` in sublattice with name `s::NameType` will be selected if
-`region(r) && s in sublats` is true. Any missing `region` or `sublat` will not be used to
-constraint the selection.
+Keywords are the same as for `siteselector`. Only sites at position `r` in sublattice with
+name `s::NameType` will be selected if `region(r) && s in sublats` is true. Any missing
+`region` or `sublat` will not be used to constraint the selection.
 
 The keyword `sublats` allows the following formats:
 
@@ -324,7 +358,7 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
 # See also:
     `hopping`
 """
-onsite(o; kw...) = onsite(o, onsiteselector(; kw...))
+onsite(o; kw...) = onsite(o, siteselector(; kw...))
 
 onsite(o, selector::Selector) = TightbindingModel(OnsiteTerm(o, selector, 1))
 
@@ -364,11 +398,11 @@ applied to all such terms.
 
 # Keyword arguments
 
-Only hoppings between two sites at positions `r₁ = r - dr/2` and `r₂ = r + dr`, belonging to
-unit cells at integer distance `dn´` and to sublattices `s₁` and `s₂` will be selected if:
-`region(r, dr) && s in sublats && dn´ in dn && norm(dr) <= range`. If any of these is
-`missing` it will not be used to constraint the selection. Note that the default `range` is
-1, not `missing`.
+Most keywords are the same as for `hopselector`. Only hoppings between two sites at
+positions `r₁ = r - dr/2` and `r₂ = r + dr`, belonging to unit cells at integer distance
+`dn´` and to sublattices `s₁` and `s₂` will be selected if: `region(r, dr) && s in sublats
+&& dn´ in dn && norm(dr) <= range`. If any of these is `missing` it will not be used to
+constraint the selection. Note that the default `range` is 1, not `missing`.
 
 The keyword `dn` can be a `Tuple`/`Vector`/`SVector` of `Int`s, or a tuple thereof. The
 keyword `sublats` allows the following formats:
@@ -429,7 +463,7 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
     `onsite`
 """
 function hopping(t; plusadjoint = false, range = 1, kw...)
-    hop = hopping(t, hoppingselector(; range = range, kw...))
+    hop = hopping(t, hopselector(; range = range, kw...))
     return plusadjoint ? hop + hop' : hop
 end
 hopping(t, selector) = TightbindingModel(HoppingTerm(t, selector, 1))

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -1,0 +1,9 @@
+using LinearAlgebra: tr
+
+@testset "basic green's function" begin
+    g = LatticePresets.square() |> hamiltonian(hopping(-1)) |> unitcell((2,0), (0,1)) |>
+        greens(bandstructure(resolution = 17))
+    @test g(0.2) ≈ transpose(g(0.2))
+    @test imag(tr(g(1))) < 0
+    @test Quantica.chop(imag(tr(g(5)))) == 0
+end


### PR DESCRIPTION
This PR implements our first solver for Green's functions. It takes the bandstructure of a periodic Hamiltonian in arbitrary dimensions `L` and constructs a `GreensFunction{<:BandGreenSolver}` object that can be used to generate the Green's function matrix of the Hamiltonian between two arbitrary unit cells.

The method is a generalization to arbitrary dimensions and unit cell distance of the classical tetrahedron method, which takes a linearization of a dispersion and eigenstates within a tetrahedron and integrates the resolvent on it it analytically. Each simplex in each band in the bandstructure is one such tetrahedron. The analytical solution used here is not published, but it is ultimately a form of the solution given in https://iopscience.iop.org/article/10.1088/0022-3719/15/34/009 but in arbitrary dimension. It also includes special formulae for the local limit (source and destination unit cells are the same), which is a useful case for local/global density of states.

The method, as implemented here,  has some ill-defined corner cases (in particular when the cell distance and group velocity become parallel in a simplex). The WIP tag is due to this. I'll try to iron out those cases soon.

The API is as follows. One build a Hamiltonian `h`, its bandstructure `b = bandstructure(h,...)`, and from that the Green's function object `g = greens(h, b)`. Then, one evaluates `g` at a given energy `ω` with `g(ω, cell1 => cell2)`, where `cell1, cell2` are integer Tuples or SVectors for the cells. If omitted they are zero. Optionally, we can preallocate a matrix to use, which gives a (typically small) performance boost: `m = similarmatrix(g); g(m, ω, cell1 => cell2)`.

The bottom line is that we now have a possible API for Green's functions that can be extended with more solvers. The simplex solver, moreover, is surprisingly performant and useful. It can yield the density of states very efficiently, for example. The code below uses a fine mesh for the bandstructure. The evaluation time scales linearly with the number of simplices in the bandstructure mesh.
```
julia> using LinearAlgebra, BenchmarkTools, Plots

julia> g = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range=1/√3)) |> greens(bandstructure(resolution = 103))
GreensFunction{Bandstructure}: Green's function from a 2D bandstructure
  Matrix size    : 2 × 2
  Element type   : scalar (Complex{Float64})
  Band simplices : 41608

julia> @btime g(0.5)
  16.262 ms (1 allocation: 144 bytes)
2×2 Array{Complex{Float64},2}:
 0.0546674-12.5321im   -13.3817+7.59403im
  -13.3817-11.7714im  0.0546674-12.5321im

julia> m = similarmatrix(g); 

julia> @time dos = [(w, -imag(tr(g(m, w)))) for w in range(-4,4,length=202)];
  3.485024 seconds (58.72 k allocations: 2.998 MiB)

julia> plot(dos, marker = 2)
```
![image](https://user-images.githubusercontent.com/4310809/82568771-9ae3e580-9b7f-11ea-82f0-5e88c19b308c.png)

A very interesting observation of the above is the lack of exact particle-hole symmetry. The reason is unrelated to this PR, but rather to the problem of finding a full meshing of bands with Dirac points (as is the case in the above example) without punching holes into it, see this zoom of `b`

![image](https://user-images.githubusercontent.com/4310809/82570544-062eb700-9b82-11ea-8438-ad7acd594fb4.png)

These holes spoil the symmetry of the resulting `g`, and also the linear DOS precisely at the Dirac point. A rough solution is to open small gaps in the Dirac points, but that creates a fast variation of dispersion and states within the Dirac point simplices and does not solve the problem completely. A proper solution could be to do point-splitting at topological defects in bandstructures (in the future roadmap).

EDIT: there is a valid question of why a single missing simplex close to zero energy can spoil the symmetry of the DOS at higher energy. I don't yet know the answer. It might have to do with the structure of the tetrahedron formula. The fact is that if  I patch up the hole (opening a gap, for example), I immediately recover the symmetry.