### PR TITLE
Multithread processing in KPM

### DIFF
--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -109,10 +109,10 @@ function addmomentaKPM!(b::KPMBuilder{<:AbstractMatrix,<:AbstractSparseMatrix}, 
     fill!(ket0, zero(eltype(ket0)))
     mul!(ket1, A´, ket)
     μlist[1] += proj(ket1, ket)
-    #ProgressMeter.next!(pmeter; showvalues = ())
+    ProgressMeter.next!(pmeter; showvalues = ())
     for n in 2:(order+1)
-            #ProgressMeter.next!(pmeter; showvalues = ())
-            μ = iterateKPM!(ket0, ket1, ket, h´, bandbracket)
+        ProgressMeter.next!(pmeter; showvalues = ())
+        μ = iterateKPM!(ket0, ket1, ket, h´, bandbracket)
         μlist[n] += μ
         n + 1 > order + 1 && break
         ket0, ket1 = ket1, ket0


### PR DESCRIPTION
The aim of this PR is to enhance the performance of the Kernel Polynomial Method (KPM) momenta calculation already built on KPM.jl, by using the recently implemented multithreading approach available on julia v1.3+ (see #https://julialang.org/blog/2019/07/multithreading/). 

The calculation of KPM momenta doesn't allow for an easy parallelisation scheme due to the sequential nature of the momentum generator algorithm. Although this might suggest that the parallelisation at this level is not a viable option, it is indeed possible to distribute on multiple threads the matrix operations for each step of the momenta calculation (see `iterateKPM()`). Typically, the overhead of distributing tasks over all available threads N times (being N the order of the KPM expansion) leads to a significant fraction of the total resource consumption, which favours serial over parallel processing. However, this might not be the case when dealing with large systems when lots of random vectors are required. 

In this situation the global calculation can benefit from a multithread processing with negligible overhead. We can see this in the following system size (D) vs time graph: the blue dots are computed using the multithreaded strategy built in this PR over 4 threads, whereas those in orange refer to an external (higher level) distribution on 4 different cores.

![image](https://user-images.githubusercontent.com/49433311/84573869-6a205600-ada3-11ea-8d3c-2428f9e41235.png)

Multithreading over multicore distribution is preferable as memory allocation is largely reduced in the former since the system constructor variables are shared and, thus, allocated only once. 

**Important remark:** Even for large systems a small D/N ratio might favour multi-core distribution over multithreading. This has been taken into account since this PR is compatible with the multicore parallelisation at a higher level as noted by @pablosanjose. 

**Usage**

By default the number of Julia threads is set to 1 so in order to benefit from this multithreading scheme it is required to set the desired number of julia threads x. This is done setting the following environment variable: `JULIA_NUM_THREADS=x ./julia`.

 