### PR TITLE
Fix broken KPM scalar optimization, use 5-arg mul! instead

### DIFF
--- a/test/test_KPM.jl
+++ b/test/test_KPM.jl
@@ -1,0 +1,9 @@
+using ArnoldiMethod, Random, FFTW
+
+@testset "basic KPM" begin
+    h = LatticePresets.honeycomb() |>
+        hamiltonian(hopping(-1, range = 1/sqrt(3))) |>
+        unitcell(region = RegionPresets.circle(10))
+    dos = dosKPM(h, order = 10, bandrange = (-3,3))
+    @test all(ρ -> ρ > 0, last(dos))
+end

--- a/test/test_KPM.jl
+++ b/test/test_KPM.jl
@@ -5,5 +5,5 @@ using ArnoldiMethod, Random, FFTW
         hamiltonian(hopping(-1, range = 1/sqrt(3))) |>
         unitcell(region = RegionPresets.circle(10))
     dos = dosKPM(h, order = 10, bandrange = (-3,3))
-    @test all(ρ -> ρ > 0, last(dos))
+    @test all(ρ -> 0 < ρ < 10, last(dos))
 end


### PR DESCRIPTION
The clever scalar version of the KPM iteration inherited from Elsa was broken. Since Julia 1.3 we have 5-argument `mul!` that implements a similar scalar algorithm. It is also multithreaded to boot. This PR uses such facility, and fixes KPM in the process (I used the computation in https://discourse.julialang.org/t/kernel-polynomial-method/34240/3 as reference). A side effect is that the code is again much clearer and closer to the original algorithm.