### PR TITLE
Postlifts: mapping scalar mesh vertices to arbitrary hamiltonian parameters

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -273,7 +273,7 @@ _samplematrix(matrixf, mesh) = matrixf(Tuple(first(vertices(mesh))))
 _wraplift(matrixf, lift::Missing) = matrixf
 _wraplift(matrixf, lift) = ϕs -> matrixf(applylift(lift, ϕs))
 
-@inline applylift(lift::Missing, ϕs) = ϕs
+@inline applylift(lift::Missing, ϕs) = Tuple(ϕs)
 
 @inline applylift(lift::Function, ϕs) = lift(Tuple(ϕs)...)
 

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -241,15 +241,7 @@ function _directions(::Val{L}; direlements = 0:1, onlypositive = true) where {L}
 end
 
 meshdelta(mesh::Mesh{<:Any,T}, lift = missing) where {T} =
-    T(0.1) * norm(applylift(lift, first(minmax_edge(mesh))))
-
-# function anyoldmatrix(matrix::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
-#     n = size(matrix, 1)
-#     ri = one(Ti):Ti(n)
-#     rv = Tv.(im .* (1:n))
-#     s = sparse(ri, ri, rv, n, n)
-#     return s
-# end
+    T(0.1) * norm(first(minmax_edge(mesh)))
 
 function anyoldmatrix(matrix::SparseMatrixCSC, rng = MersenneTwister(1))
     s = copy(matrix)
@@ -257,5 +249,4 @@ function anyoldmatrix(matrix::SparseMatrixCSC, rng = MersenneTwister(1))
     return s
 end
 
-# anyoldmatrix(m::M) where {T,M<:DenseArray{T}} = M(Diagonal(T.(im .* (1:size(m,1)))))
 anyoldmatrix(m::DenseArray, rng = MersenneTwister(1)) = rand!(rng, copy(m))

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1067,6 +1067,9 @@ function add_harmonics!(zerobloch, h::Hamiltonian{<:Lattice,L}, ϕs::SVector{L},
     return zerobloch
 end
 
+add_harmonics!(_, h::Hamiltonian{<:Lattice,L}, ϕs::SVector{L´}, _) where {L,L´} =
+    throw(DimensionMismatch("Tried applying $(L´) Bloch phases to a $(L)D Hamiltonian"))
+
 ############################################################################################
 ######## _copy! and _add! call specialized methods in tools.jl #############################
 ############################################################################################

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -333,12 +333,11 @@ segment_lengths(s::LinearMeshSpec, h::Hamiltonian) = segment_lengths(s, bravais(
 segment_lengths(s::LinearMeshSpec, ph::ParametricHamiltonian{P}) where {P} =
     segment_lengths(s, _blockdiag(SMatrix{P,P}(I), bravais(ph)))
 
-function segment_lengths(s::LinearMeshSpec{N,LS,TS}, br::SMatrix{E,LB,TB}) where {TS,TB,N,E,LS,LB}
-    T = promote_type(TS, TB)
+function segment_lengths(s::LinearMeshSpec{N}, br::SMatrix{E,L}) where {N,E,L}
     if s.samelength
-        ls = filltuple(T(1/(N-1)), Val(N-1))
+        ls = filltuple(1/(N-1), Val(N-1))
     else
-        verts = padright.(s.vertices, Val(LB))
+        verts = padright.(s.vertices, Val(L))
         dϕs = ntuple(i -> verts[i + 1] - verts[i], Val(N-1))
         ibr = pinverse(br)'
         ls = (dϕ -> norm(ibr * dϕ)).(dϕs)

--- a/src/parametric.jl
+++ b/src/parametric.jl
@@ -210,7 +210,7 @@ Base.eltype(ph::ParametricHamiltonian) = eltype(ph.h)
 bloch(ph::ParametricHamiltonian, args...) = bloch!(similarmatrix(ph), ph, args...)
 
 bloch!(matrix, ph::ParametricHamiltonian, pϕs = (), axis = 0) =
-    bloch!(matrix, h_phases(ph, toSVector(pϕs))..., axis)
+    bloch!(matrix, h_phases(ph, pϕs)..., axis)
 
 @inline function h_phases(ph::ParametricHamiltonian, pϕs)
     pnames = parameters(ph)
@@ -219,5 +219,6 @@ bloch!(matrix, ph::ParametricHamiltonian, pϕs = (), axis = 0) =
     return (h, ϕs)
 end
 
-extract_parameters_phases(pnames::NTuple{N,NameType}, ϕs::SVector{M}) where {N,M} =
-    (NamedTuple{pnames}(ntuple(i->ϕs[i], Val(N))), ntuple(i->ϕs[i+N], Val(M-N)))
+extract_parameters_phases(pnames::NTuple{N,NameType}, pϕs::NTuple{M,Any}) where {N,M} =
+    (NamedTuple{pnames}(ntuple(i -> pϕs[i], Val(N))),
+     ntuple(i -> pϕs[i+N], Val(M-N)))

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -96,9 +96,9 @@ end
 
 pinverse(m::SMatrix) = (f -> inv(f.R) * f.Q')(qr(m))
 
-_blockdiag(s1::SMatrix{M}, s2::SMatrix{N}) where {N,M} = hcat(
-    ntuple(j->vcat(s1[:,j], zero(s2[:,j])), Val(M))...,
-    ntuple(j->vcat(zero(s1[:,j]), s2[:,j]), Val(N))...)
+_blockdiag(s1::SMatrix{M,M´}, s2::SMatrix{N,N´}) where {M,M´,N,N´} = hcat(
+    ntuple(j->vcat(s1[:,j], zero(SVector{N,Bool})), Val(M´))...,
+    ntuple(j->vcat(zero(SVector{M,Bool}), s2[:,j]), Val(N´))...)
 
 function isgrowing(vs::AbstractVector, i0 = 1)
     i0 > length(vs) && return true

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -69,4 +69,10 @@ end
     @test length(bands(b)) == 4
     b = bandstructure(ph, mesh1D, lift = φ -> (φ, -φ))
     @test length(bands(b)) == 4
+
+    ph = HamiltonianPresets.graphene() |> parametric(@onsite!((o, r; E) -> o + E' * r))
+    b = bandstructure(ph, linearmesh((0,0), (1,1)), lift = (vx,vy) -> (SA[vx,vy], 0, 0))
+    @test length(bands(b)) == 2
+    b = bandstructure(ph, marchingmesh((0,1), (0,1), (3,3), points = (13,13,1)), lift = (vx,vy, k) -> (SA[vx,vy], k, k))
+    @test length(bands(b)) == 2
 end

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -1,5 +1,5 @@
 @testset "basic bandstructures" begin
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1, range = 1/√3))
+    h = HamiltonianPresets.graphene()
     b = bandstructure(h, points = 13)
     @test length(bands(b)) == 1
 
@@ -16,7 +16,7 @@
     b = bandstructure(h, linearmesh(:Γ, :X, points = 4))
     @test length(bands(b)) == 8
 
-    b = bandstructure(h, linearmesh(:Γ, :X, (0, π), :Z, :Γ, points = 4))
+    b = bandstructure(h, linearmesh(:Γ, :X, (0, π, 0), :Z, :Γ, points = 4))
     @test length(bands(b)) == 8
 end
 
@@ -50,7 +50,8 @@ end
     @test energies(s1) == energies(s2)
     # automatic lift from 2D to 3D
     h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(2)
-    b = bandstructure(h, marchingmesh((0, 2pi), (0, 2pi)))
+    @test_throws DimensionMismatch bandstructure(h, marchingmesh((0, 2pi), (0, 2pi)))
+    b = bandstructure(h, marchingmesh((0, 2pi), (0, 2pi), (0, 0), points = (10, 10, 1)))
     @test length(bands(b)) == 8
 end
 


### PR DESCRIPTION
Closes #75

This PR does various changes to meshes and bandstructures
- Disallows non-numeric vertices (i.e. they cannot directly represent non-scalar parameters of `ParametricHamiltonian`s)
- Allows to specify a `lift` kwarg in `bandstructure(h, meshspec; lift = ...)` that is now treated as a "post-lift": first, the vertices of `mesh = buildmesh(meshspec, h)` are lifted to the "embedding mesh", and then the user-provided lift is applied on the result.
- Remove the silent lifting of, say, a 2D `marchingmesh` to a 3D Brillouin zone. We now require the embedding mesh dimensions to match the hamiltonian's parameter/bloch phase space dimension (EDIT: if no postlift is provided thought the `lift` option)
- The mesh metric used for finite differences in codiagonalization (for degeneracy resolution) is now performed on the mesh itself (without lifting), as postlifts are not guaranteed to produce scalar parameters with a well defined norm

The "embedding mesh" of a `linearmesh((0,0), (0,1))` is a 2D mesh (because vertices are 2D). For a `marchingmesh((0,1), (0,1), (0,1))` it is 3D, because there are three axes. So lifting is done in two steps: first from the "cut" to the "embedding mesh" and then however the user specifies with his/her `lift`. In practice, the user-provided lift (called `postlift` only in the code, the kwarg is still `lift`) is the actual mapping from the embedding mesh to the parameter space of a ParametricHamiltonian. To understand this better, here is an example. 

Take a parametric graphene Hamiltonian, with a vectorial parameter `E` that represents an electric field (producing a lattice-periodic potential `E' * r`)
```
ph = HamiltonianPresets.graphene() |> parametric(@onsite!((o, r; E) -> o + E' * r))
```
Now, we can build a bandstructure along a cut in "electric-field-space" like this
```
bandstructure(ph, linearmesh((0,0), (1,1)), lift = (Ex, Ey) -> (SA[Ex,Ey], 0, 0))
```
This sweeps `E` from `SA[0,0]` to `SA[1,1]`. First, the linear mesh coordinates are mapped to a 2D mesh space (where the nodes (0,0) and (1,1) live). Then the postlift `(Ex, Ey) -> (SA[Ex,Ey], 0, 0)` converts the scalar 2D mesh vertices to a static vector, while fixes the bloch phases to zero. The result of the user-provided `lift` is then *always* between the embedding mesh and the parameter/bloch phase space.
