### PR TITLE
Bug fix in unitcell

### DIFF
--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -689,7 +689,10 @@ function _supercell(lat::AbstractLattice{E,L}, scmatrix::SMatrix{L,L´,Int}, reg
         dntup = Tuple(dn)
         dnvec = toSVector(Int, dntup)
         in_supercell = in_supercell_func(dnvec)
-        in_supercell || (mask[:, dntup...] .= false; continue)
+        if !in_supercell
+            mask[:, dntup...] .= false
+            continue
+        end
         r0 = brmatrix * dnvec
         for (i, site) in enumerate(lat.unitcell.sites)
             r = site + r0

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -87,14 +87,18 @@ pinvmultiple(s::SMatrix{L,0}) where {L} = (SMatrix{0,0,Int}(), 0)
 function pinvmultiple(s::SMatrix{L,L´}) where {L,L´}
     L < L´ && throw(DimensionMismatch("Supercell dimensions $(L´) cannot exceed lattice dimensions $L"))
     qrfact = qr(s)
-    n = det(qrfact.R)
     # Cannot check det(s) ≈ 0 because s can be non-square
-    abs(n) ≈ 0 && throw(ErrorException("Supercell appears to be singular"))
+    det(qrfact.R) ≈ 0 && throw(ErrorException("Supercell appears to be singular"))
     pinverse = inv(qrfact.R) * qrfact.Q'
-    return round.(Int, n * inv(qrfact.R) * qrfact.Q'), round(Int, n)
+    n = round.(Int, det(s's))
+    npinverse = round.(Int, n * pinverse)
+    return npinverse, n
 end
 
-pinverse(m::SMatrix) = (f -> inv(f.R) * f.Q')(qr(m))
+function pinverse(m::SMatrix)
+    qrm = qr(m)
+    return inv(qrm.R) * qrm.Q'
+end
 
 _blockdiag(s1::SMatrix{M}, s2::SMatrix{N}) where {N,M} = hcat(
     ntuple(j->vcat(s1[:,j], zero(s2[:,j])), Val(M))...,

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -28,6 +28,11 @@ using Quantica: Hamiltonian, ParametricHamiltonian
     @test isassigned(h, (10,0))
 end
 
+@testset "hamiltonian unitcell" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = 1/√3)) |> unitcell((1,-1), region = r -> abs(r[2])<2)
+    @test Quantica.nhoppings(h) == 22
+end
+
 @testset "similarmatrix" begin
     types = (ComplexF16, ComplexF32, ComplexF64)
     lat = LatticePresets.honeycomb()

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -37,7 +37,7 @@ end
     end
 end
 
-@testset "unitcell" begin
+@testset "lattice unitcell" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
                LatticePresets.bcc)
@@ -54,10 +54,10 @@ end
     @test unitcell(LatticePresets.honeycomb(), region = RegionPresets.circle(10, (10,0))) isa Lattice{2,0}
     @test unitcell(LatticePresets.honeycomb(), (2,1), region = RegionPresets.circle(10)) isa Lattice{2,1}
     @test unitcell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10)) isa Lattice{3,1}
-    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10, (10,20,30))) isa Lattice{3,1}
+    @test unitcell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10, (10,2,1))) isa Lattice{3,1}
 end
 
-@testset "supercell" begin
+@testset "lattice supercell" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
                LatticePresets.bcc)


### PR DESCRIPTION
There was a bad bug in `unitcell`. This `h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = 1/√3)) |> unitcell((1,-1), region = r -> abs(r[2])<10)` failed to produce a graphene nanoribbon, as it included only one vertical row of sites in a unitcell, not an armchair chain. The reason was an ugly bug in the `unitcell` core function `pinvmultiple` that computes an integer matrix that is an integer multiple of the supercell pseudoinverse. That multiple was computed as the determinant of the R factor in the QR decomposition of the supercell matrix `s`, but that is only actually valid if the latter is square and invertible. The (or at least one) correct multiple is `det(s's)`. 

Hat tip to @baggepinnen [in discourse](https://discourse.julialang.org/t/rational-pseudo-inverse-matrix/43773/3)