### PR TITLE
New ket API for KPM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,10 +30,10 @@ StaticArrays = "0.12.3, 0.13"
 julia = "1.4"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "ArnoldiMethod", "FFTW", "Arpack"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 - `marchingmesh`, `linearmesh`: define a specification to build a bandstructure discretization mesh
 - `bandstructure`, `spectrum`: compute the generalized bandstructure of a Hamiltonian or a ParametricHamiltonian
 - `bands`, `energies`, `states`: inspect spectrum and bandstructure objects
-- `momentaKPM`, `dosKPM`, `averageKPM`, `densityKPM`, `bandrangeKPM`: Kernel Polynomial Method
+- `momentaKPM`, `dosKPM`, `averageKPM`, `densityKPM`, `bandrangeKPM`: Kernel Polynomial Method (KPM)
+- `ket`, `randomkets`: define ket models for use in e.g. KPM routines
 - `greens`, `greensolver`: build Green's functions of a Hamiltonian
 
 Some of this functionality require loading one or more third-party packages, which include the following:

--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -243,7 +243,7 @@ end
 dosKPM(μ::MomentaKPM; resolution = 2) = real.(densityKPM(μ; resolution = resolution))
 
 dos_normalization_factor(kets::StochasticTraceKets, h) = nsites(h)
-dos_normalization_factor(kets, h) = 1xwxw
+dos_normalization_factor(kets, h) = 1
 
 """
     densityKPM(h::Hamiltonian, A; resolution = 2, kets = randomkets(1), kw...)

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -19,6 +19,7 @@ using SparseArrays: getcolptr, AbstractSparseMatrix
 
 export sublat, bravais, lattice, dims, sites, supercell, unitcell,
        hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector,
+       ket, randomkets,
        hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
        flatten, wrap, transform!, combine,
        spectrum, bandstructure, marchingmesh, linearmesh, buildmesh, buildlift,

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -100,7 +100,7 @@ module RegionPresets
 
 using StaticArrays
 
-struct Region{E,F}
+struct Region{E,F} <: Function
     f::F
 end
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -82,8 +82,12 @@ padright(t::NTuple{N´,Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 :
 # Pad element type to a "larger" type
 @inline padtotype(s::SMatrix{E,L}, ::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =
     S(SMatrix{E2,E}(I) * s * SMatrix{L,L2}(I))
+@inline padtotype(s::StaticVector, ::Type{S}) where {N,T,S<:SVector{N,T}} =
+    padright(T.(s), Val(N))
 @inline padtotype(x::Number, ::Type{S}) where {E,L,S<:SMatrix{E,L}} =
     S(x * (SMatrix{E,1}(I) * SMatrix{1,L}(I)))
+@inline padtotype(s::Number, ::Type{S}) where {N,T,S<:SVector{N,T}} =
+    padright(SA[T(s)], Val(N))
 @inline padtotype(x::Number, ::Type{T}) where {T<:Number} = T(x)
 @inline padtotype(u::UniformScaling, ::Type{T}) where {T<:Number} = T(u.λ)
 @inline padtotype(u::UniformScaling, ::Type{S}) where {S<:SMatrix} = S(u)

--- a/test/test_KPM.jl
+++ b/test/test_KPM.jl
@@ -2,12 +2,14 @@ using ArnoldiMethod, Random, FFTW
 
 @testset "basic KPM" begin
     h = LatticePresets.honeycomb() |>
-        hamiltonian(hopping(SA[0 1; 1 0], range = 1/sqrt(3)), orbitals = Val(2)) |>
+        hamiltonian(hopping(1.0I, range = 1/sqrt(3)), orbitals = (Val(1), Val(2))) |>
         unitcell(region = RegionPresets.circle(10))
     brange = bandrangeKPM(h)
-    m1 = momentaKPM(h, order = 30)
-    m2 = momentaKPM(h, bandrange = brange, order = 30)
+    m1 = momentaKPM(h, order = 30, kets = randomkets(1, maporbitals = true))
+    m2 = momentaKPM(h, bandrange = brange, order = 30, kets = randomkets(1, maporbitals = true))
     @test abs(m1.mulist[1]) ≈ abs(m2.mulist[1])
-    dos = dosKPM(h, order = 10, bandrange = (-3,3))
-    @test all(ρ -> 0 < ρ < 10, last(dos))
+    dos1 = dosKPM(h, order = 10, bandrange = (-3,3), kets = randomkets(1, maporbitals = true))
+    dos2 = dosKPM(h, order = 10, bandrange = (-3,3), kets = randomkets(1, r -> randn(), maporbitals = true))
+    @test all(ρ -> 0 < ρ < 10, last(dos1))
+    @test all(ρ -> 0 < ρ < 10, last(dos2))
 end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -26,6 +26,9 @@ using Quantica: Hamiltonian, ParametricHamiltonian
     h = LatticePresets.square() |> hamiltonian(hopping(1, dn = (10,0), range = Inf))
     @test Quantica.nhoppings(h) == 1
     @test isassigned(h, (10,0))
+
+    h = LatticePresets.honeycomb() |> hamiltonian(onsite(1.0, sublats = :A), orbitals = (Val(1), Val(2)))
+    @test Quantica.nonsites(h) == 1
 end
 
 @testset "hamiltonian unitcell" begin

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -8,7 +8,6 @@ using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector,
     @test (t -> t(r, r)).(model.terms) == (1, -2I)
     model = -onsite(@SMatrix[1 0; 1 1]) - 2hopping(2I)
     @test (t -> t(r, r)).(model.terms) == (-@SMatrix[1 0; 1 1], -4I)
-    @test model(r, r) == @SMatrix[-5 0; -1 -5]
 end
 
 @testset "onsite terms" begin
@@ -60,4 +59,19 @@ end
         hop´ = hopping(t´, sublats = s´, dn = dn´, range = rn)
         @test hop' === hop´
     end
+end
+
+@testset "kets" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(I), orbitals = (Val(3), Val(1)))
+    k = Matrix(randomkets(2; sublats = :B), h)
+    @test sum(e -> count(iszero, e), k) == 10
+    k = Matrix(randomkets(1; region = r -> r[2] < 0, maporbitals = true), h)
+    @test sum(e -> count(iszero, e), k) == 3
+    k = Matrix(randomkets(2, r->randn()SA[1,]; sublats = :B), h)
+    @test sum(e -> count(!iszero, e), k) == 2
+    k = Matrix(randomkets(2; sublats = :B, maporbitals = true), h)
+    @test sum(e -> count(!iszero, e), k) == 2
+    km = ket(r -> randn() * SA[1, -1, 0], sublats = :A)  + ket(r -> randn(), sublats =:B)
+    k = Matrix(km, h)
+    @test sum(e -> count(!iszero, e), k) == 3
 end


### PR DESCRIPTION
This introduces a new API to specify kets, for e.g. KPM routines. It introduces a `KetModel` type, constructed by the exported function `ket(a; kw...)` (analogous to `OnsiteModel`s created by `onsite`). `a` specifies ket amplitudes (as a constant or a function) and `kw` specifies which sites to apply the amplitude to (the `kw` are passed to `siteselector`). There is an extra `kw` that is `normalized`, that normalizes the ket when true.

As an example, a `KetModel` such as `ket(r -> norm(r)^2; sublats = :A, region = RegionPresets.circle(10), normalized = true)` can be used to create a normalized ket with amplitude proportional to `|r|^2` only of sublattice `:A` within a 10-radius circle centered at the origin.  Bear in mind that `ket` creates a *model*  independently of a Hamiltonian (just as `onsite` creates a model independent of a `Lattice`). It is only when combined with a `h::Hamiltonian` that you obtain an actual vector for the ket. This is done with the (unexported) functions `ketvector(ketmodel, h)` and `ketmatrix((ketmodels...), h)`. For the `ketmatrix`, each of the `ketmodels` produces a column of the resulting matrix.

Linear algebra can be performed on `KetModel`s, just as with `TightbinindModels`, so we can do `myket = ket(1; sublats = :A) - ket(1; sublats = :B)`, for example.

This PR also introduces `randomkets(n,...; kw...)` to create a set of `n` random kets, possibly on a portion of the system specified by `kw` as in the above example. We also have the option to make the random kets orthogonal with `orthogonal = true`.

In a typical situation we will now do KPM calculations with `dosKPM(h; kets = randomkets(10))`, and we customize the kind of ket through function `randomkets`.