### PR TITLE
Fix and generalize `wrap`

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -58,6 +58,15 @@ end
 mergetuples(ts...) = keys(merge(tonamedtuple.(ts)...))
 tonamedtuple(ts::Val{T}) where {T} = NamedTuple{T}(filltuple(0,T))
 
+function deletemultiple_nocheck(dn::SVector{N}, axes::NTuple{M,Int}) where {N,M}
+    ind = first(axes)
+    dn´ = deleteat(dn, ind)
+    taxes = Base.tail(axes)
+    axes´ = taxes .- (taxes .> ind)
+    return deletemultiple_nocheck(dn´, axes´)
+end
+deletemultiple_nocheck(dn::SVector, axes::Tuple{}) = dn
+
 _rdr(r1, r2) = (0.5 * (r1 + r2), r2 - r1)
 
 # zerotuple(::Type{T}, ::Val{L}) where {T,L} = ntuple(_ -> zero(T), Val(L))

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -33,6 +33,15 @@ end
     @test Quantica.nhoppings(h) == 22
 end
 
+@testset "hamiltonian wrap" begin
+    h = LatticePresets.bcc() |> hamiltonian(hopping((r, dr) -> 1/norm(dr), range = 10))
+    wh = wrap(h, phases = (1,2,3))
+    @test bloch(wh) ≈ bloch(h, (1,2,3))
+    h = LatticePresets.bcc() |> hamiltonian(hopping((r, dr) -> 1/norm(dr), range = 10)) |> unitcell(3)
+    wh = wrap(h, phases = (1,2,3))
+    @test bloch(wh) ≈ bloch(h, (1,2,3))
+end
+
 @testset "similarmatrix" begin
     types = (ComplexF16, ComplexF32, ComplexF64)
     lat = LatticePresets.honeycomb()


### PR DESCRIPTION
The wrap function was seriously bugged. In particular doing `wrap(h)` would end up modifying `h`. Not good :-D

This PR fixes `wrap`, and generalizes it to be able to wrap along several axes simultaneously. So, a 3D Hamiltonian `h` can be wrapped along directions 1 and 3, with corresponding phase factors `phases = (ϕ₁, ϕ₃)`, doing
```
wrap(h, (1,3); phases = (ϕ₁, ϕ₃))
```