### PR TITLE
Fix regression using Region

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1,3 +1,5 @@
+using Quantica.RegionPresets: Region
+
 #######################################################################
 # Onsite/Hopping selectors
 #######################################################################
@@ -135,11 +137,11 @@ isonsite((i, j), (dni, dnj)) = i == j && dni == dnj
 
 isinregion(i::Int, ::Missing, lat) = true
 isinregion(i::Int, dn, ::Missing, lat) = true
-isinregion(i::Int, region::Function, lat) = region(sites(lat)[i])
-isinregion(i::Int, dn, region::Function, lat) = region(sites(lat)[i] + bravais(lat) * dn)
+isinregion(i::Int, region::Union{Function,Region}, lat) = region(sites(lat)[i])
+isinregion(i::Int, dn, region::Union{Function,Region}, lat) = region(sites(lat)[i] + bravais(lat) * dn)
 
 isinregion(is::Tuple{Int,Int}, dns, ::Missing, lat) = true
-function isinregion((row, col)::Tuple{Int,Int}, (dnrow, dncol), region::Function, lat)
+function isinregion((row, col)::Tuple{Int,Int}, (dnrow, dncol), region::Union{Function,Region}, lat)
     br = bravais(lat)
     r, dr = _rdr(sites(lat)[col] + br * dncol, sites(lat)[row] + br * dnrow)
     return region(r, dr)

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -100,7 +100,7 @@ module RegionPresets
 
 using StaticArrays
 
-struct Region{E,F} <: Function
+struct Region{E,F}
     f::F
 end
 


### PR DESCRIPTION
Fixes a regression due to making `Region <: Function`. For some obscure reason that makes `unitcell(region = ::Region)` allocate like crazy (in the supercell step). This was innocently introduced in #80. The present PR reverts that, to recover small allocations, like in 
```
julia> @time LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = 1/√3)) |> unitcell(region = RegionPresets.circle(300))
  0.178050 seconds (360 allocations: 76.432 MiB)
Hamiltonian{<:Lattice} : Hamiltonian on a 0D Lattice in 2D space
  Bloch harmonics  : 1 (SparseMatrixCSC, sparse)
  Harmonic size    : 652966 × 652966
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (Complex{Float64})
  Onsites          : 0
  Hoppings         : 1956506
  Coordination     : 2.9963367158473795
```