### PR TITLE
`indices` kwarg in selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 
 # Exported API
 - `lattice`, `sublat`, `bravais`: build lattices
-- `dims`, `sites`: inspect lattices
+- `dims`, `sitepositions`, `siteindices`: inspect lattices
 - `hopping`, `onsite`, `siteselector`, `hopselector`: build tightbinding models
 - `hamiltonian`: build a Hamiltonian from tightbinding model and a lattice
 - `parametric`, `@onsite!`, `@hopping!`, `parameters`: build a parametric Hamiltonian

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -17,8 +17,9 @@ using ExprTools
 
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
-export sublat, bravais, lattice, dims, sites, supercell, unitcell,
+export sublat, bravais, lattice, dims, supercell, unitcell,
        hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector,
+       sitepositions, siteindices,
        ket, randomkets,
        hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,
        flatten, wrap, transform!, combine,

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -353,7 +353,7 @@ end
     sitepositions(lat::AbstractLattice; kw...)
     sitepositions(h::Hamiltonian; kw...)
 
-Build a container with the positions of sites in the lattice unitcell. Only sites specified
+Build a generator of the positions of sites in the lattice unitcell. Only sites specified
 by `siteselector(kw...)` are selected.
 
 """
@@ -364,7 +364,7 @@ sitepositions(h::Hamiltonian; kw...) = sitepositions(h.lattice, siteselector(;kw
     siteindices(lat::AbstractLattice; kw...)
     siteindices(lat::Hamiltonian; kw...)
 
-Build a container with the unique indices of sites in the lattice unitcell. Only sites
+Build a generator of the unique indices of sites in the lattice unitcell. Only sites
 specified by `siteselector(kw...)` are selected.
 
 """

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -592,7 +592,7 @@ function applyterm!(builder::IJVBuilder{L}, term::OnsiteTerm) where {L}
         ijv = builder[dn0]
         offset = lat.unitcell.offsets[s]
         for i in is
-            isinregion(i, dn0, rsel.selector.region, lat) || continue
+            i in rsel || continue
             r = allsitepositions(lat)[i]
             v = toeltype(term(r, r), eltype(builder), builder.orbs[s], builder.orbs[s])
             push!(ijv, (i, i, v))
@@ -617,8 +617,7 @@ function applyterm!(builder::IJVBuilder{L}, term::HoppingTerm) where {L}
                 rsource = sitej - lat.bravais.matrix * dn
                 itargets = targets(builder, sel.range, rsource, s1)
                 for i in itargets
-                    isselfhopping((i, j), (s1, s2), dn) && continue
-                    isinregion((i, j), (dn, zero(dn)), sel.region, lat) || continue
+                    ((i, j), (dn, zero(dn))) in rsel || continue
                     foundlink = true
                     rtarget = allsitepositions(lat)[i]
                     r, dr = _rdr(rsource, rtarget)
@@ -714,7 +713,7 @@ end
 
 function Base.Matrix(kms, h::Hamiltonian; orthogonal = false)
     M = orbitaltype(h)
-    kmat = Matrix{M}(undef, size(h, 2), length(kms))
+    kmat = zeros(M, size(h, 2), length(kms))
     for (j, km) in enumerate(kms)
         kvec = view(kmat, :, j)
         ket!(kvec, km, h)
@@ -734,7 +733,7 @@ function ket!(k, km::KetModel, h)
             orbs = h.orbitals[s]
             is = siterange(h.lattice, s)
             for i in is
-                isinregion(i, term.selector.region, h.lattice) || continue
+                i in rs || continue
                 r = hsites[i]
                 k[i] += generate_amplitude(km, term, r, M, orbs)
             end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -354,7 +354,7 @@ end
     sitepositions(h::Hamiltonian; kw...)
 
 Build a generator of the positions of sites in the lattice unitcell. Only sites specified
-by `siteselector(kw...)` are selected.
+by `siteselector(kw...)` are selected, see `siteselector` for details.
 
 """
 sitepositions(lat::AbstractLattice; kw...) = sitepositions(lat, siteselector(;kw...))
@@ -365,7 +365,7 @@ sitepositions(h::Hamiltonian; kw...) = sitepositions(h.lattice, siteselector(;kw
     siteindices(lat::Hamiltonian; kw...)
 
 Build a generator of the unique indices of sites in the lattice unitcell. Only sites
-specified by `siteselector(kw...)` are selected.
+specified by `siteselector(kw...)` are selected, see `siteselector` for details.
 
 """
 siteindices(lat::AbstractLattice; kw...) = siteindices(lat, siteselector(;kw...))
@@ -383,8 +383,6 @@ function transform!(f, h::Hamiltonian)
 end
 
 # Indexing #
-"""
-"""
 Base.push!(h::Hamiltonian{<:Any,L}, dn::NTuple{L,Int}) where {L} = push!(h, SVector(dn...))
 Base.push!(h::Hamiltonian{<:Any,L}, dn::Vararg{Int,L}) where {L} = push!(h, SVector(dn...))
 function Base.push!(h::Hamiltonian{<:Any,L}, dn::SVector{L,Int}) where {L} 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -350,6 +350,28 @@ end
 # External API #
 
 """
+    sitepositions(lat::AbstractLattice; kw...)
+    sitepositions(h::Hamiltonian; kw...)
+
+Build a container with the positions of sites in the lattice unitcell. Only sites specified
+by `siteselector(kw...)` are selected.
+
+"""
+sitepositions(lat::AbstractLattice; kw...) = sitepositions(lat, siteselector(;kw...))
+sitepositions(h::Hamiltonian; kw...) = sitepositions(h.lattice, siteselector(;kw...))
+
+"""
+    siteindices(lat::AbstractLattice; kw...)
+    siteindices(lat::Hamiltonian; kw...)
+
+Build a container with the unique indices of sites in the lattice unitcell. Only sites
+specified by `siteselector(kw...)` are selected.
+
+"""
+siteindices(lat::AbstractLattice; kw...) = siteindices(lat, siteselector(;kw...))
+siteindices(h::Hamiltonian; kw...) = siteindices(h.lattice, siteselector(;kw...))
+
+"""
     transform!(f::Function, h::Hamiltonian)
 
 Transform the site positions of the Hamiltonian's lattice in place without modifying the

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -503,24 +503,6 @@ ismasked(lat::Superlattice) = ismasked(lat.supercell)
 maskranges(lat::Superlattice) = (1:nsites(lat), lat.supercell.cells.indices...)
 maskranges(lat::Lattice) = (1:nsites(lat),)
 
-# External API #
-
-"""
-    sitepositions(lat::AbstractLattice; kw...)
-
-Build a container with the positions of sites in `lat`'s unitcell. Only sites specified by
-`siteselector(kw...)` are selected.
-"""
-sitepositions(lat::AbstractLattice; kw...) = sitepositions(lat, siteselector(kw...))
-
-"""
-    siteindices(lat::AbstractLattice; kw...)
-
-Build a container with the unique indices of sites in `lat`'s unitcell. Only sites specified
-by `siteselector(kw...)` are selected.
-"""
-siteindices(lat::AbstractLattice; kw...) = siteindices(lat, siteselector(kw...))
-
 """
     transform!(f::Function, lat::Lattice)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -230,8 +230,11 @@ isinsublats(s, sublats) =
 # Here we can have (1, 2:3), apart from ((1,2) .=> (3,4), 1=>2) and ((1,2) => (3,4), 1=>2)
 isinindices(i::Integer, ::Missing) = true
 isinindices(i::Integer, j::Integer) = i == j
+isinindices(i::Integer, r::AbstractUnitRange) = i in r
+isinindices(i::Integer, r::AbstractArray) = i in r
+isinindices(i::Integer, r::NTuple{N,Integer}) where {N} = i in r
 isinindices(i::Integer, inds) = any(is -> i in is, inds)
-isinindices(is::Pair, inds) = isinindices(Tuple(is), inds)
+isinindices((i,j)::Pair, inds) = isinindices((i,j), inds)
 isinindices(is::Tuple, ::Missing) = true
 # Here is => js could be (1,2) => (3,4) or 1:2 => 3:4, not simply 1 => 3
 isinindices((i, j)::Tuple, (is, js)::Pair) = i in is && j in js
@@ -288,17 +291,17 @@ _adjoint(t::SVector) = -t
 # sitepositions
 #######################################################################
 
-sitepositions(lat::AbstractArray, s::SiteSelector) = sitepositions(resolve(s, lat))
+sitepositions(lat::AbstractLattice, s::SiteSelector) = sitepositions(resolve(s, lat))
 
-sitepositions(rs::ResolvedSelector{<:SiteSelector}) = (s for (i, s) in enumerate(allsitepositions(rs.lattice)) if i in rs.selector)
+sitepositions(rs::ResolvedSelector{<:SiteSelector}) = (s for (i, s) in enumerate(allsitepositions(rs.lattice)) if i in rs)
 
 #######################################################################
 # siteindices
 #######################################################################
 
-siteindices(lat::AbstractArray, s::SiteSelector) = siteindices(resolve(s, lat))
+siteindices(lat::AbstractLattice, s::SiteSelector) = siteindices(resolve(s, lat))
 
-siteindices(rs::ResolvedSelector{<:SiteSelector}) = (i for i in eachindex(allsitepositions(rs.lattice)) if i in rs.selector)
+siteindices(rs::ResolvedSelector{<:SiteSelector}) = (i for i in eachindex(allsitepositions(rs.lattice)) if i in rs)
 
 #######################################################################
 # Tightbinding types

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,74 +1,133 @@
+using Quantica.RegionPresets: Region
+
 #######################################################################
 # Onsite/Hopping selectors
 #######################################################################
-abstract type Selector{M,S} end
+abstract type Selector end
 
-struct SiteSelector{M,S} <: Selector{M,S}
+struct SiteSelector{S,M,I} <: Selector
     region::M
     sublats::S  # NTuple{N,NameType} (unresolved) or Vector{Int} (resolved on a lattice)
+    indices::I  # Once resolved, this should be an Integer container
 end
 
-struct HopSelector{M,S,D,T} <: Selector{M,S}
+struct HopSelector{S,M,D,T,I} <: Selector
     region::M
     sublats::S  # NTuple{N,Pair{NameType,NameType}} (unres) or Vector{Pair{Int,Int}} (res)
     dns::D
     range::T
+    indices::I # Once resolved, this should be a Pair{Integer,Integer} container
+end
+
+struct ResolvedSelector{S<:Selector,L<:AbstractLattice} <: Selector
+    selector::S
+    lattice::L
+end
+
+function sublats(rs::ResolvedSelector{<:SiteSelector})
+    subs = sublats(rs.lattice)
+    return [s for s in subs if isinsublats(s, rs.selector.sublats)]
+end
+
+function sublats(rs::ResolvedSelector{<:HopSelector})
+    subs = sublats(rs.lattice)
+    return [s => d for s in subs for d in subs if isinsublats(s => d, rs.selector.sublats)]
 end
 
 """
-    siteselector(; region = missing, sublats = missing)
+    siteselector(; region = missing, sublats = missing, indices = missing)
 
 Return a `SiteSelector` object that can be used to select sites in a lattice contained
-within the specified region and sublattices. Only sites at position `r` in sublattice with
-name `s::NameType` will be selected if `region(r) && s in sublats` is true. Any missing
-`region` or `sublat` will not be used to constraint the selection.
+within the specified region and sublattices. Only sites with index `i`, at position `r` and
+belonging to a sublattice with name `s::NameType` will be selected if
+
+    `region(r) && s in sublats && i in indices`
+
+Any missing `region`, `sublat` or `indices` will not be used to constraint the selection.
 
 The keyword `sublats` allows the following formats:
 
-    sublats = :A           # Onsite on sublat :A only
-    sublats = (:A,)        # Same as above
-    sublats = (:A, :B)     # Onsite on sublat :A and :B
+    sublats = :A                    # Sites on sublat :A only
+    sublats = (:A,)                 # Same as above
+    sublats = (:A, :B)              # Sites on sublat :A and :B
+
+The keyword `indices` accepts a single integer, or a collection thereof. If several
+collections are given, they are flattened into a single one. Possible combinations:
+
+    indices = 1                     # Site 1 only
+    indices = (1, )                 # Same as above
+    indices = (1, 2, 3)             # Sites 1, 2 or 3
+    indices = [1, 2, 3]             # Same as above
+    indices = 1:3                   # Same as above
+    indices = (1:3, 7, 8)           # Sites 1, 2, 3, 7 or 8
 """
-siteselector(; region = missing, sublats = missing) =
-    SiteSelector(region, sanitize_sublats(sublats))
+siteselector(; region = missing, sublats = missing, indices = missing) =
+    SiteSelector(region, sublats, indices)
+
+# siteselector(; region = missing, sublats = missing, indices = missing) =
+#     SiteSelector(region, sanitize_sublats(sublats), sanitize_indices(indices))
+
+# sanitize_sublats(::Missing) = missing
+# sanitize_sublats(s::Integer) = (nametype(s),)
+# sanitize_sublats(s::NameType) = (s,)
+# sanitize_sublats(s::Tuple) = nametype.(s)
+# sanitize_sublats(s::Tuple{}) = ()
+# sanitize_sublats(n) = throw(ErrorException(
+#     "`sublats` for `onsite` must be either `missing`, a sublattice name or a tuple of names, see `onsite` for details"))
+
+# sanitize_indices(::Missing) = missing
+# sanitize_indices(i::Integer) = (i,)
+# sanitize_indices(is::NTuple{N,Integer}) where {N} = is
+# sanitize_indices(is::AbstractVector{<:Integer}) = is
+# sanitize_indices(is::AbstractUnitRange{<:Integer}) = is
+# sanitize_indices(is) = Iterators.flatten(is)
 
 """
-    hopselector(; region = missing, sublats = missing, dn = missing, range = missing)
+    hopselector(; region = missing, sublats = missing, dn = missing, range = missing, indices = missing)
 
 Return a `HopSelector` object that can be used to select hops between two sites in a
-lattice. Only hops between two sites at positions `r₁ = r - dr/2` and `r₂ = r + dr`,
-belonging to unit cells at integer distance `dn´` and to sublattices `s₁` and `s₂` will be
-selected if: `region(r, dr) && s in sublats && dn´ in dn && norm(dr) <= range`. If any of
-these is `missing` it will not be used to constraint the selection.
+lattice. Only hops between two sites, with indices `ipair = src => dst`, at positions `r₁ =
+r - dr/2` and `r₂ = r + dr`, belonging to unit cells at integer distance `dn´` and to
+sublattices `s₁` and `s₂` will be selected if:
 
-The keyword `dn` can be a `Tuple`/`Vector`/`SVector` of `Int`s, or a tuple thereof. The
-keyword `sublats` allows the following formats:
+    `region(r, dr) && s in sublats && dn´ in dn && norm(dr) <= range && ipair in indices`
 
-    sublats = :A => :B                 # Hopping from :A to :B sublattices
-    sublats = (:A => :B,)              # Same as above
-    sublats = (:A => :B, :C => :D)     # Hopping from :A to :B or :C to :D
-    sublats = (:A, :C) .=> (:B, :D)    # Broadcasted pairs, same as above
-    sublats = (:A, :C) => (:B, :D)     # Direct product, (:A=>:B, :A=:D, :C=>:B, :C=>D)
+If any of these is `missing` it will not be used to constraint the selection.
+
+The keyword `dn` can be a `Tuple`/`Vector`/`SVector` of `Int`s, or a tuple thereof.
+
+The keyword `sublats` allows the following formats:
+
+    sublats = :A => :B                  # Hopping from :A to :B sublattices, but not from :B to :A
+    sublats = (:A => :B,)               # Same as above
+    sublats = (:A => :B, :C => :D)      # Hopping from :A to :B or :C to :D
+    sublats = (:A, :C) .=> (:B, :D)     # Broadcasted pairs, same as above
+    sublats = (:A, :C) => (:B, :D)      # Direct product, (:A=>:B, :A=:D, :C=>:B, :C=>D)
+
+The keyword `indices` accepts a single `src => dest` pair or a collection thereof. Any `src
+== dest` will be neglected. Possible combinations:
+
+    indices = 1 => 2                    # Hopping from site 1 to 2, but not from 2 to 1
+    indices = (1 => 2, 2 => 1)          # Hoppings from 1 to 2 or from 2 to 1
+    indices = [1 => 2, 2 => 1]          # Same as above
+    indices = [(1, 2) .=> (2, 1)]       # Broadcasted pairs, same as above
+    indices = [1:10 => 20:25, 3 => 30]  # Direct product, any hopping from sites 1:10 to sites 20:25, or from 3 to 30
+
 """
-hopselector(; region = missing, sublats = missing, dn = missing, range = missing) =
-    HopSelector(region, sanitize_sublatpairs(sublats), sanitize_dn(dn), sanitize_range(range))
+hopselector(; region = missing, sublats = missing, dn = missing, range = missing, indices = missing) =
+    HopSelector(region, sublats, sanitize_dn(dn), sanitize_range(range), indices)
 
-sanitize_sublats(s::Missing) = missing
-sanitize_sublats(s::Integer) = (nametype(s),)
-sanitize_sublats(s::NameType) = (s,)
-sanitize_sublats(s::Tuple) = nametype.(s)
-sanitize_sublats(s::Tuple{}) = ()
-sanitize_sublats(n) = throw(ErrorException(
-    "`sublats` for `onsite` must be either `missing`, a sublattice name or a tuple of names, see `onsite` for details"))
+# hopselector(; region = missing, sublats = missing, dn = missing, range = missing, indices = missing) =
+#     HopSelector(region, sanitize_sublatpairs(sublats), sanitize_dn(dn), sanitize_range(range), sanitize_index_pairs(indices))
 
-sanitize_sublatpairs(s::Missing) = missing
-sanitize_sublatpairs(p::Pair{<:Union{NameType,Integer}, <:Union{NameType,Integer}}) =
-    (ensurenametype(p),)
-sanitize_sublatpairs(pp::Pair) =
-    ensurenametype.(tupletopair.(tupleproduct(first(pp), last(pp))))
-sanitize_sublatpairs(ps::Tuple) = tuplejoin(sanitize_sublatpairs.(ps)...)
-sanitize_sublatpairs(s) = throw(ErrorException(
-    "`sublats` for `hopping` must be either `missing` or a series of sublattice `Pair`s, see `hopping` for details"))
+# sanitize_sublatpairs(s::Missing) = missing
+# sanitize_sublatpairs(p::Pair{<:Union{NameType,Integer}, <:Union{NameType,Integer}}) =
+#     (ensurenametype(p),)
+# sanitize_sublatpairs(pp::Pair) =
+#     ensurenametype.(tupletopair.(tupleproduct(first(pp), last(pp))))
+# sanitize_sublatpairs(ps::Tuple) = tuplejoin(sanitize_sublatpairs.(ps)...)
+# sanitize_sublatpairs(s) = throw(ErrorException(
+#     "`sublats` for `hopping` must be either `missing` or a series of sublattice `Pair`s, see `hopping` for details"))
 
 ensurenametype((s1, s2)::Pair) = nametype(s1) => nametype(s2)
 
@@ -83,74 +142,103 @@ _sanitize_dn(dn::Vector) = SVector{length(dn),Int}(dn)
 sanitize_range(::Missing) = missing
 sanitize_range(range::Real) = isfinite(range) ? float(range) + sqrt(eps(float(range))) : float(range)
 
-sublats(lat::AbstractLattice, s::SiteSelector{<:Any,Missing}) = collect(1:nsublats(lat))
-
-function sublats(lat::AbstractLattice, s::SiteSelector{<:Any,<:Tuple})
-    names = lat.unitcell.names
-    ss = Int[]
-    for name in s.sublats
-        i = findfirst(isequal(name), names)
-        i !== nothing && push!(ss, i)
-    end
-    return ss
-end
-
-function sublats(lat::AbstractLattice, s::HopSelector{<:Any,<:Tuple})
-    names = lat.unitcell.names
-    ss = Pair{Int,Int}[]
-    for (nsrc, ndst) in s.sublats
-        isrc = findfirst(isequal(nsrc), names)
-        idst = findfirst(isequal(ndst), names)
-        isrc !== nothing && idst !== nothing && push!(ss, isrc => idst)
-    end
-    return ss
-end
-
-sublats(lat::AbstractLattice, s::HopSelector{<:Any,Missing}) =
-    tupletopair.(vec(collect(Iterators.product(1:nsublats(lat), 1:nsublats(lat)))))
-
-# selector already resolved for a lattice
-sublats(lat, s::Selector{<:Any,<:Vector}) = s.sublats
+# sanitize_index_pairs(::Missing) = missing
+# sanitize_index_pairs(singlepair::Pair{T,T}) where {T<:Integer} = (singlepair,)
+# sanitize_index_pairs(singlepair::Pair) = Iterators.product(last(singlepair), first(singlepair))
+# sanitize_index_pairs(pairs) = Iterators.flatten(sanitize_index_pairs.(pairs))
 
 # API
 
-resolve(s::HopSelector, lat::AbstractLattice) =
-    HopSelector(s.region, sublats(lat, s), _checkdims(s.dns, lat), s.range)
-resolve(s::SiteSelector, lat::AbstractLattice) = SiteSelector(s.region, sublats(lat, s))
+function resolve(s::SiteSelector, lat::AbstractLattice)
+    s = SiteSelector(s.region, resolve_sublats(s.sublats, lat), s.indices)
+    return ResolvedSelector(s, lat)
+end
 
-_checkdims(dns::Missing, lat::AbstractLattice{E,L}) where {E,L} = dns
-_checkdims(dns::Tuple{Vararg{SVector{L,Int}}}, lat::AbstractLattice{E,L}) where {E,L} = dns
-_checkdims(dns, lat::AbstractLattice{E,L}) where {E,L} =
+function resolve(s::HopSelector, lat::AbstractLattice)
+    s = HopSelector(s.region, resolve_sublat_pairs(s.sublats, lat), check_dn_dims(s.dns, lat), s.range, s.indices)
+    return ResolvedSelector(s, lat)
+end
+
+resolve_sublats(::Missing, lat) = missing # must be resolved to iterate over sublats
+resolve_sublats(s, lat) = resolve_sublat_name.(s, Ref(lat))
+
+function resolve_sublat_name(name::Union{NameType,Integer}, lat)
+    i = findfirst(isequal(name), lat.unitcell.names)
+    return i === nothing ? 0 : i
+end
+
+resolve_sublat_name(s, lat) =
+    throw(ErrorException( "Unexpected format $s for `sublats`, see `onsite` for supported options"))
+
+resolve_sublat_pairs(::Missing, lat) = missing
+resolve_sublat_pairs(s::Tuple, lat) = resolve_sublat_pairs.(s, Ref(lat))
+resolve_sublat_pairs((src, dst)::Pair, lat) = resolve_sublat_name.(src, Ref(lat)) => resolve_sublat_name.(dst, Ref(lat))
+
+resolve_sublat_pairs(s, lat) =
+    throw(ErrorException( "Unexpected format $s for `sublats`, see `hopping` for supported options"))
+
+check_dn_dims(dns::Missing, lat::AbstractLattice{E,L}) where {E,L} = dns
+check_dn_dims(dns::Tuple{Vararg{SVector{L,Int}}}, lat::AbstractLattice{E,L}) where {E,L} = dns
+check_dn_dims(dns, lat::AbstractLattice{E,L}) where {E,L} =
     throw(DimensionMismatch("Specified cell distance `dn` does not match lattice dimension $L"))
 
 # are sites at (i,j) and (dni, dnj) or (dn, 0) selected?
-(s::SiteSelector)(lat::AbstractLattice, (i, j)::Tuple, (dni, dnj)::Tuple{SVector, SVector}) =
-    isonsite((i, j), (dni, dnj)) && isinregion(i, dni, s.region, lat) && isinsublats(sublat(lat, i), s.sublats)
+@inline function Base.in(i::Integer, rs::ResolvedSelector{<:SiteSelector, LA}) where {E,L,LA<:AbstractLattice{E,L}}
+    dn0 = zero(SVector{L,Int})
+    return ((i, i), (dn0, dn0)) in rs
+end
 
-(s::HopSelector)(lat::AbstractLattice, inds, dns) =
-    !isonsite(inds, dns) && isinregion(inds, dns, s.region, lat) && isindns(dns, s.dns) &&
-    isinrange(inds, s.range, lat) && isinsublats(tupletopair(sublat.(Ref(lat), inds)), s.sublats)
+Base.in(((i, j), (dni, dnj))::Tuple, rs::ResolvedSelector{<:SiteSelector}) =
+    isonsite((i, j), (dni, dnj)) && isinindices(i, rs.selector.indices) &&
+    isinregion(i, dni, rs.selector.region, rs.lattice) &&
+    isinsublats(sublat(rs.lattice, i), rs.selector.sublats)
+
+@inline function Base.in(is::Union{Pair,Tuple{Integer,Integer}}, rs::ResolvedSelector{<:HopSelector, LA}) where {E,L,LA<:AbstractLattice{E,L}}
+    dn0 = zero(SVector{L,Int})
+    return (Tuple(is), (dn0, dn0)) in rs
+end
+
+Base.in((inds, dns), rs::ResolvedSelector{<:HopSelector}) =
+    !isonsite(inds, dns) && isinindices(inds, rs.selector.indices) &&
+    isinregion(inds, dns, rs.selector.region, rs.lattice) && isindns(dns, rs.selector.dns) &&
+    isinrange(inds, rs.selector.range, rs.lattice) &&
+    isinsublats(tupletopair(sublat.(Ref(rs.lattice), inds)), rs.selector.sublats)
 
 isonsite((i, j), (dni, dnj)) = i == j && dni == dnj
 
 isinregion(i::Int, ::Missing, lat) = true
 isinregion(i::Int, dn, ::Missing, lat) = true
-isinregion(i::Int, region::Function, lat) = region(sites(lat)[i])
-isinregion(i::Int, dn, region::Function, lat) = region(sites(lat)[i] + bravais(lat) * dn)
+isinregion(i::Int, region::Union{Function,Region}, lat) = region(allsitepositions(lat)[i])
+isinregion(i::Int, dn, region::Union{Function,Region}, lat) = region(allsitepositions(lat)[i] + bravais(lat) * dn)
 
 isinregion(is::Tuple{Int,Int}, dns, ::Missing, lat) = true
-function isinregion((row, col)::Tuple{Int,Int}, (dnrow, dncol), region::Function, lat)
+function isinregion((row, col)::Tuple{Int,Int}, (dnrow, dncol), region::Union{Function,Region}, lat)
     br = bravais(lat)
-    r, dr = _rdr(sites(lat)[col] + br * dncol, sites(lat)[row] + br * dnrow)
+    r, dr = _rdr(allsitepositions(lat)[col] + br * dncol, allsitepositions(lat)[row] + br * dnrow)
     return region(r, dr)
 end
 
-isinsublats(s::Int, ::Missing) = true
-isinsublats(s::Int, sublats::Vector{Int}) = s in sublats
-isinsublats(ss::Pair{Int,Int}, ::Missing) = true
-isinsublats(ss::Pair{Int,Int}, sublats::Vector{Pair{Int,Int}}) = ss in sublats
+# There are no sublat ranges, so supporting (:A, (:B, :C)) is not necessary
+isinsublats(s::Integer, ::Missing) = true
+isinsublats(s::Integer, sublats) = s in sublats
+isinsublats(ss::Pair, ::Missing) = true
+isinsublats((i, j)::Pair, (is, js)::Pair) = i in is && j in js
+isinsublats(pair::Pair, sublats) = any(is -> isinsublats(pair, is), sublats)
 isinsublats(s, sublats) =
-    throw(ArgumentError("Sublattices $sublats in selector are not resolved."))
+    throw(ArgumentError("Sublattices $s in selector cannot be resolved."))
+
+# Here we can have (1, 2:3), apart from ((1,2) .=> (3,4), 1=>2) and ((1,2) => (3,4), 1=>2)
+isinindices(i::Integer, ::Missing) = true
+isinindices(i::Integer, j::Integer) = i == j
+isinindices(i::Integer, inds) = any(is -> i in is, inds)
+isinindices(is::Pair, inds) = isinindices(Tuple(is), inds)
+isinindices(is::Tuple, ::Missing) = true
+# Here is => js could be (1,2) => (3,4) or 1:2 => 3:4, not simply 1 => 3
+isinindices((i, j)::Tuple, (is, js)::Pair) = i in is && j in js
+# Here we support ((1,2) .=> (3,4), 3=>4) or ((1,2) .=> 3:4, 3=>4)
+isinindices(ind::Tuple, indpairs) = any(is -> isinindices(ind, is), indpairs)
+isinindices(ind, inds) =
+    throw(ArgumentError("Indices $ind in selector cannot be resolved."))
 
 isindns((dnrow, dncol)::Tuple{SVector,SVector}, dns) = isindns(dnrow - dncol, dns)
 isindns(dn::SVector{L,Int}, dns::Tuple{Vararg{SVector{L,Int}}}) where {L} = dn in dns
@@ -160,17 +248,18 @@ isindns(dn, dns) =
 
 isinrange(inds, ::Missing, lat) = true
 isinrange((row, col)::Tuple{Int,Int}, range::Number, lat) =
-    norm(sites(lat)[col] - sites(lat)[row]) <= range
+    norm(allsitepositions(lat)[col] - allsitepositions(lat)[row]) <= range
+
 
 # merge non-missing fields of s´ into s
 merge_non_missing(s::SiteSelector, s´::SiteSelector) =
     SiteSelector(merge_non_missing.(
-        (s.region,  s.sublats),
-        (s´.region, s´.sublats))...)
+        (s.region,  s.sublats, s.indices),
+        (s´.region, s´.sublats, s´.indices))...)
 merge_non_missing(s::HopSelector, s´::HopSelector) =
     HopSelector(merge_non_missing.(
-        (s.region,  s.sublats,  s.dns,  s.range),
-        (s´.region, s´.sublats, s´.dns, s´.range))...)
+        (s.region,  s.sublats,  s.dns,  s.range, s.indices),
+        (s´.region, s´.sublats, s´.dns, s´.range, s´.indices))...)
 merge_non_missing(o, o´::Missing) = o
 merge_non_missing(o, o´) = o´
 
@@ -182,16 +271,34 @@ function Base.adjoint(s::HopSelector)
     sublats´ = _adjoint.(s.sublats)
     dns´ = _adjoint.(s.dns)
     range = s.range
-    return HopSelector(region´, sublats´, dns´, range)
+    indices´ = _adjoint.(s.indices)
+    return HopSelector(region´, sublats´, dns´, range, indices´)
 end
 
 _adjoint(::Missing) = missing
 _adjoint(f::Function) = (r, dr) -> f(r, -dr)
 _adjoint(t::Pair) = reverse(t)
+_adjoint(t::Tuple) = _adjoint.(t)
 _adjoint(t::SVector) = -t
 
 # is_unconstrained_selector(s::HopSelector{Missing,Missing,Missing}) = true
 # is_unconstrained_selector(s::HopSelector) = false
+
+#######################################################################
+# sitepositions
+#######################################################################
+
+sitepositions(lat::AbstractArray, s::SiteSelector) = sitepositions(resolve(s, lat))
+
+sitepositions(rs::ResolvedSelector{<:SiteSelector}) = (s for (i, s) in enumerate(allsitepositions(rs.lattice)) if i in rs.selector)
+
+#######################################################################
+# siteindices
+#######################################################################
+
+siteindices(lat::AbstractArray, s::SiteSelector) = siteindices(resolve(s, lat))
+
+siteindices(rs::ResolvedSelector{<:SiteSelector}) = (i for i in eachindex(allsitepositions(rs.lattice)) if i in rs.selector)
 
 #######################################################################
 # Tightbinding types
@@ -255,7 +362,7 @@ HoppingTerm(t::HoppingTerm, os::HopSelector) =
 (h::HoppingTerm{<:Function})(r, dr) = h.coefficient * h.t(r, dr)
 (h::HoppingTerm)(r, dr) = h.coefficient * h.t
 
-sublats(t::TightbindingModelTerm, lat) = sublats(lat, t.selector)
+sublats(t::TightbindingModelTerm, lat) = resolve_sublats(t.selector, lat)
 
 sublats(m::TightbindingModel) = (t -> t.selector.sublats).(terms(m))
 
@@ -519,7 +626,7 @@ findblock(s, sr) = findfirst(r -> s in r, sr)
 #######################################################################
 # @onsite! and @hopping!
 #######################################################################
-abstract type ElementModifier{N,F,S} end
+abstract type ElementModifier{N,S,F} end
 
 struct ParametricFunction{N,F,P<:Val}
     f::F
@@ -530,19 +637,15 @@ ParametricFunction{N}(f::F, p::P) where {N,F,P} = ParametricFunction{N,F,P}(f, p
 
 (pf::ParametricFunction)(args...; kw...) = pf.f(args...; kw...)
 
-struct OnsiteModifier{N,F<:ParametricFunction{N},S<:Selector} <: ElementModifier{N,F,S}
+struct OnsiteModifier{N,S<:Selector,F<:ParametricFunction{N}} <: ElementModifier{N,S,F}
     f::F
     selector::S
 end
 
-OnsiteModifier(f, selector) = OnsiteModifier(f, selector, false)
-
-struct HoppingModifier{N,F<:ParametricFunction{N},S<:Selector} <: ElementModifier{N,F,S}
+struct HoppingModifier{N,S<:Selector,F<:ParametricFunction{N}} <: ElementModifier{N,S,F}
     f::F
     selector::S
 end
-
-HoppingModifier(f, selector) = HoppingModifier(f, selector, false)
 
 const UniformModifier = ElementModifier{1}
 const UniformHoppingModifier = HoppingModifier{1}
@@ -627,6 +730,8 @@ end
 
 get_kwname(x::Symbol) = x
 get_kwname(x::Expr) = x.head === :kw ? x.args[1] : x.head  # x.head == :...
+
+resolve(s::ResolvedSelector, lat) = s
 
 resolve(o::OnsiteModifier, lat) = OnsiteModifier(o.f, resolve(o.selector, lat))
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -183,7 +183,8 @@ Base.in(((i, j), (dni, dnj))::Tuple, rs::ResolvedSelector{<:SiteSelector}) =
     isinregion(i, dni, rs.selector.region, rs.lattice) &&
     isinsublats(sublat(rs.lattice, i), rs.selector.sublats)
 
-@inline function Base.in(is::Tuple{Integer,Integer}, rs::ResolvedSelector{<:HopSelector, LA}) where {E,L,LA<:AbstractLattice{E,L}}
+Base.in((j, i)::Pair{<:Integer,<:Integer}, rs::ResolvedSelector{<:HopSelector}) = (i, j) in rs
+function Base.in(is::Tuple{Integer,Integer}, rs::ResolvedSelector{<:HopSelector, LA}) where {E,L,LA<:AbstractLattice{E,L}}
     dn0 = zero(SVector{L,Int})
     return (is, (dn0, dn0)) in rs
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -73,7 +73,7 @@ siteselector(; region = missing, sublats = missing, indices = missing) =
 # sanitize_indices(is) = Iterators.flatten(is)
 
 """
-    hopselector(; region = missing, sublats = missing, dn = missing, range = missing, indices = missing)
+    hopselector(; region = missing, sublats = missing, indices = missing, dn = missing, range = missing)
 
 Return a `HopSelector` object that can be used to select hops between two sites in a
 lattice. Only hops between two sites, with indices `ipair = src => dst`, at positions `r₁ =
@@ -508,7 +508,7 @@ _onlyonsites(s, t::HoppingTerm, args...) = (_onlyonsites(s, args...)...,)
 _onlyonsites(s) = ()
 
 """
-    hopping(t; region = missing, sublats = missing, dn = missing, range = 1, plusadjoint = false)
+    hopping(t; region = missing, sublats = missing, indices = missing, dn = missing, range = 1, plusadjoint = false)
 
 Create an `TightbindingModel` with a single `HoppingTerm` that applies a hopping `t` to a
 `Lattice` when creating a `Hamiltonian` with `hamiltonian`.

--- a/src/parametric.jl
+++ b/src/parametric.jl
@@ -94,7 +94,7 @@ function parametric_ptrdata!(allptrs, h::Hamiltonian{LA,L,M,<:AbstractSparseMatr
         rows = rowvals(matrix)
         for col in 1:size(matrix, 2), ptr in nzrange(matrix, col)
             row = rows[ptr]
-            selected = selector(lat, (row, col), (dn, zero(dn)))
+            selected = ((row, col), (dn, zero(dn))) in selector
             if selected
                 push!(ptrdata, ptrdatum(t, lat, ptr, (row, col), dn))
                 push!(allptrs_har, ptr)
@@ -122,10 +122,10 @@ end
 ptrdatum(t::UniformModifier, lat, ptr, (row, col), dn) = ptr
 
 # Non-uniform case
-ptrdatum(t::OnsiteModifier, lat, ptr, (row, col), dn) = (ptr, sites(lat)[col])
+ptrdatum(t::OnsiteModifier, lat, ptr, (row, col), dn) = (ptr, allsitepositions(lat)[col])
 
 function ptrdatum(t::HoppingModifier, lat, ptr, (row, col), dn)
-    r, dr = _rdr(sites(lat)[col], sites(lat)[row] + bravais(lat) * dn)
+    r, dr = _rdr(allsitepositions(lat)[col], allsitepositions(lat)[row] + bravais(lat) * dn)
     return (ptr, r, dr)
 end
 

--- a/src/plot_makie.jl
+++ b/src/plot_makie.jl
@@ -107,7 +107,7 @@ function plot!(plot::HamiltonianPlot)
 end
 
 function plotsites!(plot, lat, srange, dn, n, color)
-    allsites = Quantica.sites(lat)
+    allsites = Quantica.allsitepositions(lat)
     br = lat.bravais.matrix
     sites = [padright(allsites[i] + br * dn, Val(3)) for i in srange]
     plot[:tooltips][] && (tt = [(site, 0, n) for site in srange])
@@ -137,7 +137,7 @@ end
 function plotlinks!(plot, lat, itr, dn, n, color)
     links = Pair{SVector{3,Float32},SVector{3,Float32}}[]
     plot[:tooltips][] && (tt = Tuple{Int,Int,Int}[])
-    sites = Quantica.sites(lat)
+    sites = Quantica.allsitepositions(lat)
     br = lat.bravais.matrix
     for (row, col) in itr
         iszero(dn) && row == col && continue

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -62,7 +62,7 @@ function linkstable(h::Hamiltonian, (a1, a2) = (1, 2))
     lat = h.lattice
     T = numbertype(lat)
     slats = sublats(lat)
-    rs = sites(lat)
+    rs = allsitepositions(lat)
     table = NamedTuple{(:x, :y, :x2, :y2, :sublat, :tooltip, :opacity, :islink),
                        Tuple{T,T,T,T,NameType,String,Float64,Bool}}[]
     h0 = h.harmonics[1].h

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -100,7 +100,7 @@ module RegionPresets
 
 using StaticArrays
 
-struct Region{E,F} <: Function
+struct Region{E,F}
     f::F
 end
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -22,7 +22,7 @@ unitvector(::Type{SVector{L,T}}, i) where {L,T} =
 ensuretuple(s::Tuple) = s
 ensuretuple(s) = (s,)
 
-tupletopair(s::Tuple) = Pair(first(s), last(s))
+indstopair(s::Tuple) = Pair(last(s), first(s))
 
 tuplemost(t::NTuple{N,Any}) where {N} = ntuple(i -> t[i], Val(N-1))
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -22,7 +22,7 @@ unitvector(::Type{SVector{L,T}}, i) where {L,T} =
 ensuretuple(s::Tuple) = s
 ensuretuple(s) = (s,)
 
-tupletopair(s::Tuple) = Pair(s...)
+tupletopair(s::Tuple) = Pair(first(s), last(s))
 
 tuplemost(t::NTuple{N,Any}) where {N} = ntuple(i -> t[i], Val(N-1))
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -29,6 +29,10 @@ using Quantica: Hamiltonian, ParametricHamiltonian
 
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(1.0, sublats = :A), orbitals = (Val(1), Val(2)))
     @test Quantica.nonsites(h) == 1
+
+    h = LatticePresets.square() |> unitcell(3) |> hamiltonian(hopping(1, indices = (1:8 .=> 2:9, 9=>1), range = 3, plusadjoint = true))
+    @test Quantica.nhoppings(h) == 48
+
 end
 
 @testset "hamiltonian unitcell" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -37,11 +37,19 @@ end
     end
 end
 
-
 @testset "siteindices/sitepositions" begin
     lat = LatticePresets.honeycomb() |> unitcell(region = RegionPresets.circle(10))
     @test sum(sitepositions(lat, sublats = :A)) ≈ -sum(sitepositions(lat, sublats = :B))
     @test length(collect(siteindices(lat, sublats = :A))) == nsites(lat) ÷ 2
+    
+    lat = LatticePresets.honeycomb() |> unitcell(2)
+    @test collect(siteindices(lat)) == 1:8
+    @test collect(siteindices(lat; indices = 10)) == Int[]
+    @test collect(siteindices(lat; indices = 5:10)) == 5:8
+    @test collect(siteindices(lat; indices = 5:10)) == 5:8
+    @test collect(siteindices(lat; indices = 5:10)) == 5:8
+    @test collect(siteindices(lat; indices = (1, 5:10))) == [1, 5 ,6, 7, 8]
+    @test collect(siteindices(lat; indices = (1, 10))) == [1]
 end
 
 @testset "lattice unitcell" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -37,6 +37,14 @@ end
     end
 end
 
+
+@testset "siteindices/sitepositions" begin
+    lat = LatticePresets.honeycomb() |> unitcell(region = RegionPresets.circle(10))
+    @test sum(sitepositions(lat, sublats = :A)) ≈ -sum(sitepositions(lat, sublats = :B))
+    @test length(collect(siteindices(lat, sublats = :A))) == nsites(lat) ÷ 2
+    @test siteindices(lat)
+end
+
 @testset "lattice unitcell" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -42,7 +42,6 @@ end
     lat = LatticePresets.honeycomb() |> unitcell(region = RegionPresets.circle(10))
     @test sum(sitepositions(lat, sublats = :A)) ≈ -sum(sitepositions(lat, sublats = :B))
     @test length(collect(siteindices(lat, sublats = :A))) == nsites(lat) ÷ 2
-    @test siteindices(lat)
 end
 
 @testset "lattice unitcell" begin


### PR DESCRIPTION
Closes #82 

This PR implements the `indices` kwarg in `Selector`s, and in doing so introduces some heavy refactoring of the whole `Selector` engine. See the updated `siteselector` and `hopselector` docstrings for details.

We now have `ResolvedSelector` in addition to `SiteSelector` and `HopSelector`. `ResolvedSelector` is produced by `resolve(::Selector, ::AbstractLattice)`, which now simply replaces sublat names with sublat indices, but does not do any further clever transformation of selection specs (i.e. things like `(:A, :B) => (:C, :D)` become `(1,2) => (3,4)`, but not (1=>3, 1=>4, 2=>3, 2=>4)` anymore). The actual interpretation of the different selector directives is done when querying whether a site or site pair is selected by the `ResolvedSelector`. This is now done using the `Base.in` function, which is more idiomatic than what we had before.

This change is motivated by the fact that, upon introducing `indices` in selectors, it makes much sense to allow ranges such as `hopselector(indices = 1:100 => 101:200)`, for example. If we were to expand that, checking membership as in `1=>2 in resolved_selector` would be very inefficient. Leaving the input form unexpanded and using dispatch is the optimal approach for  `indices`, so we might as well extend that to `sublats` while we are at it.

Together with this we now have to new functions in the API, `sitepositions(h; kw...)` (which replaces `sites`) and `siteindices(h; kw...)`. These return a (lazy) generator, that can be used in comprehensions to iterate over selected site positions and indices. Note that, as per the current Julia design, such generators have no eltype of length defined, so collecting them is not as fast as it could be. Iterating over them, however, is plenty fast.

`siteindices` also allows to refactor the `applyterms!` machinery used to build Hamiltonian from models. This PR also includes such refactor. It has the advantage that whatever future extension to selectors that we do will be automatically applied to Hamiltonian building.

So, with this PR we now have, amongst other combinations, the following type of possibilities,
```
onsite(1, indices = 1:100, region = ...)
hopping(1, indices = (1 => 3, 1:100 .=> 101:200), range = 2)
[ket(1, indices = s) for s in siteindices(h, region = ...)]
parametric(h, @hopping!((t; p) -> p; indices = 30 => 31))
```
