### PR TITLE
Allow range = (rmin, rmax)

### DIFF
--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -33,6 +33,14 @@ using Quantica: Hamiltonian, ParametricHamiltonian
     h = LatticePresets.square() |> unitcell(3) |> hamiltonian(hopping(1, indices = (1:8 .=> 2:9, 9=>1), range = 3, plusadjoint = true))
     @test Quantica.nhoppings(h) == 48
 
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (1, 1)))
+    @test Quantica.nhoppings(h) == 12
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (1, 2)))
+    @test Quantica.nhoppings(h) == 27
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (2, 1)))
+    @test Quantica.nhoppings(h) == 0
 end
 
 @testset "hamiltonian unitcell" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -36,8 +36,8 @@ using Quantica: Hamiltonian, ParametricHamiltonian
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (1, 1)))
     @test Quantica.nhoppings(h) == 12
 
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (1, 2)))
-    @test Quantica.nhoppings(h) == 27
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (1, 2/√3)))
+    @test Quantica.nhoppings(h) == 18
 
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (2, 1)))
     @test Quantica.nhoppings(h) == 0

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1,14 +1,16 @@
 using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector, sublats, resolve, isinindices, isinsublats
 
 @testset "selectors" begin
+    @test  isinsublats(1, missing)
     @test  isinsublats(1, 1)
     @test !isinsublats(2, 1)
     @test  isinsublats(1, (1,2))
     @test !isinsublats(3, (1,2))
-    # @test  isinsublats(3, (1, 3:4))  # Unsupported
-    # @test !isinsublats(2, (1, 3:4))  # Unsupported
-    @test !isinsublats(3, [1:2, 5:6])
+    # @test  isinsublats(3, (1, 3:4))   # Unsupported
+    # @test !isinsublats(2, (1, 3:4))   # Unsupported
+    # @test !isinsublats(3, [1:2, 5:6]) # Unsupported
 
+    @test  isinsublats(1=>2, missing)
     @test  isinsublats(1=>2, 1=>2)
     @test !isinsublats(1=>2, 1=>3)
     @test  isinsublats(1=>2, (1=>2, 3=>4))


### PR DESCRIPTION
Closes #86 

Nothing much to discuss here. Just a note on implementation. Instead of doing a tree search with NearestNeighbors strictly in the (rmin, rmax) range, we still do a target candidate search with rmax, and then rely on the selector check to exclude those with norm below rmin. Also, eps(T) padding of range is done to ensure that `range = (1,1)` selects anything at distance 1, regardless of floating point errors.