### PR TITLE
Bugfix min_range

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -603,22 +603,24 @@ function applyterm!(builder::IJVBuilder{L}, term::HoppingTerm) where {L}
     for (s2, s1) in sublats(rsel)  # Each is a Pair s2 => s1
         dns = dniter(rsel)
         for dn in dns
-            foundlink = false
+            keepgoing = false
             ijv = builder[dn]
             for j in source_candidates(rsel, s2)
                 sitej = allpos[j]
                 rsource = sitej - lat.bravais.matrix * dn
                 is = targets(builder, rsel.selector.range, rsource, s1)
                 for i in is
+                    # Make sure we don't stop searching until we reach minimum range
+                    is_below_min_range((i, j), (dn, zero(dn)), rsel) && (keepgoing = true)
                     ((i, j), (dn, zero(dn))) in rsel || continue
-                    foundlink = true
+                    keepgoing = true
                     rtarget = allsitepositions(lat)[i]
                     r, dr = _rdr(rsource, rtarget)
                     v = toeltype(term(r, dr), eltype(builder), builder.orbs[s1], builder.orbs[s2])
                     push!(ijv, (i, j, v))
                 end
             end
-            foundlink && acceptcell!(dns, dn)
+            keepgoing && acceptcell!(dns, dn)
         end
     end
     return nothing

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -472,6 +472,9 @@ siterange(lat::AbstractLattice, sublat) = siterange(lat.unitcell, sublat)
 
 allsitepositions(lat::AbstractLattice) = sitepositions(lat.unitcell)
 
+siteposition(i, lat::AbstractLattice) = allsitepositions(lat)[i]
+siteposition(i, dn::SVector, lat::AbstractLattice) = siteposition(i, lat) + bravais(lat) * dn
+
 offsets(lat::AbstractLattice) = offsets(lat.unitcell)
 
 sublatsites(lat::AbstractLattice) = sublatsites(lat.unitcell)

--- a/src/model.jl
+++ b/src/model.jl
@@ -194,6 +194,12 @@ isinrange((row, col), (dnrow, dncol), range, lat) =
 _isinrange(p, rmax::Real) = p'p <= rmax^2
 _isinrange(p, (rmin, rmax)::Tuple{Real,Real}) =  rmin^2 <= p'p <= rmax^2
 
+is_below_min_range(inds, dns, rsel::ResolvedSelector) =
+    is_below_min_range(inds, dns, rsel.selector.range, rsel.lattice)
+is_below_min_range((i, j), (dni, dnj), (rmin, rmax)::Tuple, lat) =
+    norm(siteposition(i, dni, lat) - siteposition(j, dnj, lat)) < rmin
+is_below_min_range(inds, dn, range, lat) = false
+
 # There are no sublat ranges, so supporting (:A, (:B, :C)) is not necessary
 isinsublats(s::Integer, ::Missing) = true
 isinsublats(s::Integer, sublats) = s in sublats

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -41,6 +41,9 @@ using Quantica: Hamiltonian, ParametricHamiltonian
 
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (2, 1)))
     @test Quantica.nhoppings(h) == 0
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (30, 30)))
+    @test Quantica.nhoppings(h) == 12
 end
 
 @testset "hamiltonian unitcell" begin


### PR DESCRIPTION
There was an edge case opened by #87 whereby a min_range larger than several bravais vectors would make the search algorithm for hoppings bail out too soon and link nothing. This resolves the issue by not allowing the search to stop until min_range is surpassed