### PR TITLE
NeighborRange default for hopping range

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 # Exported API
 - `lattice`, `sublat`, `bravais`: build lattices
 - `dims`, `sitepositions`, `siteindices`: inspect lattices
-- `hopping`, `onsite`, `siteselector`, `hopselector`: build tightbinding models
+- `hopping`, `onsite`, `siteselector`, `hopselector`, `nrange`: build tightbinding models
 - `hamiltonian`: build a Hamiltonian from tightbinding model and a lattice
 - `parametric`, `@onsite!`, `@hopping!`, `parameters`: build a parametric Hamiltonian
 - `supercell`, `unitcell`, `flatten`, `wrap`, `transform!`, `combine`: build derived lattices or Hamiltonians

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -18,7 +18,7 @@ using ExprTools
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
 export sublat, bravais, lattice, dims, supercell, unitcell,
-       hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector,
+       hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector, nrange,
        sitepositions, siteindices,
        ket, randomkets,
        hamiltonian, parametric, bloch, bloch!, optimize!, similarmatrix,

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -603,22 +603,24 @@ function applyterm!(builder::IJVBuilder{L}, term::HoppingTerm) where {L}
     for (s2, s1) in sublats(rsel)  # Each is a Pair s2 => s1
         dns = dniter(rsel)
         for dn in dns
-            foundlink = false
+            keepgoing = false
             ijv = builder[dn]
             for j in source_candidates(rsel, s2)
                 sitej = allpos[j]
                 rsource = sitej - lat.bravais.matrix * dn
                 is = targets(builder, rsel.selector.range, rsource, s1)
                 for i in is
+                    # Make sure we don't stop searching until we reach minimum range
+                    is_below_min_range((i, j), (dn, zero(dn)), rsel) && (keepgoing = true)
                     ((i, j), (dn, zero(dn))) in rsel || continue
-                    foundlink = true
+                    keepgoing = true
                     rtarget = allsitepositions(lat)[i]
                     r, dr = _rdr(rsource, rtarget)
                     v = toeltype(term(r, dr), eltype(builder), builder.orbs[s1], builder.orbs[s2])
                     push!(ijv, (i, j, v))
                 end
             end
-            foundlink && acceptcell!(dns, dn)
+            keepgoing && acceptcell!(dns, dn)
         end
     end
     return nothing

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -472,6 +472,9 @@ siterange(lat::AbstractLattice, sublat) = siterange(lat.unitcell, sublat)
 
 allsitepositions(lat::AbstractLattice) = sitepositions(lat.unitcell)
 
+siteposition(i, lat::AbstractLattice) = allsitepositions(lat)[i]
+siteposition(i, dn::SVector, lat::AbstractLattice) = siteposition(i, lat) + bravais(lat) * dn
+
 offsets(lat::AbstractLattice) = offsets(lat.unitcell)
 
 sublatsites(lat::AbstractLattice) = sublatsites(lat.unitcell)

--- a/src/model.jl
+++ b/src/model.jl
@@ -280,6 +280,12 @@ isinrange((row, col), (dnrow, dncol), range, lat) =
 _isinrange(p, rmax::Real) = p'p <= rmax^2
 _isinrange(p, (rmin, rmax)::Tuple{Real,Real}) =  rmin^2 <= p'p <= rmax^2
 
+is_below_min_range(inds, dns, rsel::ResolvedSelector) =
+    is_below_min_range(inds, dns, rsel.selector.range, rsel.lattice)
+is_below_min_range((i, j), (dni, dnj), (rmin, rmax)::Tuple, lat) =
+    norm(siteposition(i, dni, lat) - siteposition(j, dnj, lat)) < rmin
+is_below_min_range(inds, dn, range, lat) = false
+
 # There are no sublat ranges, so supporting (:A, (:B, :C)) is not necessary
 isinsublats(s::Integer, ::Missing) = true
 isinsublats(s::Integer, sublats) = s in sublats

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -156,8 +156,31 @@ function ispositive(ndist)
     return result
 end
 
+function non_negative_dn_shell(::Val{L}) where {L}
+    dns = CartesianIndices(filltuple(-1:1, Val(L))) .|> Tuple .|> SVector{L,Int} |> vec
+    filter!(t -> iszero(t) || ispositive(t), dns)
+    return dns
+end
+
+non_negative_dn_shell(::Val{0}) = (SVector{0,Int}(),)
+
 chop(x::T, x0 = one(T)) where {T<:Real} = ifelse(abs(x) < √eps(T(x0)), zero(T), x)
 chop(x::C, x0 = one(R)) where {R<:Real,C<:Complex{R}} = chop(real(x), x0) + im*chop(imag(x), x0)
+
+function unique_sorted_approx!(v::AbstractVector{T}) where {T}
+    i = 1
+    xprev = first(v)
+    for j in 2:length(v)
+        if v[j] ≈ xprev
+            xprev = v[j]
+        else
+            i += 1
+            xprev = v[i] = v[j]
+        end
+    end
+    resize!(v, i)
+    return v
+end
 
 ############################################################################################
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -156,14 +156,6 @@ function ispositive(ndist)
     return result
 end
 
-function non_negative_dn_shell(::Val{L}) where {L}
-    dns = CartesianIndices(filltuple(-1:1, Val(L))) .|> Tuple .|> SVector{L,Int} |> vec
-    filter!(t -> iszero(t) || ispositive(t), dns)
-    return dns
-end
-
-non_negative_dn_shell(::Val{0}) = (SVector{0,Int}(),)
-
 chop(x::T, x0 = one(T)) where {T<:Real} = ifelse(abs(x) < √eps(T(x0)), zero(T), x)
 chop(x::C, x0 = one(R)) where {R<:Real,C<:Complex{R}} = chop(real(x), x0) + im*chop(imag(x), x0)
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -44,6 +44,9 @@ using Quantica: Hamiltonian, ParametricHamiltonian, nhoppings
 
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (30, 30)))
     @test Quantica.nhoppings(h) == 12
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (10, 10.1)))
+    @test Quantica.nhoppings(h) == 48
 end
 
 @testset "hamiltonian unitcell" begin
@@ -354,4 +357,6 @@ end
     @test hamiltonian(lat, hopping(1, range = nrange(2))) |> nhoppings == 18
     @test hamiltonian(lat, hopping(1, range = nrange(3))) |> nhoppings == 24
     @test hamiltonian(lat, hopping(1, range = (nrange(2), nrange(3)))) |> nhoppings == 18
+    @test hamiltonian(lat, hopping(1, range = (nrange(20), nrange(20)))) |> nhoppings == 18
+    @test hamiltonian(lat, hopping(1, range = (nrange(20), nrange(21)))) |> nhoppings == 30
 end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -40,7 +40,10 @@ using Quantica: Hamiltonian, ParametricHamiltonian, nhoppings
     @test nhoppings(h) == 18
 
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (2, 1)))
-    @test nhoppings(h) == 0
+    @test Quantica.nhoppings(h) == 0
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (30, 30)))
+    @test Quantica.nhoppings(h) == 12
 end
 
 @testset "hamiltonian unitcell" begin


### PR DESCRIPTION
This implements a new default behavior for the `range` keyword in `hopping`. This default used to be hard-coded to `range = 1`, which is rather arbitrary and can lead to surprises, as discussed in #85.

With this PR, the default for `hopping` is `range = nrange(1)`, where `nrange(n)` creates a `NeighborRange` object that represents the distance between nᵗʰ-order nearest-neighbors of a lattice's sites. `nrange` is a new exported function. 

The default behavior for something like `hopping(1)` then corresponds to nearest neighbors only (`nrange(1)`)
```
julia> h = LatticePresets.honeycomb(a0 = 0.24) |> hamiltonian(hopping(1))
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
  Harmonic size    : 2 × 2
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (Complex{Float64})
  Onsites          : 0
  Hoppings         : 6
  Coordination     : 3.0
```

We can also choose to specify hoppings up to second-nearest neighbors with
```
julia> h = LatticePresets.honeycomb(a0 = 0.24) |> hamiltonian(hopping(1, range = nrange(2)))
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 7 (SparseMatrixCSC, sparse)
  Harmonic size    : 2 × 2
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (Complex{Float64})
  Onsites          : 0
  Hoppings         : 18
  Coordination     : 9.0
```

Since #87 we can also specify (inclusive) range intervals. This ability extends to `NeighborRanges` now.
```
julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (nrange(2), nrange(3))))
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 9 (SparseMatrixCSC, sparse)
  Harmonic size    : 2 × 2
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (Complex{Float64})
  Onsites          : 0
  Hoppings         : 18
  Coordination     : 9.0

julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (nrange(3), nrange(3))))
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
  Harmonic size    : 2 × 2
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (Complex{Float64})
  Onsites          : 0
  Hoppings         : 6
  Coordination     : 3.0
```

Apart from `nrange(n::Int)`, `nrange` has a second method `nrange(n::Int, lat::AbstractLattice)` that computes said distance for a given lattice. So, for example
```
julia> lat = LatticePresets.honeycomb(a0 = 1); nrange(1, lat) ≈ 1/√3
true

julia> lat = LatticePresets.honeycomb(a0 = 2); nrange(1, lat) ≈ 2/√3
true

julia> lat = LatticePresets.honeycomb(a0 = 2); nrange(2, lat) ≈ 2
true
```