### PR TITLE
Draw intercell hoppings as full lines in VegaLite

### DIFF
--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -94,7 +94,7 @@ function linkstable(h::Hamiltonian, (a1, a2) = (1, 2))
                         push!(rows, row)
                     end
                     # draw half-links but only intracell
-                    iszero(har.dn) && (rdst = (rsrc + rdst)/2)
+                    rdst = iszero(dn) ? (rdst + rsrc) / 2 : rdst
                     x  = get(rsrc, a1, zero(T)); y  = get(rsrc, a2, zero(T))
                     x´ = get(rdst, a1, zero(T)); y´ = get(rdst, a2, zero(T))
                     # Exclude links perpendicular to the screen

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -93,7 +93,8 @@ function linkstable(h::Hamiltonian, (a1, a2) = (1, 2))
                             opacity = 0.5, islink = false))
                         push!(rows, row)
                     end
-                    rdst = (rsrc + rdst)/2
+                    # draw half-links but only intracell
+                    iszero(har.dn) && (rdst = (rsrc + rdst)/2)
                     x  = get(rsrc, a1, zero(T)); y  = get(rsrc, a2, zero(T))
                     x´ = get(rdst, a1, zero(T)); y´ = get(rdst, a2, zero(T))
                     # Exclude links perpendicular to the screen

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -94,7 +94,7 @@ function linkstable(h::Hamiltonian, (a1, a2) = (1, 2))
                         push!(rows, row)
                     end
                     # draw half-links but only intracell
-                    rdst = iszero(dn) ? (rdst + rsrc) / 2 : rdst
+                    rdst = iszero(har.dn) ? (rdst + rsrc) / 2 : rdst
                     x  = get(rsrc, a1, zero(T)); y  = get(rsrc, a2, zero(T))
                     x´ = get(rdst, a1, zero(T)); y´ = get(rdst, a2, zero(T))
                     # Exclude links perpendicular to the screen


### PR DESCRIPTION
This makes it equivalent to the behaviour with Makie. 

Before:
<img width="613" alt="Screen Shot 2020-09-19 at 20 20 10" src="https://user-images.githubusercontent.com/4310809/93686291-90961180-fab5-11ea-87ef-4a8c5518b11f.png">

After:
<img width="622" alt="Screen Shot 2020-09-19 at 20 20 19" src="https://user-images.githubusercontent.com/4310809/93686295-95f35c00-fab5-11ea-8590-e235dda447a2.png">
