### PR TITLE
Makie plots: unshaded sites that scale correctly with zoom

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -331,22 +331,6 @@ nsublats(h::Hamiltonian) = nsublats(h.lattice)
 
 norbitals(h::Hamiltonian) = length.(h.orbitals)
 
-function meandist(h::Hamiltonian)
-    distsum = 0.0
-    num = 0
-    ss = allsitepositions(h.lattice)
-    br = h.lattice.bravais.matrix
-    for (dn, row, col) in nonzero_indices(h)
-        if row != col
-            num += 1
-            rsrc = ss[col]
-            rdst = ss[row] + br * dn
-            distsum += norm(rsrc - rdst)
-        end
-    end
-    return iszero(num) ? 0.0 : distsum / num
-end
-
 # External API #
 
 """


### PR DESCRIPTION
This requires Makie 0.11.1 or later. Since it is not a direct Quantica dependence, the user should make sure that their installed version is sufficiently new.

Previously the points in Makie scatter plots were of a fixed size in pixel space. Since 0.11.1 we can now set a fixed size in Scene space. This allows sites plotted with the default unshaded method (fast) to scale just as shaded sites. So now sites at two zoom levels are scaled as expected

<img width="325" alt="Screen Shot 2020-09-19 at 20 42 34" src="https://user-images.githubusercontent.com/4310809/93686810-28492f00-fab9-11ea-824c-957ac8115187.png">
<img width="432" alt="Screen Shot 2020-09-19 at 20 46 21" src="https://user-images.githubusercontent.com/4310809/93686816-326b2d80-fab9-11ea-925e-37038c715f88.png">

This PR also introduces a fix to `linkoffset` plot keyword, so that `linkoffset = 0` (the default) corresponds to links that just touch the site borders, as in the plots above
