### PR TITLE
Bugfix in combined_offsets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1.4'
-          - 'nightly'
+          - '1.5'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -554,19 +554,18 @@ function Base.isequal(b1::Bravais{E,L}, b2::Bravais{E,L}) where {E,L}
     return true
 end
 
+# should be cumsum([diff.(offset)...]) but non-allocating
 function combined_offsets(us::Unitcell...)
     nsubs = sum(nsublats, us)
     offsets = Vector{Int}(undef, nsubs + 1)
-    lastoffset = 0
-    idx = 1
+    offsets[1] = 0
+    idx = 2
     for u in us
-        for idx´ in 1:(length(u.offsets) - 1)
-            offsets[idx] = lastoffset + u.offsets[idx´]
+        for idx´ in 2:length(u.offsets)
+            offsets[idx] = offsets[idx-1] + u.offsets[idx´] - u.offsets[idx´-1]
             idx += 1
         end
-        lastoffset = u.offsets[end]
     end
-    offsets[end] = lastoffset + last(us).offsets[end]
     return offsets
 end
 

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -41,7 +41,7 @@ end
     lat = LatticePresets.honeycomb() |> unitcell(region = RegionPresets.circle(10))
     @test sum(sitepositions(lat, sublats = :A)) ≈ -sum(sitepositions(lat, sublats = :B))
     @test length(collect(siteindices(lat, sublats = :A))) == nsites(lat) ÷ 2
-    
+
     lat = LatticePresets.honeycomb() |> unitcell(2)
     @test collect(siteindices(lat)) == 1:8
     @test collect(siteindices(lat; indices = 10)) == Int[]
@@ -50,6 +50,17 @@ end
     @test collect(siteindices(lat; indices = 5:10)) == 5:8
     @test collect(siteindices(lat; indices = (1, 5:10))) == [1, 5 ,6, 7, 8]
     @test collect(siteindices(lat; indices = (1, 10))) == [1]
+end
+
+@testset "lattice combine" begin
+    lat0 = transform!(r -> SA[r[2], -r[1]], LatticePresets.honeycomb()) |> unitcell((1,1), (-1,1))
+    br = bravais(lat0)
+    cell_1 = lat0 |>
+        unitcell(region = r -> -1.01/√3 <= r[1] <= 4/√3 && 0 <= r[2] <= 3.5)
+    cell_2 = transform!(r -> r + br * SA[2.2, -1], copy(cell_1))
+    cell_p = lattice(sublat(br * SA[1.6,0.73], br * SA[1.6,1.27]))
+    cells = combine(cell_1, cell_2, cell_p)
+    @test Quantica.nsites.(Ref(cells), 1:5) == [14, 14, 14, 14, 2]
 end
 
 @testset "lattice unitcell" begin


### PR DESCRIPTION
There was a bug that broke the use of `combine` on more than two lattices.