### PR TITLE
Extending transform! for general-purpose mutation

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -32,7 +32,7 @@ function spectrum(h; method = defaultmethod(h), transform = missing)
     bloch!(matrix, h)
     (ϵk, ψk) = diagonalize(matrix, method)
     s = Spectrum(ϵk, ψk)
-    transform === missing || transform!(transform, s)
+    transform === missing || transform!(s, transform)
     return s
 end
 
@@ -57,11 +57,11 @@ Return the states of `s` as the columns of a `Matrix`
 states(s::Spectrum) = s.states
 
 """
-    transform!(f::Function, s::Spectrum)
+    transform!(s::Spectrum, f::Function)
 
 Transform the energies of `s` by applying `f` to them in place.
 """
-transform!(f, s::Spectrum) = (map!(f, s.energies, s.energies); s)
+transform!(s::Spectrum, f::Function) = (map!(f, s.energies, s.energies); s)
 
 #######################################################################
 # Bandstructure
@@ -134,11 +134,11 @@ states(bs::Bandstructure, i) = states(bands(bs)[i])
 states(b::Band) = reshape(b.states, b.dimstates, :)
 
 """
-    transform!(f::Function, b::Bandstructure)
+    transform!(b::Bandstructure, f::Function)
 
 Transform the energies of all bands in `b` by applying `f` to them in place.
 """
-function transform!(f, bs::Bandstructure)
+function transform!(bs::Bandstructure, f::Function)
     for band in bands(bs)
         vs = vertices(band)
         for (i, v) in enumerate(vs)
@@ -271,7 +271,7 @@ function bandstructure(h::Union{Hamiltonian,ParametricHamiltonian}, mesh::Mesh;
     d = DiagonalizeHelper(method, codiag, minoverlap)
     matrixf(ϕs) = bloch!(matrix, h, applylift(lift, ϕs))
     b = _bandstructure(matrixf, matrix, mesh, d)
-    transform === missing || transform!(transform, b)
+    transform === missing || transform!(b, transform)
     return b
 end
 
@@ -283,7 +283,7 @@ function bandstructure(matrixf::Function, mesh::Mesh;
     codiag = codiagonalizer(matrixf´, matrix, mesh)
     d = DiagonalizeHelper(method´, codiag, minoverlap)
     b = _bandstructure(matrixf´, matrix, mesh, d)
-    transform === missing || transform!(transform, b)
+    transform === missing || transform!(b, transform)
     return b
 end
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -23,5 +23,5 @@ Base.promote(ss::Sublat{E,T}...) where {E,T} = ss
 Base.promote_rule(::Type{Sublat{E1,T1}}, ::Type{Sublat{E2,T2}}) where {E1,E2,T1,T2} =
     Sublat{max(E1, E2), promote_type(T1, T2)}
 
-Bravais{E,L,T}(b::Bravais) where {E,L,T} =
+(::Type{B})(b::Bravais) where {E,L,T,B<:Bravais{E,L,T}} =
     Bravais(padtotype(b.matrix, SMatrix{E,L,T}), padright(b.semibounded, Val(L)))

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -356,14 +356,24 @@ siteindices(lat::AbstractLattice; kw...) = siteindices(lat, siteselector(;kw...)
 siteindices(h::Hamiltonian; kw...) = siteindices(h.lattice, siteselector(;kw...))
 
 """
-    transform!(f::Function, h::Hamiltonian)
+    transform!(h::Hamiltonian, f::Function)
 
 Transform the site positions of the Hamiltonian's lattice in place without modifying the
 Hamiltonian harmonics.
+
+    transform!(h::Hamiltonian, bravais::Bravais)
+
+Replace the Bravais matrix of `h`'s lattice with `bravais` in place.
+
 """
-function transform!(f, h::Hamiltonian)
-    transform!(f, h.lattice)
+function transform!(h::Hamiltonian, f::Function)
+    transform!(h.lattice, f)
     return h
+end
+
+function transform!(h::Hamiltonian, br::Bravais)
+    transform!(h.lattice, br)
+    return h´
 end
 
 # Indexing #

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -113,7 +113,7 @@ sanitize_semibounded(sb::NTuple{L,Bool}, ::SMatrix{E,L}) where {E,L} = SVector{L
 sanitize_semibounded(sb, ::SMatrix{E,L}) where {E,L} =
     SVector{L,Bool}(ntuple(i -> i in sb, Val(L)))
 
-transform(f::F, b::Bravais{E,0}) where {E,F<:Function} = b
+transform(b::Bravais{E,0}, f::F) where {E,F<:Function} = b
 
 function transform(b::Bravais{E,L,T}, f::F) where {E,L,T,F<:Function}
     svecs = let z = zero(SVector{E,T})

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -53,7 +53,7 @@ function minmax_edge(m::Mesh{D,T}) where {D,T<:Real}
     return minedge, maxedge
 end
 
-transform!(f::Function, m::Mesh) = (map!(f, vertices(m), vertices(m)); m)
+transform!(m::Mesh, f::Function) = (map!(f, vertices(m), vertices(m)); m)
 
 ######################################################################
 # Compute N-simplices (N = number of vertices)

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -78,10 +78,10 @@ function twisted_bilayer_graphene(;
     htop = hamiltonian(lattop, modelintra; kw...) |> unitcell(sctop)
     hbot = hamiltonian(latbot, modelintra; kw...) |> unitcell(scbot)
     let R = @SMatrix[cos(θ/2) -sin(θ/2) 0; sin(θ/2) cos(θ/2) 0; 0 0 1]
-        transform!(r -> R * r, htop)
+        transform!(htop, r -> R * r)
     end
     let R = @SMatrix[cos(θ/2) sin(θ/2) 0; -sin(θ/2) cos(θ/2) 0; 0 0 1]
-        transform!(r -> R * r, hbot)
+        transform!(hbot, r -> R * r)
     end
     modelinter = hopping((r,dr) -> (
         hopintra * exp(-3*(norm(dr)/a0 - 1))  *  dot(dr, SVector(1,1,0))^2/sum(abs2, dr) -

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -41,12 +41,12 @@ end
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2) + hopping(-1, range = 1/√3))
     mesh1D = marchingmesh((0, 2π))
     b = bandstructure(h, mesh1D, lift = φ -> (φ, -φ), transform = inv)
-    b´ = transform!(inv, bandstructure(h, mesh1D, lift = φ -> (φ, -φ)))
+    b´ = transform!(bandstructure(h, mesh1D, lift = φ -> (φ, -φ)), inv)
     @test length(bands(b)) == length(bands(b´)) == 2
     @test vertices(bands(b)[1]) == vertices(bands(b´)[1])
     h´ = unitcell(h)
     s1 = spectrum(h´, transform = inv)
-    s2 = transform!(inv,spectrum(h´))
+    s2 = transform!(spectrum(h´), inv)
     @test energies(s1) == energies(s2)
     # automatic lift from 2D to 3D
     h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(2)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -63,6 +63,12 @@ end
     @test bloch(wh) ≈ bloch(h, (1,2,3))
 end
 
+@testset "hamiltonian transform!" begin
+    h = LatticePresets.square() |> hamiltonian(hopping(1))
+    transform!(h, r->2r)
+    @test bravais(h) ≈ SA[2 0; 0 2]
+end
+
 @testset "similarmatrix" begin
     types = (ComplexF16, ComplexF32, ComplexF64)
     lat = LatticePresets.honeycomb()

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,5 +1,5 @@
 using Quantica: nsites, Sublat, Bravais, Lattice, Superlattice
-using Random
+using Random, LinearAlgebra
 
 @testset "bravais" begin
     @test bravais() isa Bravais{0,0,Float64,0}
@@ -25,6 +25,16 @@ end
         @test lattice(b, s, type = t, dim = Val(e)) isa Lattice{e,min(l,e),t}
         @test lattice(b, s, type = t, dim = e) isa Lattice{e,min(l,e),t}
     end
+end
+
+@testset "lattice transform!" begin
+    lat = LatticePresets.honeycomb()
+    transform!(lat, r -> 2r)
+    @test norm(bravais(lat)[:,1]) ≈ 2 && norm(bravais(lat)[:,2]) ≈ 2
+    transform!(lat, r -> SA[r[2], -r[1]])
+    @test all(r -> r[2] ≈ 0, Quantica.allsitepositions(lat))
+    transform!(lat, bravais((1,0), (0, 1)))
+    @test bravais(lat) == SA[1 0; 0 1]
 end
 
 @testset "lattice presets" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -63,11 +63,11 @@ end
 end
 
 @testset "lattice combine" begin
-    lat0 = transform!(r -> SA[r[2], -r[1]], LatticePresets.honeycomb()) |> unitcell((1,1), (-1,1))
+    lat0 = transform!(LatticePresets.honeycomb(), r -> SA[r[2], -r[1]]) |> unitcell((1,1), (-1,1))
     br = bravais(lat0)
     cell_1 = lat0 |>
         unitcell(region = r -> -1.01/√3 <= r[1] <= 4/√3 && 0 <= r[2] <= 3.5)
-    cell_2 = transform!(r -> r + br * SA[2.2, -1], copy(cell_1))
+    cell_2 = transform!(copy(cell_1), r -> r + br * SA[2.2, -1])
     cell_p = lattice(sublat(br * SA[1.6,0.73], br * SA[1.6,1.27]))
     cells = combine(cell_1, cell_2, cell_p)
     @test Quantica.nsites.(Ref(cells), 1:5) == [14, 14, 14, 14, 2]


### PR DESCRIPTION
We need a unified mechanism to mutate object properties, e.g. changing the Bravais matrix of a lattice or a Hamiltonian. This PR repurposes `transform!` to modify various objects in place, and adds the functionality of changing Bravais matrices of Lattices and Hamiltonians (to be extended as needed in the future). The original functionality `transform!(lat, f::Function)` is preserved, but no takes the function as second argument, so that *always* the first argument is mutated. To make this work, we need to make `Lattice` a mutable struct (not `Hamiltonian`, for the moment).