### PR TITLE
Move bravais to kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 - Compute electronic structures and expectation values using Kernel Polynomial methods
 
 # Exported API
-- `lattice`, `sublat`, `bravais`: build lattices
-- `dims`, `sitepositions`, `siteindices`: inspect lattices
+- `lattice`, `sublat`: build lattices
 - `hopping`, `onsite`, `siteselector`, `hopselector`, `nrange`: build tightbinding models
 - `hamiltonian`: build a Hamiltonian from tightbinding model and a lattice
 - `parametric`, `@onsite!`, `@hopping!`, `parameters`: build a parametric Hamiltonian
+- `dims`, `sitepositions`, `siteindices`, `bravais`: inspect lattices and Hamiltonians
 - `supercell`, `unitcell`, `flatten`, `wrap`, `transform!`, `combine`: build derived lattices or Hamiltonians
 - `marchingmesh`, `linearmesh`: define a specification to build a bandstructure discretization mesh
 - `bandstructure`, `spectrum`: compute the generalized bandstructure of a Hamiltonian or a ParametricHamiltonian

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -23,5 +23,4 @@ Base.promote(ss::Sublat{E,T}...) where {E,T} = ss
 Base.promote_rule(::Type{Sublat{E1,T1}}, ::Type{Sublat{E2,T2}}) where {E1,E2,T1,T2} =
     Sublat{max(E1, E2), promote_type(T1, T2)}
 
-Bravais{E,L,T}(b::Bravais) where {E,L,T} =
-    Bravais(padtotype(b.matrix, SMatrix{E,L,T}), padright(b.semibounded, Val(L)))
+Bravais{E,L,T}(b::Bravais) where {E,L,T} = Bravais(padtotype(b.matrix, SMatrix{E,L,T}))

--- a/src/plot_makie.jl
+++ b/src/plot_makie.jl
@@ -42,7 +42,7 @@ function mindist(h::Hamiltonian)
     distmin = zero(Float64)
     num = 0
     ss = allsitepositions(h.lattice)
-    br = h.lattice.bravais.matrix
+    br = bravais(h.lattice)
     for (dn, row, col) in nonzero_indices(h)
         if row != col
             num += 1
@@ -121,7 +121,7 @@ end
 
 function plotsites!(plot, lat, srange, dn, n, color)
     allsites = Quantica.allsitepositions(lat)
-    br = lat.bravais.matrix
+    br = bravais(lat)
     sites = [padright(allsites[i] + br * dn, Val(3)) for i in srange]
     plot[:tooltips][] && (tt = [(site, 0, n) for site in srange])
     if !isempty(sites)
@@ -153,7 +153,7 @@ function plotlinks!(plot, lat, itr, dn, n, color)
     links = Pair{SVector{3,Float32},SVector{3,Float32}}[]
     plot[:tooltips][] && (tt = Tuple{Int,Int,Int}[])
     sites = Quantica.allsitepositions(lat)
-    br = lat.bravais.matrix
+    br = bravais(lat)
     for (row, col) in itr
         iszero(dn) && row == col && continue
         rdst = padright(sites[row] + br * dn, Val(3))

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,10 +1,10 @@
 toSMatrix() = SMatrix{0,0,Float64}()
-toSMatrix(ss::NTuple{N,Number}...) where {N} = toSMatrix(SVector{N}.(ss)...)
-toSMatrix(ss::SVector{N}...) where {N} = hcat(ss...)
-toSMatrix(::Type{T}, ss...) where {T} = _toSMatrix(T, toSMatrix(ss...))
+toSMatrix(s) = toSMatrix(tuple(s))
+toSMatrix(ss::NTuple{M,NTuple{N,Number}}) where {N,M} = toSMatrix(SVector{N}.(ss))
+toSMatrix(ss::NTuple{M,SVector{N}}) where {N,M} = hcat(ss...)
+toSMatrix(::Type{T}, ss) where {T} = _toSMatrix(T, toSMatrix(ss))
 _toSMatrix(::Type{T}, s::SMatrix{N,M}) where {N,M,T} = convert(SMatrix{N,M,T}, s)
 # Dynamic dispatch
-toSMatrix(ss::AbstractVector...) = toSMatrix(Tuple.(ss)...)
 toSMatrix(s::AbstractMatrix) = SMatrix{size(s,1), size(s,2)}(s)
 
 toSVector(::Tuple{}) = SVector{0,Float64}()

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -29,6 +29,8 @@ end
     for a0 in a0s, t in (Float32, Float64), e in 1:4, preset in presets
         @test preset(; a0 = a0, type = t, dim = e) isa Lattice{e,<:Any,t}
     end
+    @test LatticePresets.cubic(bravais = (1,0)) isa Lattice{3,1}
+    @test LatticePresets.cubic(bravais = ((1,0), (0,1)), dim = Val(2)) isa Lattice{2,2}
 end
 
 @testset "siteindices/sitepositions" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,12 +1,6 @@
 using Quantica: nsites, Sublat, Bravais, Lattice, Superlattice
 using Random
-
-@testset "bravais" begin
-    @test bravais() isa Bravais{0,0,Float64,0}
-    @test bravais((1, 2), (3, 3)) isa Bravais{2,2,Int,4}
-    @test bravais(@SMatrix[1.0 2; 3 3]) isa Bravais{2,2,Float64,4}
-    @test bravais((1,0), semibounded = false) isa Bravais{2,1,Int,2}
-end
+using LinearAlgebra: I
 
 @testset "sublat" begin
     sitelist = [(3,3), (3,3.), [3,3.], SA[3, 3], SA[3, 3f0], SA[3f0, 3.]]
@@ -21,9 +15,9 @@ end
 @testset "lattice" begin
     s = sublat((1, 2))
     for t in (Float32, Float64), e in 1:4, l = 1:4
-        b = bravais(ntuple(_ -> (1,), l)...)
-        @test lattice(b, s, type = t, dim = Val(e)) isa Lattice{e,min(l,e),t}
-        @test lattice(b, s, type = t, dim = e) isa Lattice{e,min(l,e),t}
+        br = SMatrix{l,l,Float64}(I)
+        @test lattice(s; bravais = br, type = t, dim = Val(e)) isa Lattice{e,min(l,e),t}
+        @test lattice(s; bravais = br, type = t, dim = e) isa Lattice{e,min(l,e),t}
     end
 end
 
@@ -32,8 +26,8 @@ end
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular,
                LatticePresets.honeycomb, LatticePresets.cubic, LatticePresets.fcc,
                LatticePresets.bcc)
-    for a0 in a0s, s in (true, false), t in (Float32, Float64), e in 1:4, preset in presets
-        @test preset(; a0 = a0, semibounded = s, type = t, dim = e) isa Lattice{e,<:Any,t}
+    for a0 in a0s, t in (Float32, Float64), e in 1:4, preset in presets
+        @test preset(; a0 = a0, type = t, dim = e) isa Lattice{e,<:Any,t}
     end
 end
 


### PR DESCRIPTION
This is quite a breaking change. It changes the `lattice(bravais, sublats...; kw...)` syntax to `lattice(sublats...; bravais = ..., kw...)` syntax. Any user code that uses this method should be updated.

Examples
```
julia> lattice(sublat((0, 0)); bravais = (1, 0), dim = Val(3))
Lattice{3,1,Float64} : 1D lattice in 3D space
  Bravais vectors : ((1.0, 0.0, 0.0),)
  Sublattices     : 1
    Names         : (:A)
    Sites         : (1) --> 1 total per unit cell

julia> lattice(sublat((0, 0)); bravais = ((1, 0), (0, 1)), dim = Val(3))
Lattice{3,2,Float64} : 2D lattice in 3D space
  Bravais vectors : ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
  Sublattices     : 1
    Names         : (:A)
    Sites         : (1) --> 1 total per unit cell
```

This has several advantages. For example we can override the Bravais vectors of a `LatticePreset`, since kwargs are forwarded
```
julia> LatticePresets.cubic(bravais = SA[1 0; 0 2])
Lattice{3,2,Float64} : 2D lattice in 3D space
  Bravais vectors : ((1.0, 0.0, 0.0), (0.0, 2.0, 0.0))
  Sublattices     : 1
    Names         : (:A)
    Sites         : (1) --> 1 total per unit cell
```

It also simplifies the API, since now the function `bravais` is restricted to method `bravais(lattice)`, which returns the Bravais matrix of a `lattice` (or Hamiltonian)

This PR also simplifies the `Bravais` struct, which no longer contains information about "semiboundedness" of axes. That functionality is meant for higher level Green's function code, no need to clutter the basic data structures

This PR also enables a future PR that will allow modifying the Bravais vectors of a given lattice (or Hamiltonian) by doing
```
lattice(lat; bravais = newbravais)
```
along with any other modification of parameters passed as kwargs.