### PR TITLE
lattice(lat; kw...)

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -14,13 +14,16 @@ Base.convert(::Type{T}, l::Bravais) where T<:Bravais = T(l)
 
 # Constructors for conversion
 
-Sublat{E,T}(s::Sublat, name = s.name) where {E,T} =
+Sublat{E,T,V}(s::Sublat, name = s.name) where {E,T,V<:Vector} =
     Sublat([padright(site, zero(T), Val(E)) for site in s.sites], name)
 
 # We need this to promote different sublats into common dimensionality and type to combine
 # into a lattice, while neglecting orbital dimension
 Base.promote(ss::Sublat{E,T}...) where {E,T} = ss
-Base.promote_rule(::Type{Sublat{E1,T1}}, ::Type{Sublat{E2,T2}}) where {E1,E2,T1,T2} =
-    Sublat{max(E1, E2), promote_type(T1, T2)}
+function Base.promote_rule(::Type{Sublat{E1,T1,Vector{SVector{E1,T1}}}}, ::Type{Sublat{E2,T2,Vector{SVector{E2,T2}}}}) where {E1,E2,T1,T2}
+    E´ = max(E1, E2)
+    T´ = promote_type(T1, T2)
+    return Sublat{E´, T´, Vector{SVector{E´,T´}}}
+end
 
 Bravais{E,L,T}(b::Bravais) where {E,L,T} = Bravais(padtotype(b.matrix, SMatrix{E,L,T}))

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -263,7 +263,7 @@ julia> h[(3,3)][[1,2],[1,2]] .= Ref(@SMatrix[1 2; 2 1])
 # See also:
     `onsite`, `hopping`, `bloch`, `bloch!`
 """
-hamiltonian(lat, ts...; orbitals = missing, kw...) =
+hamiltonian(lat::AbstractLattice, ts...; orbitals = missing, kw...) =
     _hamiltonian(lat, sanitize_orbs(orbitals, lat.unitcell.names), ts...; kw...)
 _hamiltonian(lat::AbstractLattice, orbs; kw...) = _hamiltonian(lat, orbs, TightbindingModel(); kw...)
 _hamiltonian(lat::AbstractLattice, orbs, m::TightbindingModel; type::Type = Complex{numbertype(lat)}, kw...) =

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -232,11 +232,11 @@ corresponds to a bounded lattice with no Bravais vectors.
 A keyword `names` can be used to rename `sublats`. Given names can be replaced to ensure
 that all sublattice names are unique.
 
-    lattice(lat::AbstractLattice; kw...)
+    lattice(lat::AbstractLattice; bravais = missing, dim = missing, type = missing, names = missing)
 
-Create a new lattice by applying the provided `kw` to `lat`. For performance, allocations
-will be avoided if possible (it depends on `kw`), so the result can share memory of `lat`.
-To avoid that, do `lattice(copy(lat); kw...)`.
+Create a new lattice by applying any non-missing `kw` to `lat`. For performance, allocations
+will be avoided if possible (depends on `kw`), so the result can share memory of `lat`. To
+avoid that, do `lattice(copy(lat); kw...)`.
 
 See also `LatticePresets` for built-in lattices.
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -232,6 +232,12 @@ corresponds to a bounded lattice with no Bravais vectors.
 A keyword `names` can be used to rename `sublats`. Given names can be replaced to ensure
 that all sublattice names are unique.
 
+    lattice(lat::AbstractLattice; kw...)
+
+Create a new lattice by applying the provided `kw` to `lat`. For performance, allocations
+will be avoided if possible (it depends on `kw`), so the result can share memory of `lat`.
+To avoid that, do `lattice(copy(lat); kw...)`.
+
 See also `LatticePresets` for built-in lattices.
 
 # Examples

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,4 +1,4 @@
-using Quantica: nsites, Sublat, Bravais, Lattice, Superlattice
+using Quantica: nsites, Sublat, Bravais, Lattice, Superlattice, allsitepositions
 using Random
 using LinearAlgebra: I
 
@@ -19,6 +19,21 @@ end
         @test lattice(s; bravais = br, type = t, dim = Val(e)) isa Lattice{e,min(l,e),t}
         @test lattice(s; bravais = br, type = t, dim = e) isa Lattice{e,min(l,e),t}
     end
+    lat = lattice(sublat((0,0,0)), sublat((1,1,1f0)); bravais = SMatrix{3,3}(I))
+    lat2 = lattice(lat, bravais = ())
+    @test lat2 isa Lattice{3,0}
+    @test allsitepositions(lat) === allsitepositions(lat2)
+    lat2 = lattice(lat, bravais = (), names = :A)
+    @test lat2 isa Lattice{3,0}
+    @test allsitepositions(lat) === allsitepositions(lat2)
+    lat2 = lattice(lat, dim = Val(2))
+    @test lat2 isa Lattice{2,2} # must be L <= E
+    @test allsitepositions(lat) !== allsitepositions(lat2)
+    lat2 = lattice(lat, type = Float64)
+    @test lat2 isa Lattice{3,3}
+    @test allsitepositions(lat) !== allsitepositions(lat2)
+    lat2 = lattice(lat, dim = Val(2), bravais = SA[1 2; 3 4])
+    @test bravais(lat2) == SA[1 2; 3 4]
 end
 
 @testset "lattice presets" begin


### PR DESCRIPTION
As mentioned in the cancelled #93 we need to complete the ways we provide to change a lattice, or to build one lattice from another. At the moment we cannot change the Bravais matrix, the type, the embedding dimension or the sublattice names of a lattice after creation. This PR, that builds on #94, does just that. It provides a method `lattice(lat; kw...)` where `kw` are any of the kwargs for lattice creation (`bravais`, `dim`, `type` and `names`). To do this elegantly we needed to move `bravais` to a kwarg, which was done in #94.

From the implementation point of view, the key of this PR is to keep the mutation as efficient as possible. If we're only changing Bravais vectors, there is no need to touch the site position array or sublattice offsets. In contrast, if we're changing the dimension or the position type we need to allocate a whole new `Unitcell`. This done via parametric dispatch.

An open question here is whether we want also a `hamiltonian(ham; kw...)` or not. The keywords of `hamiltonian` are `orbitals` and `type`. Changing any of the two (unless only change the orbital names, but not their number, which is kind of a trivial change) implies recomputing the Hamiltonian (i.e. reapplying the model to the lattice, which often does not make sense without changing the model itself), so I'm inclined not to add such a method.