### PR TITLE
VegaLite plot range

### DIFF
--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -1,11 +1,11 @@
 using .VegaLite
 
 """
-    vlplot(b::Bandstructure{1}; size = 640, points = false, labels = ("φ/2π", "ε"), scaling = (1/2π, 1))
+    vlplot(b::Bandstructure{1}; size = 640, points = false, labels = ("φ/2π", "ε"), scaling = (1/2π, 1), range = missing)
 
 Plots the 1D bandstructure `b` using VegaLite.
 
-    vlplot(h::Hamiltonian; size = 800, labels = ("x", "y"), axes::Tuple{Int,Int} = (1,2))
+    vlplot(h::Hamiltonian; size = 800, labels = ("x", "y"), axes::Tuple{Int,Int} = (1,2), range = missing)
 
 Plots the the Hamiltonian lattice projected along `axes` using VegaLite.
 
@@ -14,14 +14,16 @@ Plots the the Hamiltonian lattice projected along `axes` using VegaLite.
     - `points`: whether to plot points on line plots
     - `labels`: labels for the x and y plot axes
     - `scaling`: `(scalex, scaley)` scalings for the x (Bloch phase) and y (energy) variables
+    - `range`: `(ymin, ymax)` or `((xmin, xmax), (ymin, ymax))` to constrain plot range
     - `axes`: lattice axes to project onto the plot x-y plane
 """
-function VegaLite.vlplot(b::Bandstructure; labels = ("φ", "ε"), scaling = (1, 1), size = 640, points = false)
+function VegaLite.vlplot(b::Bandstructure; labels = ("φ", "ε"), scaling = (1, 1), size = 640, points = false, range = missing)
     labelx, labely = labels
     table = bandtable(b, make_it_two(scaling))
     sizes = make_it_two(size)
     corners = _corners(table)
-    (domainx, domainy), _ = domain_size(corners, size)
+    range´ = sanitize_plotrange(range)
+    (domainx, domainy), _ = domain_size(corners, size, range´)
     p = table |> vltheme(sizes, points) + @vlplot(
         mark = :line,
         x = {:x, scale = {domain = domainx, nice = false}, title = labelx},
@@ -39,10 +41,11 @@ function bandtable(b::Bandstructure{1}, (scalingx, scalingy) = (1, 1))
 end
 
 function VegaLite.vlplot(h::Hamiltonian{LA};
-                         labels = ("x","y"), size = 800, axes::Tuple{Int,Int} = (1,2)) where {E,LA<:Lattice{E}}
+                         labels = ("x","y"), size = 800, axes::Tuple{Int,Int} = (1,2), range = missing) where {E,LA<:Lattice{E}}
     table = linkstable(h, axes)
     corners = _corners(table)
-    (domainx, domainy), sizes = domain_size(corners, size)
+    range´ = sanitize_plotrange(range)
+    (domainx, domainy), sizes = domain_size(corners, size, range´)
     p = table |> vltheme(sizes) +
         @vlplot(:rule, color = :sublat, opacity = {:opacity, legend = nothing},
             transform = [{filter = "datum.islink"}],
@@ -129,10 +132,10 @@ function _corners(table)
     return min´, max´
 end
 
-function domain_size(corners, size)
+function domain_size(corners, size, (rangex, rangey))
     sizex, sizey = make_it_two(size)
-    domainx = (corners[1][1], corners[2][1])
-    domainy = (corners[1][2], corners[2][2])
+    domainx = iclamp((corners[1][1], corners[2][1]), rangex)
+    domainy = iclamp((corners[1][2], corners[2][2]), rangey)
     dx = domainx[2]-domainx[1]
     dy = domainy[2]-domainy[1]
     if dx > dy
@@ -144,6 +147,10 @@ function domain_size(corners, size)
     end
     return (domainx, domainy), (sizex, sizey)
 end
+
+sanitize_plotrange(::Missing) = (missing, missing)
+sanitize_plotrange(yrange::Tuple{Number, Number}) = (missing, yrange)
+sanitize_plotrange(ranges::NTuple{2,Tuple{Number, Number}}) = ranges
 
 make_it_two(x::Number) = (x, x)
 make_it_two(x::Tuple{Number,Number}) = x

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -10,7 +10,7 @@ Plots the 1D bandstructure `b` using VegaLite.
 Plots the the Hamiltonian lattice projected along `axes` using VegaLite.
 
 # Options:
-    - `size`: the `(width, height)` of the plot (or `width == height` if a single number)
+    - `size`: the `(width, height)` of the plot (or `max(width, height)` if a single number)
     - `points`: whether to plot points on line plots
     - `labels`: labels for the x and y plot axes
     - `scaling`: `(scalex, scaley)` scalings for the x (Bloch phase) and y (energy) variables

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -133,18 +133,11 @@ function _corners(table)
 end
 
 function domain_size(corners, size, (rangex, rangey))
-    sizex, sizey = make_it_two(size)
     domainx = iclamp((corners[1][1], corners[2][1]), rangex)
     domainy = iclamp((corners[1][2], corners[2][2]), rangey)
     dx = domainx[2]-domainx[1]
     dy = domainy[2]-domainy[1]
-    if dx > dy
-        sizex = size
-        sizey = size * dy/dx
-    else
-        sizex = size * dx/dy
-        sizey = size
-    end
+    sizex, sizey = compute_sizes(size, (dx, dy))
     return (domainx, domainy), (sizex, sizey)
 end
 
@@ -154,3 +147,16 @@ sanitize_plotrange(ranges::NTuple{2,Tuple{Number, Number}}) = ranges
 
 make_it_two(x::Number) = (x, x)
 make_it_two(x::Tuple{Number,Number}) = x
+
+function compute_sizes(size::Number, (dx, dy))
+    if dx > dy
+        sizex = size
+        sizey = size * dy/dx
+    else
+        sizex = size * dx/dy
+        sizey = size
+    end
+    return sizex, sizey
+end
+
+compute_sizes(ss::Tuple{Number,Number}, d) = ss

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -133,9 +133,9 @@ function pinverse(m::SMatrix)
     return inv(qrm.R) * qrm.Q'
 end
 
-_blockdiag(s1::SMatrix{M}, s2::SMatrix{N}) where {N,M} = hcat(
-    ntuple(j->vcat(s1[:,j], zero(s2[:,j])), Val(M))...,
-    ntuple(j->vcat(zero(s1[:,j]), s2[:,j]), Val(N))...)
+_blockdiag(s1::SMatrix{E1,L1,T1}, s2::SMatrix{E2,L2,T2}) where {E1,L1,T1,E2,L2,T2} = hcat(
+    ntuple(j->vcat(s1[:,j], zero(SVector{E2,T2})), Val(L1))...,
+    ntuple(j->vcat(zero(SVector{E1,T1}), s2[:,j]), Val(L2))...)
 
 function isgrowing(vs::AbstractVector, i0 = 1)
     i0 > length(vs) && return true
@@ -394,3 +394,6 @@ function _fast_sparse_muladd!(dst::AbstractMatrix{T}, src::SparseMatrixCSC, α =
 end
 
 rclamp(r1::UnitRange, r2::UnitRange) = isempty(r1) ? r1 : clamp(minimum(r1), extrema(r2)...):clamp(maximum(r1), extrema(r2)...)
+
+iclamp(minmax, r::Missing) = minmax
+iclamp((x1, x2), (xmin, xmax)) = (max(x1, xmin), min(x2, xmax))


### PR DESCRIPTION
Introduces a `range` kwarg in vlplot to constrain the plot range, in both x and y, or only in y
It also corrects a bug that didn't allow to specify sizex != sizey