### PR TITLE
Generalize `unitcell` and `supercell` to use generic `SiteSelector` machinery

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -2,10 +2,12 @@ toSMatrix() = SMatrix{0,0,Float64}()
 toSMatrix(s) = toSMatrix(tuple(s))
 toSMatrix(ss::NTuple{M,NTuple{N,Number}}) where {N,M} = toSMatrix(SVector{N}.(ss))
 toSMatrix(ss::NTuple{M,SVector{N}}) where {N,M} = hcat(ss...)
-toSMatrix(::Type{T}, ss) where {T} = _toSMatrix(T, toSMatrix(ss))
+
+toSMatrix(::Type{T}, ss) where {T<:Number} = _toSMatrix(T, toSMatrix(ss))
 _toSMatrix(::Type{T}, s::SMatrix{N,M}) where {N,M,T} = convert(SMatrix{N,M,T}, s)
 # Dynamic dispatch
 toSMatrix(s::AbstractMatrix) = SMatrix{size(s,1), size(s,2)}(s)
+toSMatrix(s::AbstractVector) = toSMatrix(Tuple(s))
 
 toSVector(::Tuple{}) = SVector{0,Float64}()
 toSVector(v::SVector) = v
@@ -127,6 +129,8 @@ function pinvmultiple(s::SMatrix{L,L´}) where {L,L´}
     npinverse = round.(Int, n * pinverse)
     return npinverse, n
 end
+
+pinverse(::SMatrix{E,0,T}) where {E,T} = SMatrix{0,E,T}() # BUG: workaround StaticArrays bug SMatrix{E,0,T}()'
 
 function pinverse(m::SMatrix)
     qrm = qr(m)


### PR DESCRIPTION
This was one tricky refactor, as it touches some of the oldest parts of Quantica. It generalizes the `supercell` routines to take arbitrary SiteSelectors. Before, `supercell` just took a `region` kwarg that was used to constrain any non-periodic direction of a superlattice (this then extended to `unitcell` too). With this PR we can specify other constraints, such as `indices` or `sublats` when building a new supercell or unitcell.

As an example application, we can combine this with the `not` wrapper from #97 to create vacancies by index (i.e. instead of by position). First create a Hamiltonian without vacancies, and plot it to locate the indices for the desired vacancies
```
using VegaLite
h = LatticePresets.honeycomb() |> unitcell(region = RegionPresets.circle(10)) |> hamiltonian(hopping(1))
vlplot(h)
```
<img width="481" alt="Screen Shot 2020-09-22 at 21 26 51" src="https://user-images.githubusercontent.com/4310809/93928313-6729ef80-fd1a-11ea-9c66-ddc0a97e1618.png">

Now, just rebuild the unitcell of `h` excluding the desired site with `indices`
```
h´ = unitcell(h, indices = not(549))
vlplot(h´)
```
<img width="479" alt="Screen Shot 2020-09-22 at 21 28 41" src="https://user-images.githubusercontent.com/4310809/93928453-a2c4b980-fd1a-11ea-821b-5d097b286fd2.png">
