### PR TITLE
Kets : support `SMatrix` eltype

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -339,3 +339,24 @@ function Base.iterate(s::SparseMatrixReader, state = (1, 1))
 end
 
 enumerate_sparse(s::SparseMatrixCSC) = SparseMatrixReader(s)
+
+#######################################################################
+# SiteSublats
+#######################################################################
+
+struct SiteSublats{G,U}
+    g::G
+    u::U
+end
+
+sitesublats(u) = SiteSublats(((i, s) for s in sublats(u) for i in siterange(u, s)), u)
+
+Base.iterate(s::SiteSublats, x...) = iterate(s.g, x...)
+
+Base.IteratorSize(::SiteSublats) = Base.HasLength()
+
+Base.IteratorEltype(::SiteSublats) = Base.HasEltype()
+
+Base.eltype(::SiteSublats) = Tuple{Int,Int}
+
+Base.length(s::SiteSublats) = nsites(s.u)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -58,7 +58,7 @@ struct Unitcell{E,T,N}
     sites::Vector{SVector{E,T}}
     names::NTuple{N,NameType}
     offsets::Vector{Int}        # Linear site number offsets for each sublat
-end                             # so that diff(offset) == sublatsites
+end                             # so that diff(offset) == sublatlengths
 
 Unitcell(sublats::Sublat...; kw...) = Unitcell(promote(sublats...); kw...)
 
@@ -115,7 +115,7 @@ siterange(u::Unitcell, sublat) = (1+u.offsets[sublat]):u.offsets[sublat+1]
 enumeratesites(u::Unitcell, sublat) = ((i, sitepositions(u)[i]) for i in siterange(u, sublat))
 
 nsites(u::Unitcell) = length(u.sites)
-nsites(u::Unitcell, sublat) = sublatsites(u)[sublat]
+nsites(u::Unitcell, sublat) = sublatlengths(u)[sublat]
 
 offsets(u::Unitcell) = u.offsets
 
@@ -127,7 +127,7 @@ function sublat(u::Unitcell, siteidx)
     return l
 end
 
-sublatsites(u::Unitcell) = diff(u.offsets)
+sublatlengths(u::Unitcell) = diff(u.offsets)
 
 nsublats(u::Unitcell) = length(u.names)
 
@@ -209,7 +209,7 @@ function Base.show(io::IO, lat::Lattice)
 "$i  Bravais vectors : $(displayvectors(bravais(lat); digits = 6))
 $i  Sublattices     : $(nsublats(lat))
 $i    Names         : $(displaynames(lat))
-$i    Sites         : $(display_as_tuple(sublatsites(lat))) --> $(nsites(lat)) total per unit cell")
+$i    Sites         : $(display_as_tuple(sublatlengths(lat))) --> $(nsites(lat)) total per unit cell")
 end
 
 Base.summary(::Lattice{E,L,T}) where {E,L,T} =
@@ -380,7 +380,7 @@ function Base.show(io::IO, lat::Superlattice)
 "$i  Bravais vectors : $(displayvectors(bravais(lat); digits = 6))
 $i  Sublattices     : $(nsublats(lat))
 $i    Names         : $(displaynames(lat))
-$i    Sites         : $(display_as_tuple(sublatsites(lat))) --> $(nsites(lat)) total per unit cell\n")
+$i    Sites         : $(display_as_tuple(sublatlengths(lat))) --> $(nsites(lat)) total per unit cell\n")
     print(ioindent, lat.supercell)
 end
 
@@ -446,9 +446,11 @@ allsitepositions(lat::AbstractLattice) = sitepositions(lat.unitcell)
 siteposition(i, lat::AbstractLattice) = allsitepositions(lat)[i]
 siteposition(i, dn::SVector, lat::AbstractLattice) = siteposition(i, lat) + bravais(lat) * dn
 
+sitesublats(lat::AbstractLattice) = sitesublats(lat.unitcell)
+
 offsets(lat::AbstractLattice) = offsets(lat.unitcell)
 
-sublatsites(lat::AbstractLattice) = sublatsites(lat.unitcell)
+sublatlengths(lat::AbstractLattice) = sublatlengths(lat.unitcell)
 
 enumeratesites(lat::AbstractLattice, sublat) = enumeratesites(lat.unitcell, sublat)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -520,7 +520,7 @@ displayrange(::Missing) = "any"
 displayrange(nr::NeighborRange) = "NeighborRange($(nr.n))"
 displayrange(rs::Tuple) = "($(displayrange(first(rs))), $(displayrange(last(rs))))"
 
-function Base.show(io::IO, o::OnsiteTerm{F}) where {F}
+function Base.show(io::IO, o::OnsiteTerm{F,<:SiteSelector}) where {F}
     i = get(io, :indent, "")
     print(io,
 "$(i)OnsiteTerm{$(displayparameter(F))}:
@@ -528,7 +528,7 @@ $(i)  Sublattices      : $(o.selector.sublats === missing ? "any" : o.selector.s
 $(i)  Coefficient      : $(o.coefficient)")
 end
 
-function Base.show(io::IO, h::HoppingTerm{F}) where {F}
+function Base.show(io::IO, h::HoppingTerm{F,<:HopSelector}) where {F}
     i = get(io, :indent, "")
     print(io,
 "$(i)HoppingTerm{$(displayparameter(F))}:
@@ -1006,8 +1006,10 @@ ket(f; normalized = true, maporbitals::Bool = false, kw...) = KetModel(onsite(f;
 Base.:*(x, k::KetModel) = KetModel(k.model * x, k.normalized, k.maporbitals)
 Base.:*(k::KetModel, x) = KetModel(x * k.model, k.normalized, k.maporbitals)
 Base.:-(k::KetModel) = KetModel(-k.model, k.normalized, k.maporbitals)
-Base.:-(k1::KetModel, k2::KetModel) = KetModel(k1.model - k2.model, k1.normalized && k2.normalized, k1.maporbitals && k2.maporbitals)
-Base.:+(k1::KetModel, k2::KetModel) = KetModel(k1.model + k2.model, k1.normalized && k2.normalized, k1.maporbitals && k2.maporbitals)
+Base.:-(k1::KetModel, k2::KetModel) = KetModel(k1.model - k2.model, k1.normalized && k2.normalized, _andVal(k1.maporbitals, k2.maporbitals))
+Base.:+(k1::KetModel, k2::KetModel) = KetModel(k1.model + k2.model, k1.normalized && k2.normalized, _andVal(k1.maporbitals, k2.maporbitals))
+
+_andVal(::Val{A},::Val{B}) where {A,B} = Val(A && B)
 
 resolve(k::KetModel, lat::AbstractLattice) = KetModel(resolve(k.model, lat), k.normalized, k.maporbitals)
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -178,6 +178,15 @@ function unique_sorted_approx!(v::AbstractVector{T}) where {T}
     return v
 end
 
+normalize_columns!(kmat::AbstractMatrix) = normalize_columns!(kmat, axes(kmat, 2))
+
+function normalize_columns!(kmat::AbstractMatrix, cols)
+    for col in cols
+        normalize!(view(kmat, :, col))
+    end
+    return kmat
+end
+
 ############################################################################################
 
 function pushapproxruns!(runs::AbstractVector{<:UnitRange}, list::AbstractVector{T},

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1,4 +1,5 @@
-using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector, sublats, resolve, isinindices, isinsublats
+using Quantica: TightbindingModel, OnsiteTerm, HoppingTerm, padtotype, Selector, sublats, resolve, isinindices, isinsublats, nsites
+using LinearAlgebra: norm
 
 @testset "selector membership" begin
     @test  isinindices(1, missing)
@@ -152,14 +153,32 @@ end
 @testset "kets" begin
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(I), orbitals = (Val(3), Val(1)))
     k = Matrix(randomkets(2; sublats = :B), h)
-    @test sum(e -> count(iszero, e), k) == 10
+        @test sum(e -> count(iszero, e), k) == 10
+    k = Matrix(randomkets(2, r->rand() * SA[1 2 3 4]; sublats = :B), h)
+        @test eltype(k) isa Type{<:SMatrix{3,4,ComplexF64}}
+        @test k[2,1][1,2] ≈ 2*k[2,1][1,1]
+    k = Matrix(randomkets(2, r->rand() * SA[1, 2, 3]; sublats = :A), h)
+        @test eltype(k) isa Type{<:SVector{3,ComplexF64}}
+        @test k[2,1][1] ≈ 2*k[2,1][2]
+    k = Matrix(randomkets(2, r->rand() * SA[1 2; 2 3; 3 4]; sublats = :A), h)
+        @test eltype(k) isa Type{<:SMatrix{3,2,ComplexF64}}
+        @test k[2,1][1,2] ≈ 2*k[2,1][1,1]
     k = Matrix(randomkets(1; region = r -> r[2] < 0, maporbitals = true), h)
-    @test sum(e -> count(iszero, e), k) == 3
+        @test sum(e -> count(iszero, e), k) == 3
     k = Matrix(randomkets(2, r->randn()SA[1,]; sublats = :B), h)
-    @test sum(e -> count(!iszero, e), k) == 2
+        @test sum(e -> count(!iszero, e), k) == 2
     k = Matrix(randomkets(2; sublats = :B, maporbitals = true), h)
-    @test sum(e -> count(!iszero, e), k) == 2
+        @test sum(e -> count(!iszero, e), k) == 2
     km = ket(r -> randn() * SA[1, -1, 0], sublats = :A)  + ket(r -> randn(), sublats =:B)
     k = Matrix(km, h)
-    @test sum(e -> count(!iszero, e), k) == 3
+        @test sum(e -> count(!iszero, e), k) == 3
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(I), orbitals = (Val(3), Val(1)), type = Float64) |> unitcell(3)
+    k = Matrix(randomkets(2; sublats = :B), h)
+        @test eltype(k) isa Type{SVector{3,ComplexF64}}
+    k = Matrix(randomkets(4, r -> randn(); sublats = :B, normalized = true, indices = not(18)), h)
+        @test eltype(k) isa Type{SVector{3,Float64}}
+        @test all(col -> norm(view(k, :, col)) ≈ 1/2, axes(k,2)) # due to 1/√n for n random vectors
+        @test all((iszero(k[row, col]) for col in axes(k,2), row in 1:nsites(h)÷2))
+        @test all((iszero(k[18, col]) for col in axes(k,2)))
 end


### PR DESCRIPTION
After #80 we lost the ability to use a ket in KPM calculations with an `SMatrix` eltype. We were restricted to scalar eltypes for Hamiltonians with scalar eltypes and `Quantica.orbitaltype(h)::SVector` eltype otherwise. However, it is useful to allow kets with SMatrix eltype, as an extension of the `SVector` eltype. It is useful when using `randomkets` and wanting to have some correlation between individual random kets. Then, instead of N correlated random kets we can have a single one with SMatrix eltype. 

Example (relevant for Nambu stochastic trace KPM)
```
h = LatticePresets.honeycomb() |> hamiltonian(hopping(I), orbitals = Val(2)) |> unitcell(100) |> unitcell
k = randomkets(n, r -> cis(2π*rand()) * SA[1 0; 0 -1])
dosKPM(h, kets = k)
```
Note that `Matrix(k, h)` is actually an N×n matrix (where `N == nsites(h)`) with eltype `<:SMatrix{2,2}`. This is equivalent to two random vectors with `<:SVector{2}` eltype (since we have two orbitals per site in `h`), but their elements are correlated. If one has element `SA[x; 0]` the other has `SA[0; -1]` on the same site.

Internally this comes with several changes. For one, we now allow `resolve`ing `KetModel`s and `TightbindingModel`s as a whole (not only the selectors of their individual model terms), so that we can resolve them only once and them pass them on to be applied in a hot loop without needing to resolve term by term. This was an optional change, but it seemed worthwhile, and might be used to clean up also some other parts of the code. We also created a new type of iterator `SiteSublats` for combined site index and sublattice. Again this could be used in other parts of the code.

All in all, those changes can be viewed as creating a little bit of bloat in the code. We should in particular remember to revisit this in the future, and perhaps try to simplify the `ResolvedSelector` design somewhat...