### PR TITLE
Add ambient occlusion (`ssao = true`) in Makie `plot`

### DIFF
--- a/src/plot_makie.jl
+++ b/src/plot_makie.jl
@@ -73,6 +73,7 @@ end
         linkthickness = 6, linkoffset = 0.000, linkradius = 0.1,
         tooltips = true, digits = 3,
         _tooltips_rowcolhar = Vector{Tuple{Int,Int,Int}}[],
+        ssao = true,
         colors = map(t -> RGBAf0(t...),
             ((0.960,0.600,.327), (0.410,0.067,0.031),(0.940,0.780,0.000),
             (0.640,0.760,0.900),(0.310,0.370,0.650),(0.600,0.550,0.810),
@@ -143,6 +144,7 @@ end
 
 function plotsites_hi!(plot, sites, color)
     meshscatter!(plot, sites;
+        ssao = plot[:ssao][],
         color = color,
         markerspace = SceneSpace,
         markersize = plot[:siteradius][], light = plot[:light][])
@@ -183,6 +185,7 @@ function plotlinks_hi!(plot, links, color)
     scales = [Vec3f0(radius, radius, norm(r2 - r1)/2) for (r1, r2) in links]
     cylinder = Cylinder(Point3f0(0., 0., -1.0), Point3f0(0., 0, 1.0), Float32(1))
     meshscatter!(plot, positions;
+        ssao = plot[:ssao][],
         color = color, marker = cylinder, markersize = scales, rotations = rotvectors,
         light = plot[:light][])
     return nothing
@@ -263,6 +266,7 @@ end
     Theme(
     linewidth = 3,
     wireframe = true,
+    ssao = true,
     colors = map(t -> RGBAf0((0.8 .* t)...),
         ((0.973, 0.565, 0.576), (0.682, 0.838, 0.922), (0.742, 0.91, 0.734),
          (0.879, 0.744, 0.894), (1.0, 0.84, 0.0), (1.0, 1.0, 0.669),
@@ -306,7 +310,7 @@ function plot!(plot::BandPlot3D)
         if isempty(connectivity)
             scatter!(plot, vertices, color = color)
         else
-            mesh!(plot, vertices, connectivity, color = color, transparency = false)
+            mesh!(plot, vertices, connectivity, color = color, transparency = false, ssao = plot[:ssao][])
             if plot[:wireframe][]
                 edgevertices = collect(Quantica.edgevertices(band.mesh))
                 linesegments!(plot, edgevertices, linewidth = plot[:linewidth])
@@ -315,7 +319,3 @@ function plot!(plot::BandPlot3D)
     end
     return plot
  end
-
-function allpairs(simplex::NTuple{D,Int}, vertices) where D
-    ntuple(i -> (i))
-end


### PR DESCRIPTION
Makes lightning a bit more realistic with Makie.

Before (`plot(b, ssao = false)`):
![image](https://user-images.githubusercontent.com/4310809/94918134-4009b580-04b2-11eb-8ebd-2eb69416a0f2.png)

After (`plot(b, ssao = true)`):
![image](https://user-images.githubusercontent.com/4310809/94918183-5748a300-04b2-11eb-9879-118a05d30bb1.png)

