### PR TITLE
VegaLite plots of wavefunctions

### DIFF
--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -3,11 +3,20 @@ using .VegaLite
 """
     vlplot(b::Bandstructure{1}; kw...)
 
-Plots the 1D bandstructure `b` using VegaLite.
+Plot the 1D bandstructure `b` using VegaLite.
 
     vlplot(h::Hamiltonian; kw...)
 
-Plots the the Hamiltonian lattice projected along `axes` using VegaLite.
+Plot the the Hamiltonian lattice projected along `axes` using VegaLite.
+
+    vlplot(h::Hamiltonian, psi::AbstractVector; kw...)
+
+Plot an eigenstate `psi` (of same dimension as `h`) on the lattice, using one of various
+possible visualization channels: `sitesize`, `siteopacity`, `sitecolor`, `linksize`,
+`linkopacity` or `linkcolor` (see keywords below). For site channels, a function `psi ->
+f(psi)` must be provided (e.g. `f(psi_i) = norm(psi_i)` to plot the norm of the wavefunction
+at each site). For link channels, a function `(psi´, psi) -> f(psi´, psi)` must be provided
+(e.g. `f(psi_i, psi_j) = imag(psi_i'* psi_j)` to plot the current).
 
 # Keyword arguments and defaults:
     - `size = 800`: the `(width, height)` of the plot (or `max(width, height)` if a single number)
@@ -55,15 +64,16 @@ function bandtable(b::Bandstructure{1}, (scalingx, scalingy), bandsiter)
     return table
 end
 
-function VegaLite.vlplot(h::Hamiltonian{LA};
+function VegaLite.vlplot(h::Hamiltonian{LA}, psi = missing;
                          labels = ("x","y"), size = 800, axes::Tuple{Int,Int} = (1,2), xlims = missing, ylims = missing, digits = 4,
                          sitesize = 15, siteopacity = 0.9, linksize = 0.25, linkopacity = 1.0,
                          sitecolor = missing, linkcolor = sitecolor, colorscheme = "lightgreyred", discretecolorscheme = "category10",
                          plotsites = true, plotlinks = true) where {E,LA<:Lattice{E}}
     directives = (; axes = axes, digits = digits,
-                    sitesize_func = sitefunc(sitesize), siteopacity_func = sitefunc(siteopacity),
-                    linksize_func = linkfunc(linksize), linkopacity_func = linkfunc(linkopacity),
-                    sitecolor_func = sitefunc(sitecolor), linkcolor_func = sitefunc(linkcolor))
+                    sitesize_func = sitefunc(sitesize, psi), siteopacity_func = sitefunc(siteopacity, psi),
+                    linksize_func = linkfunc(linksize, psi), linkopacity_func = linkfunc(linkopacity, psi),
+                    sitecolor_func = sitefunc(sitecolor, psi), linkcolor_func = sitefunc(linkcolor, psi))
+    checkdims_psi(h, psi)
     table      = linkstable(h, directives)
     maxthick   = maximum(s -> ifelse(s.islink, s.scale, zero(s.scale)), table)
     maxsize    = plotsites ? maximum(s -> ifelse(s.islink, zero(s.scale), s.scale), table) : sqrt(15*maxthick)
@@ -123,9 +133,6 @@ function VegaLite.vlplot(h::Hamiltonian{LA};
     return table |> p
 end
 
-needslegend(x::Number) = nothing
-needslegend(x) = true
-
 function vltheme((sizex, sizey), points = false)
     p = @vlplot(
         tooltip = :tooltip,
@@ -138,12 +145,30 @@ function vltheme((sizex, sizey), points = false)
     return p
 end
 
+needslegend(x::Number) = nothing
+needslegend(x) = true
+
 sitefunc(f::Function) = f
-sitefunc(r::Number) = i -> r
-sitefunc(::Missing) = i -> 0.0
+sitefunc(o::Number) = psi -> o
+sitefunc(::Missing) = psi -> 0.0
+sitefunc(o, psi::Missing) = sitefunc(o)
+
+function sitefunc(o, psi::AbstractVector)
+    f = sitefunc(o)
+    return i -> f(psi[i])
+end
 
 linkfunc(f::Function) = f
-linkfunc(t) = (i, j) -> t
+linkfunc(t) = (psi´, psi) -> t
+linkfunc(t, psi::Missing) = linkfunc(t)
+
+function linkfunc(t, psi::AbstractVector)
+    f = linkfunc(t)
+    return (i,j) -> f(psi[i], psi[j])
+end
+
+checkdims_psi(h, psi) = size(h, 2) == size(psi, 1) || throw(ArgumentError("The eigenstate length $(size(psi,1)) must match the Hamiltonian dimension $(size(h, 2))"))
+checkdims_psi(h, ::Missing) = nothing
 
 function linkstable(h::Hamiltonian, d)
     (a1, a2) = d.axes

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -77,7 +77,7 @@ function VegaLite.vlplot(h::Hamiltonian{LA}, psi = missing;
     table      = linkstable(h, directives)
     maxthick   = maximum(s -> ifelse(s.islink, s.scale, zero(s.scale)), table)
     maxsize    = plotsites ? maximum(s -> ifelse(s.islink, zero(s.scale), s.scale), table) : sqrt(15*maxthick)
-    opacityrange = extrema(s -> s.opacity, table)
+    maxopacity = maximum(s -> s.opacity, table)
     corners    = _corners(table)
     plotrange  = (xlims, ylims)
     (domainx, domainy), sizes = domain_size(corners, size, plotrange)
@@ -101,7 +101,7 @@ function VegaLite.vlplot(h::Hamiltonian{LA}, psi = missing;
                 scale = {domain = colorrange, scheme = colorscheme´},
                 legend = needslegend(sitecolor)},
             opacity = {:opacity,
-                scale = {range = [0, 1], domain = opacityrange},
+                scale = {range = [0, 1], domain = [0, maxopacity]},
                 legend = needslegend(linkopacity)},
             transform = [{filter = "datum.islink"}],
             selection = {grid2 = {type = :interval, bind = :scales}},
@@ -121,7 +121,7 @@ function VegaLite.vlplot(h::Hamiltonian{LA}, psi = missing;
                 scale = {domain = colorrange, scheme = colorscheme´},
                 legend = needslegend(sitecolor)},
             opacity = {:opacity,
-                scale = {range = [0, 1], domain = opacityrange},
+                scale = {range = [0, 1], domain = [0, maxopacity]},
                 legend = needslegend(siteopacity)},
             selection = {grid1 = {type = :interval, bind = :scales}},
             transform = [{filter = "!datum.islink"}],


### PR DESCRIPTION
Closes #103 

The strategy is to visualize the lattice (like with `vlplot(h)`) but specifying functions for one of possible site or link properties that employ the wavefunction to generate the property value. There are 6 available channels, 3 for sites and 3 for links, corresponding to size, color and opacity. 

Example using the site size and site color channels:
```
julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(I)) |> unitcell(10) |> unitcell;

julia> sp = states(spectrum(h));

julia> using LinearAlgebra;

julia> vlplot(h, sp[:,1], sitecolor = psi -> norm(psi), sitesize = psi -> 200*norm(psi))
```
<img width="558" alt="Screen Shot 2020-10-09 at 21 41 31" src="https://user-images.githubusercontent.com/4310809/95625100-3e269000-0a78-11eb-92c7-655d3c0d6b4c.png">

Perhaps we could try to be clever with scaling (to avoid needing that 200 there?)...
