### PR TITLE
Unflatten: restore orbital structure into elements

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -86,11 +86,15 @@ end
 
 padright(sv::StaticVector{E,T}, x::T, ::Val{E}) where {E,T} = sv
 padright(sv::StaticVector{E1,T1}, x::T2, ::Val{E2}) where {E1,T1,E2,T2} =
-    (T = promote_type(T1,T2); SVector{E2, T}(ntuple(i -> i > E1 ? x : convert(T, sv[i]), Val(E2))))
+    (T = promote_type(T1,T2); SVector{E2,T}(ntuple(i -> i > E1 ? x : convert(T, sv[i]), Val(E2))))
 padright(sv::StaticVector{E,T}, ::Val{E2}) where {E,T,E2} = padright(sv, zero(T), Val(E2))
 padright(sv::StaticVector{E,T}, ::Val{E}) where {E,T} = sv
 padright(t::NTuple{N´,Any}, x, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? x : t[i], Val(N))
 padright(t::NTuple{N´,Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 : t[i], Val(N))
+
+padright(v, ::Type{S}) where {E,T,S<:SVector{E,T}} = padright(v, zero(T), S)
+padright(v, x::T, ::Type{S}) where {E,T,S<:SVector{E,T}} =
+    SVector{E,T}(ntuple(i -> i > length(v) ? x : convert(T, v[i]), Val(E)))
 
 # Pad element type to a "larger" type
 @inline padtotype(s::SMatrix{E,L}, ::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -77,3 +77,20 @@ end
     @test length(bands(b)) == 4
     @test_throws UndefKeywordError bandstructure(ph, mesh2D, mapping = (k, φ) -> ((;p = SA[1, φ]),))
 end
+
+@testset "unflatten" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = (Val(2), Val(1))) |> unitcell(2) |> unitcell
+    sp = states(spectrum(h))[:,1]
+    sp´ = Quantica.unflatten(sp, h)
+    l = size(h, 1)
+    @test length(sp) == 1.5 * l
+    @test length(sp´) == l
+    @test all(x -> iszero(last(x)), sp´[l+1:end])
+
+    h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = Val(2)) |> unitcell(2) |> unitcell
+    sp = states(spectrum(h))[:,1]
+    sp´ = Quantica.unflatten(sp, h)
+    l = size(h, 1)
+    @test length(sp) == 2 * l
+    @test length(sp´) == l
+end

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -81,16 +81,24 @@ end
 @testset "unflatten" begin
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = (Val(2), Val(1))) |> unitcell(2) |> unitcell
     sp = states(spectrum(h))[:,1]
-    sp´ = Quantica.unflatten(sp, h)
+    sp´ = Quantica.maybe_unflatten(sp, h)
     l = size(h, 1)
     @test length(sp) == 1.5 * l
     @test length(sp´) == l
     @test all(x -> iszero(last(x)), sp´[l+1:end])
+    @test sp´ isa Vector
+    @test sp´ !== sp
 
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = Val(2)) |> unitcell(2) |> unitcell
     sp = states(spectrum(h))[:,1]
-    sp´ = Quantica.unflatten(sp, h)
+    sp´ = Quantica.maybe_unflatten(sp, h)
     l = size(h, 1)
     @test length(sp) == 2 * l
     @test length(sp´) == l
+    @test sp´ isa Base.ReinterpretArray
+
+    h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = Val(2)) |> unitcell(2) |> unitcell
+    sp = states(spectrum(h))[:,1]
+    sp´ = Quantica.maybe_unflatten(sp, h)
+    @test sp === sp
 end


### PR DESCRIPTION
This introduces an unexported `unflatten(vec, h)` that turns a flattened vector (e.g. eigenstate produced by using a `flatten` blochtype) to another `vec´` of `length(vec´) = size(h,1)` and `eltype(vec´) = orbitaltype(h)`. That is, `unflatten` restores the eigenstate that would have been obtained without flattening the Hamiltonian. 

This is required to make progress in generalizing #111 to multiorbital Hamiltonians.