### PR TITLE
Algebra with compatible Hamiltonians

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -145,6 +145,9 @@ end
 
 # normalize_axis_directions(q::SMatrix{M,N}) where {M,N} = hcat(ntuple(i->q[:,i]*sign(q[i,i]), Val(N))...)
 
+padprojector(::Type{S}, ::Val{N}) where {M,N,S<:SMatrix{M,M}} = S(Diagonal(SVector(padright(filltuple(1, Val(N)), Val(M)))))
+padprojector(::Type{S}, ::NTuple{N,Any}) where {S,N} = padprojector(S, Val(N))
+
 _blockdiag(s1::SMatrix{E1,L1,T1}, s2::SMatrix{E2,L2,T2}) where {E1,L1,T1,E2,L2,T2} = hcat(
     ntuple(j->vcat(s1[:,j], zero(SVector{E2,T2})), Val(L1))...,
     ntuple(j->vcat(zero(SVector{E1,T1}), s2[:,j]), Val(L2))...)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -450,3 +450,15 @@ end
     @test hamiltonian(lat, hopping(1, range = (nrange(20), nrange(20)))) |> nhoppings == 18
     @test hamiltonian(lat, hopping(1, range = (nrange(20), nrange(21)))) |> nhoppings == 30
 end
+
+@testset "hamiltonian algebra" begin
+    h1 = LatticePresets.honeycomb() |> hamiltonian(onsite(-I) + hopping(I), orbitals = (Val(2), Val(1))) |> unitcell(4)
+    h2 = LatticePresets.honeycomb() |> hamiltonian(hopping(3I, range = 1), orbitals = (Val(2), Val(1))) |> unitcell(4)
+    phis = (0.3, 0.8)
+    @test bloch(3.3*h1, phis) ≈ 3.3*bloch(h1, phis)
+    @test bloch(3.3*h1 + h2, phis) ≈ 3.3*bloch(h1, phis) + bloch(h2, phis)
+    @test bloch(h1^2, phis) ≈ bloch(h1, phis)^2
+    h´ = 2.3h1^3 - 2h2*h1 - 3I
+    @test Quantica.check_orbital_consistency(h´) === nothing
+    @test bloch(flatten(h´), phis) ≈ 2.3bloch(flatten(h1), phis)^3 - 2bloch(flatten(h2), phis)*bloch(flatten(h1), phis) - 3I
+end


### PR DESCRIPTION
This PR allows one to do basic algebra with Hamiltonians (that share lattice and orbital structure). This includes `^`, `*`, `+`, `-` and addition of the identity `I`.

 An example
```
julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(I), orbitals = (Val(2), Val(1))) |> unitcell(2)
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 5 (SparseMatrixCSC, sparse)
  Harmonic size    : 8 × 8
  Orbitals         : ((:a, :a), (:a,))
  Element type     : 2 × 2 blocks (Complex{Float64})
  Onsites          : 0
  Hoppings         : 24
  Coordination     : 3.0

julia> 2h^2 + h
Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
  Bloch harmonics  : 13 (SparseMatrixCSC, sparse)
  Harmonic size    : 8 × 8
  Orbitals         : ((:a, :a), (:a,))
  Element type     : 2 × 2 blocks (Complex{Float64})
  Onsites          : 8
  Hoppings         : 72
  Coordination     : 9.0
```

One possible usecase for this is the computation of the square of the shifted spectrum of `h` (doing e.g. `spectrum((h-z*I)^2, method->ArpackPackage(which = :LM))`) as a cheap way towards internal eigenvalues using Arnoldi.

(Note that the addition of `UniformScaling` respects the orbital structure of `h`)