### PR TITLE
Unitcell stress test: coordination should not change with full-rank supercells

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DualNumbers = "0.6"

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -17,6 +17,8 @@ using ExprTools
 
 using SparseArrays: getcolptr, AbstractSparseMatrix
 
+using Statistics: mean
+
 export sublat, bravais, lattice, dims, supercell, unitcell,
        hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector, nrange,
        sitepositions, siteindices, not,

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -652,15 +652,20 @@ supercell_center(lat::AbstractLattice{E,L,T}) where {E,L,T} =
 # supplements supercell with most orthogonal bravais axes
 function extended_supercell(bravais, supercell::SMatrix{L,L´}) where {L,L´}
     L == L´ && return supercell
-    bravais_new = bravais * supercell
+    bravais_new_norm = normalize_cols(bravais * supercell)
+    bravais_norm = normalize_cols(bravais)
     # νnorm are the L projections of old bravais on new bravais axis subspace
-    ν = bravais' * bravais_new  # L×L´
+    ν = bravais_norm' * bravais_new_norm  # L×L´
     νnorm = SVector(ntuple(row -> norm(ν[row,:]), Val(L)))
     νorder = sortperm(νnorm)
     ext_axes = hcat(ntuple(i -> unitvector(SVector{L,Int}, νorder[i]), Val(L-L´))...)
     ext_supercell = hcat(supercell, ext_axes)
     return ext_supercell
 end
+
+normalize_cols(s::SMatrix{L,0}) where {L} = s
+normalize_cols(s::SMatrix{0,L}) where {L} = s
+normalize_cols(s) = mapslices(v -> v/norm(v), s, dims = 1)
 
 function _superlat(lat, scmatrix, pararegion, selector_perp, seed)
     br = bravais(lat)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -68,7 +68,7 @@ end
         h´ = unitcell(h, sc)
         h´´ = unitcell(h´, 2)
         @test coordination(h´´) ≈ coordination(h´) ≈ c
-        h´ = unitcell(h, Tuple(Ic))
+        h´ = unitcell(h´, Tuple(Ic))
         h´´ = unitcell(h´, 2)
         @test coordination(h´´) ≈ coordination(h´)
     end


### PR DESCRIPTION
This is the result of a stress test on the unitcell routines to catch edge cases. We want to guarantee that any `unitcell(h, sc)` with any full-rank `sc` does not change the coordination of the resulting Hamiltonian. To achieve that we needed to correct some bugs and edge cases. Long story short, we were assuming supercell definitions that were slightly different when building the superlattice and the Hamiltonian (position-based vs dn-based). Now both should be consistent (position-based). We also need to be strict about which sites end  up in the final lattice: they should be only those within the bounds of the supercell, no hanging sites. Also, we needed to be a little more conservative in the scan of dn space when building the supercell.

Now tests over a full range of full-rank supercells generate the correct lattices, with identical coordination.