### PR TITLE
Remove kmesh from Bandstructure

### DIFF
--- a/src/greens.jl
+++ b/src/greens.jl
@@ -91,8 +91,7 @@ Base.summary(g::GreensFunction{<:BandGreenSolver}) =
     "GreensFunction{Bandstructure}: Green's function from a $(latdim(g.h))D bandstructure"
 
 function greensolver(b::Bandstructure{D}) where {D}
-    V = D + 1
-    indsedges = tuplepairs(Val(D+1)) # not inferred for D>2
+    indsedges = tuplepairs(Val(D))
     v = [SimplexData(simplex, band, indsedges) for band in bands(b) for simplex in band.simplices]
     return BandGreenSolver(v,  indsedges)
 end

--- a/src/plot_makie.jl
+++ b/src/plot_makie.jl
@@ -247,14 +247,14 @@ end
 # plot(::Bandstructure)
 #######################################################################
 
-function plot(bs::Bandstructure{1}; kw...)
+function plot(bs::Bandstructure{2}; kw...)
     scene = bandplot2d(bs; kw...)
     axis = scene[Axis]
     axis[:names, :axisnames] = ("φ", "ε")
     return scene
 end
 
-function plot(bs::Bandstructure{2}; kw...)
+function plot(bs::Bandstructure{3}; kw...)
     scene = bandplot3d(bs; kw...)
     axis = scene[Axis]
     to_value(scene[:show_axis]) && (axis[:names, :axisnames] = ("φ₁", "φ₂", "ε"))

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -94,9 +94,9 @@ link_shader(shader::Missing, psi, h) = (row, col) -> 0.0
 # vlplot
 #######################################################################
 """
-    vlplot(b::Bandstructure{1}; kw...)
+    vlplot(b::Bandstructure{2}; kw...)
 
-Plot the 1D bandstructure `b` using VegaLite.
+Plot the 1D bandstructure `b` using VegaLite in 2D.
 
     vlplot(h::Hamiltonian; kw...)
 
@@ -168,9 +168,8 @@ function VegaLite.vlplot(b::Bandstructure;
     return p
 end
 
-function bandtable(b::Bandstructure{1}, (scalingx, scalingy), bandsiter)
+function bandtable(b::Bandstructure{2}, (scalingx, scalingy), bandsiter)
     bandsiter´ = bandsiter === missing ? eachindex(bands(b)) : bandsiter
-    ks = vertices(b.kmesh)
     bnds = bands(b)
     table = [(x = v[1] * scalingx, y = v[2] * scalingy, band = i, tooltip = string(v))
              for i in bandsiter´ for v in vertices(bnds[i])]


### PR DESCRIPTION
`Bandstructure{D}` objects contain the D-dimensional k-space mesh (called `kmesh`), in addition to the (k, ϵ) mesh inside of each `Band`. This is redundant and can easily lead to bugs if we at some point assume that the `kmesh` is a D projection of the `Band` meshes in D+1 dimensions. It is not, in general, as `Bands` can have missing vertices, or in the future even might have more vertices than `kmesh` if they have been "refined".

This PR removes `kmesh` and makes `Bandstructure{D}` stand for a collection of bands, each defined as a mesh in D dimensions. Hence, a 1D bandstructure as a function of phase `ϕ₁` is now `Bandstructure{2}`, where the 2 stands for the dimensions of `(ϕ₁, ϵ)` space.