### PR TITLE
Fix for complex spectra

### DIFF
--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -4,13 +4,12 @@
 #######################################################################
 abstract type AbstractDiagonalizeMethod end
 
-struct Diagonalizer{M<:AbstractDiagonalizeMethod,S<:SubArray,T<:Real}
+struct Diagonalizer{M<:AbstractDiagonalizeMethod,T<:Real}
     method::M
     minoverlap::T
-    matviewtype::Type{S}
 end
 
-diagonalizer(matrix, method, minoverlap) = Diagonalizer(method, float(minoverlap), method_matviewtype(method, matrix))
+diagonalizer(method, minoverlap) = Diagonalizer(method, float(minoverlap))
 
 ## Diagonalize methods ##
 
@@ -91,7 +90,7 @@ similarmatrix(h, method::AbstractDiagonalizeMethod) = similarmatrix(h, method_ma
 method_matrixtype(::LinearAlgebraPackage, h) = Matrix{blockeltype(h)}
 method_matrixtype(::AbstractDiagonalizeMethod, h) = flatten
 
-# Type of states in bandstructure. Should be Matrix view, because eigvecs are dense and we need to support degeneracies
-method_matviewtype(::AbstractDiagonalizeMethod, ::AbstractMatrix{T}) where {T} = subarray_matrix_type(orbitaltype(T))
+# # Type of states in bandstructure. Should be Matrix view, because eigvecs are dense and we need to support degeneracies
+# method_matviewtype(::AbstractDiagonalizeMethod, ::AbstractMatrix{T}) where {T} = subarray_matrix_type(orbitaltype(T))
 
-subarray_matrix_type(::Type{M}) where {M} = typeof(view(Matrix{eltype(M)}(undef, 2, 2), :, 1:0))
+# subarray_matrix_type(::Type{M}) where {M} = typeof(view(Matrix{eltype(M)}(undef, 2, 2), :, 1:0))

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -369,7 +369,7 @@ struct Runs{T,F}
     istogether::F
 end
 
-approxruns(xs::Vector{T}) where {T} = Runs(xs, (x, y) -> isapprox(x, y; atol = sqrt(eps(T))))
+approxruns(xs::Vector{T}) where {T<:Number} = Runs(xs, (x, y) -> isapprox(x, y; atol = sqrt(eps(real(T)))))
 equalruns(xs) = Runs(xs, ==)
 
 function last_in_run(xs::Vector{T}, i, istogether) where {T}

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -178,6 +178,7 @@ function bandtable(b::Bandstructure{1,T}, (scalingx, scalingy), bandsiter) where
         segment = 0
         verts = vertices(band)
         sinds = band.simpinds
+        isempty(sinds) && continue
         s0 = first(sinds)
         for s in sinds
             if first(s) == last(s0)

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -29,6 +29,11 @@ using Quantica: nbands, nvertices, nedges, nsimplices
     b = bandstructure(h, :Γ, :X, (0, π), :Z, :Γ; subticks = (4,5,6,7))
     @test nbands(b) == 1
     @test nvertices(b) == 113
+
+    # complex spectra
+    h = LatticePresets.honeycomb() |> hamiltonian(onsite(im) + hopping(-1)) |> unitcell(2)
+    b = bandstructure(h, cuboid((-π, π), (-π, π), subticks = 7))
+    @test nbands(b)  == 1
 end
 
 @testset "functional bandstructures" begin


### PR DESCRIPTION
Complex eigenvalues made the merging of degeneracies in bandstructure trip. We fix this by making a smarter `Subspace` type that converts complex eigenvalues to the type of momenta. We also make sure the `approxruns::Runs` iterator deals with complex eigenvalues correctly.