### PR TITLE
Vertex degeneracies as tooltips in vegalite bandstructures

### DIFF
--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -172,7 +172,7 @@ end
 # We optimize 1D band plots by collecting connected simplices into line segments (because :rule is considerabley slower than :line)
 function bandtable(b::Bandstructure{1,T}, (scalingx, scalingy), bandsiter) where {T}
     bandsiter´ = bandsiter === missing ? eachindex(bands(b)) : bandsiter
-    NT = typeof((;x = zero(T), y = zero(T), band = 1))
+    NT = typeof((;x = zero(T), y = zero(T), band = 1, tooltip = 1))
     table = NT[]
     for (nb, band) in enumerate(bands(b))
         verts = vertices(band)
@@ -181,15 +181,15 @@ function bandtable(b::Bandstructure{1,T}, (scalingx, scalingy), bandsiter) where
         s0 = (0, 0)
         for s in sinds
             if first(s) == last(s0) || s0 == (0, 0)
-                push!(table, (; x = verts[first(s)][1] * scalingx, y = verts[first(s)][2] * scalingy, band = nb))
+                push!(table, (; x = verts[first(s)][1] * scalingx, y = verts[first(s)][2] * scalingy, band = nb, tooltip = degeneracy(band, first(s))))
             else
-                push!(table, (; x = verts[last(s0)][1] * scalingx, y = verts[last(s0)][2] * scalingy, band = nb))
-                push!(table, (; x = T(NaN), y = T(NaN), band = nb))  # cut
-                push!(table, (; x = verts[first(s)][1] * scalingx, y = verts[first(s)][2] * scalingy, band = nb))
+                push!(table, (; x = verts[last(s0)][1] * scalingx, y = verts[last(s0)][2] * scalingy, band = nb, tooltip = degeneracy(band, last(s0))))
+                push!(table, (; x = T(NaN), y = T(NaN), band = nb, tooltip = 0))  # cut
+                push!(table, (; x = verts[first(s)][1] * scalingx, y = verts[first(s)][2] * scalingy, band = nb, tooltip = degeneracy(band, first(s))))
             end
             s0 = s
         end
-        push!(table, (; x = verts[last(s0)][1] * scalingx, y = verts[last(s0)][2] * scalingy, band = nb))
+        push!(table, (; x = verts[last(s0)][1] * scalingx, y = verts[last(s0)][2] * scalingy, band = nb, tooltip = degeneracy(band, last(s0))))
     end
     return table
 end

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -3,42 +3,42 @@ using Arpack
 
 @testset "basic bandstructures" begin
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1))
-    b = bandstructure(h, subticks = 13)
+    b = bandstructure(h, subticks = 13, showprogress = false)
     @test nbands(b)  == 1
 
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1)) |> unitcell(2)
-    b = bandstructure(h, cuboid(0.99 .* (-π, π), 0.99 .* (-π, π), subticks = 13))
+    b = bandstructure(h, cuboid(0.99 .* (-π, π), 0.99 .* (-π, π), subticks = 13), showprogress = false)
     @test nbands(b)  == 3
 
     h = LatticePresets.honeycomb() |>
         hamiltonian(onsite(0.5, sublats = :A) + onsite(-0.5, sublats = :B) +
                     hopping(-1, range = 1/√3))
-    b = bandstructure(h, subticks = (13, 15))
+    b = bandstructure(h, subticks = (13, 15), showprogress = false)
     @test nbands(b)  == 2
 
     h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(2)
-    b = bandstructure(h, subticks = (5, 7, 5))
+    b = bandstructure(h, subticks = (5, 7, 5), showprogress = false)
     @test nbands(b)  == 1
 
-    b = bandstructure(h, :Γ, :X; subticks = 4)
+    b = bandstructure(h, :Γ, :X; subticks = 4, showprogress = false)
     @test nbands(b)  == 1
 
-    b = bandstructure(h, :Γ, :X, (0, π), :Z, :Γ; subticks = 4)
+    b = bandstructure(h, :Γ, :X, (0, π), :Z, :Γ; subticks = 4, showprogress = false)
     @test nbands(b)  == 1
     @test nvertices(b) == 73
 
-    b = bandstructure(h, :Γ, :X, (0, π), :Z, :Γ; subticks = (4,5,6,7))
+    b = bandstructure(h, :Γ, :X, (0, π), :Z, :Γ; subticks = (4,5,6,7), showprogress = false)
     @test nbands(b) == 1
     @test nvertices(b) == 113
 
     # complex spectra
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(im) + hopping(-1)) |> unitcell(2)
-    b = bandstructure(h, cuboid((-π, π), (-π, π), subticks = 7))
+    b = bandstructure(h, cuboid((-π, π), (-π, π), subticks = 7), showprogress = false)
     @test nbands(b)  == 1
 
     # spectrum sorting
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1)) |> unitcell(10)
-    b = bandstructure(h, :K, :K´, subticks = 7, method = ArpackPackage(sigma = 0.1im, nev = 12))
+    b = bandstructure(h, :K, :K´, subticks = 7, method = ArpackPackage(sigma = 0.1im, nev = 12), showprogress = false)
     @test nbands(b) == 1
 end
 
@@ -47,7 +47,7 @@ end
     matrix = similarmatrix(hc, LinearAlgebraPackage())
     hf((x,)) = bloch!(matrix, hc, (x, -x))
     m = cuboid((0, 1))
-    b = bandstructure(hf, m)
+    b = bandstructure(hf, m, showprogress = false)
     @test nbands(b)  == 2
 
     hc2 = LatticePresets.honeycomb() |> hamiltonian(hopping(-1))
@@ -55,15 +55,15 @@ end
     matrix2 = similarmatrix(hc2, LinearAlgebraPackage())
     hf2((s, x)) = bloch!(matrix2, hp2(s = s), (x, x))
     m2 = cuboid((0, 1), (0, 1))
-    b = bandstructure(hf2, m2)
+    b = bandstructure(hf2, m2, showprogress = false)
     @test nbands(b)  == 1
 end
 
 @testset "bandstructures lifts & transforms" begin
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2) + hopping(-1, range = 1/√3))
     mesh1D = cuboid((0, 2π))
-    b = bandstructure(h, mesh1D, mapping = φ -> (φ, -φ), transform = inv)
-    b´ = transform!(inv, bandstructure(h, mesh1D, mapping = φ -> (φ, -φ)))
+    b = bandstructure(h, mesh1D, mapping = φ -> (φ, -φ), transform = inv, showprogress = false)
+    b´ = transform!(inv, bandstructure(h, mesh1D, mapping = φ -> (φ, -φ), showprogress = false))
     @test nbands(b)  == nbands(b´) == 1
     @test vertices(bands(b)[1]) == vertices(bands(b´)[1])
     h´ = unitcell(h)
@@ -72,29 +72,29 @@ end
     @test energies(s1) == energies(s2)
     # no automatic mapping from 2D to 3D
     h = LatticePresets.cubic() |> hamiltonian(hopping(1)) |> unitcell(2)
-    @test_throws DimensionMismatch bandstructure(h, cuboid((0, 2pi), (0, 2pi)))
+    @test_throws DimensionMismatch bandstructure(h, cuboid((0, 2pi), (0, 2pi)), showprogress = false)
 end
 
 @testset "parametric bandstructures" begin
     ph = LatticePresets.linear() |> hamiltonian(onsite(0I) + hopping(-I), orbitals = Val(2)) |> unitcell(2) |>
          parametric(@onsite!((o; k) -> o + k*I), @hopping!((t; k = 2, p = [1,2])-> t - k*I + p'p))
     mesh2D = cuboid((0, 1), (0, 2π), subticks = 15)
-    b = bandstructure(ph, mesh2D, mapping = (x, k) -> (x, (;k = k)))
+    b = bandstructure(ph, mesh2D, mapping = (x, k) -> (x, (;k = k)), showprogress = false)
     @test nbands(b)  == 4
-    b = bandstructure(ph, mesh2D, mapping = (x, k) -> ((x,), (;k = k)))
+    b = bandstructure(ph, mesh2D, mapping = (x, k) -> ((x,), (;k = k)), showprogress = false)
     @test nbands(b)  == 4
-    b = bandstructure(ph, mesh2D, mapping = (x, k) -> (SA[x], (;k = k)))
+    b = bandstructure(ph, mesh2D, mapping = (x, k) -> (SA[x], (;k = k)), showprogress = false)
     @test nbands(b)  == 4
-    b = bandstructure(ph, mesh2D, mapping = (k, φ) -> (1, (;k = k, p = SA[1, φ])))
+    b = bandstructure(ph, mesh2D, mapping = (k, φ) -> (1, (;k = k, p = SA[1, φ])), showprogress = false)
     @test nbands(b)  == 1
 
     ph = LatticePresets.linear() |> hamiltonian(onsite(0I) + hopping(-I), orbitals = Val(2)) |> unitcell(2) |>
         unitcell |> parametric(@onsite!((o; k) -> o + k*I), @hopping!((t; k = 2, p = [1,2])-> t - k*I + p'p))
-    b = bandstructure(ph, mesh2D, mapping = (k, φ) -> (;k = k, p = SA[1, φ]))
+    b = bandstructure(ph, mesh2D, mapping = (k, φ) -> (;k = k, p = SA[1, φ]), showprogress = false)
     @test nbands(b)  == 1
-    b = bandstructure(ph, mesh2D, mapping = (k, φ) -> ((;k = k, p = SA[1, φ]),))
+    b = bandstructure(ph, mesh2D, mapping = (k, φ) -> ((;k = k, p = SA[1, φ]),), showprogress = false)
     @test nbands(b)  == 1
-    @test_throws UndefKeywordError bandstructure(ph, mesh2D, mapping = (k, φ) -> ((;p = SA[1, φ]),))
+    @test_throws UndefKeywordError bandstructure(ph, mesh2D, mapping = (k, φ) -> ((;p = SA[1, φ]),), showprogress = false)
 end
 
 @testset "unflatten" begin

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -38,8 +38,8 @@ using Arpack
 
     # spectrum sorting
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1)) |> unitcell(10)
-    b = bandstructure(h, :Γ, :K, :K´, subticks = 7, method = ArpackPackage(sigma = im, nev = 8))
-    @test nbands(b)  == 1
+    b = bandstructure(h, :K, :K´, subticks = 7, method = ArpackPackage(sigma = 0.1im, nev = 12))
+    @test nbands(b) == 1
 end
 
 @testset "functional bandstructures" begin


### PR DESCRIPTION
To see the tooltips one must hover a vertex in the plot. If we don't plot the vertices (with `vlplot(b, points = true)`), we need to hunt for them along the band lines:

<img width="515" alt="Screen Shot 2020-11-04 at 18 22 43" src="https://user-images.githubusercontent.com/4310809/98144615-c149d300-1eca-11eb-8d2d-73672aa91741.png">
