### PR TITLE
Boolean regions

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -31,7 +31,7 @@ export sublat, bravais, lattice, dims, supercell, unitcell,
        momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM,
        greens, greensolver
 
-export LatticePresets, RegionPresets, HamiltonianPresets
+export RegionPresets, RP, LatticePresets, LP, HamiltonianPresets, HP
 
 export LinearAlgebraPackage, ArpackPackage, KrylovKitPackage
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -733,6 +733,7 @@ function _cell_iter(lat::Lattice{E,L}, sc::SMatrix{L,L´}, pararegion, rsel_perp
             site_not_in_explored_bbox && (acceptcell!(iter, dn); first_found && break)
         end
         # make sure we don't stop search until we find at least one site in supercell
+        # (necessary when seed is outside your region)
         first_found || acceptcell!(iter, dn)
     end
     c = CartesianIndices(iter)

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -107,6 +107,11 @@ Region{E}(f::F) where {E,F<:Function} = Region{E,F}(f)
 Base.show(io::IO, ::Region{E}) where {E} =
     print(io, "Region{$E} : region in $(E)D space")
 
+Base.:&(r1::Region{E}, r2::Region{E}) where {E} = Region{E}(r -> r1.f(r) && r2.f(r))
+Base.:|(r1::Region{E}, r2::Region{E}) where {E}  = Region{E}(r -> r1.f(r) || r2.f(r))
+Base.xor(r1::Region{E}, r2::Region{E}) where {E}  = Region{E}(r -> xor(r1.f(r),r2.f(r)))
+Base.:!(r1::Region{E}) where {E}  = Region{E}(r -> !r1.f(r))
+
 extended_eps(T = Float64) = sqrt(eps(T))
 
 circle(radius = 10.0, c...) = Region{2}(_region_ellipse((radius, radius), c...))
@@ -145,3 +150,11 @@ function _region_cuboid((lx, ly, lz), (cx, cy, cz) = (0, 0, 0))
 end
 
 end # module
+
+#######################################################################
+# Aliases
+#######################################################################
+
+const RP = RegionPresets
+const LP = LatticePresets
+const HP = HamiltonianPresets

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -109,7 +109,7 @@ Base.show(io::IO, ::Region{E}) where {E} =
 
 Base.:&(r1::Region{E}, r2::Region{E}) where {E} = Region{E}(r -> r1.f(r) && r2.f(r))
 Base.:|(r1::Region{E}, r2::Region{E}) where {E}  = Region{E}(r -> r1.f(r) || r2.f(r))
-Base.xor(r1::Region{E}, r2::Region{E}) where {E}  = Region{E}(r -> xor(r1.f(r),r2.f(r)))
+Base.xor(r1::Region{E}, r2::Region{E}) where {E}  = Region{E}(r -> xor(r1.f(r), r2.f(r)))
 Base.:!(r1::Region{E}) where {E}  = Region{E}(r -> !r1.f(r))
 
 extended_eps(T = Float64) = sqrt(eps(T))

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -113,3 +113,14 @@ end
     @test supercell(LatticePresets.bcc(), (2,1,0), region = RegionPresets.circle(10, (1,0))) isa Superlattice{3,3}
     @test supercell(LatticePresets.cubic(), (2,1,0), region = RegionPresets.sphere(10)) isa Superlattice{3,3}
 end
+
+@testset "boolean regions" begin
+    lat = unitcell(LP.square(), region = xor(RP.square(10), RP.square(20)))
+    @test nsites(lat) == 320
+    lat = unitcell(LP.honeycomb(), region = xor(RP.circle(20), RP.square(10)))
+    lat´ = unitcell(LP.honeycomb(), region = RP.circle(20) & !RP.square(10))
+    @test allsitepositions(lat) == allsitepositions(lat´)
+    lat = unitcell(LP.honeycomb(), region = RP.circle(5, (5,0)) | RP.circle(5, (15,0)) | RP.circle(5, (25,0)))
+    lat´ = unitcell(LP.honeycomb(), region = RP.circle(5, (5,0)))
+    @test nsites(lat) == 3 * nsites(lat´)
+end


### PR DESCRIPTION
Closes #121 

This introduces boolean operators `&`, `I`, `xor` and `!` for `RegionPresets.Region`s

This also fixes a ~little~ bug in `supercell` that could lead to empty lattices when searching for sites did not immediately turn up a candidate. 

It also introduces convenience aliases `LP` for `LatticePresets`, `HP` for `HamiltonianPresets` and `RP` for `RegionPresets`

Usage example
```
h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1)) |> 
    unitcell(region = xor(RP.circle(10), RP.circle(6, (3,0)), RP.circle(6, (-3,0))))
```

<img width="874" alt="Screen Shot 2020-11-05 at 09 54 03" src="https://user-images.githubusercontent.com/4310809/98219184-f860c880-1f4c-11eb-9c65-d861a6a5f48d.png">
