### PR TITLE
Remove dangling bonds with `mincoordination`

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1246,41 +1246,47 @@ function supercell(ham::Hamiltonian, args...; kw...)
     return Hamiltonian(slat, ham.harmonics, ham.orbitals)
 end
 
-function unitcell(ham::Hamiltonian{<:Lattice}, args...; modifiers = (), kw...)
+function unitcell(ham::Hamiltonian{<:Lattice}, args...; modifiers = (), mincoordination = missing, kw...)
     sham = supercell(ham, args...; kw...)
-    return unitcell(sham; modifiers = modifiers)
+    return unitcell(sham; modifiers = modifiers, mincoordination = mincoordination)
 end
 
-function unitcell(ham::Hamiltonian{LA,L}; modifiers = ()) where {E,L,T,L´,LA<:Superlattice{E,L,T,L´}}
+function unitcell(ham::Hamiltonian{LA,L}; modifiers = (), mincoordination = missing) where {E,L,T,L´,LA<:Superlattice{E,L,T,L´}}
     slat = ham.lattice
     sc = slat.supercell
     supercell_dn = r_to_dn(slat, sc.matrix, SVector{L´}(1:L´))
     pos = allsitepositions(slat)
     br = bravais(slat)
     modifiers´ = resolve.(ensuretuple(modifiers), Ref(slat))
-    mapping = OffsetArray{Int}(undef, sc.sites, sc.cells.indices...) # store supersite indices newi
+
+    # Build a version of slat that has a filtered supercell mask according to mincoordination
+    slat´ = filtered_superlat!(ham, mincoordination, supercell_dn, br, sc.matrix, pos)
+    # store supersite indices newi
+    mapping = OffsetArray{Int}(undef, sc.sites, sc.cells.indices...)
     mapping .= 0
-    foreach_supersite((s, oldi, olddn, newi) -> mapping[oldi, Tuple(olddn)...] = newi, slat)
+    foreach_supersite((s, oldi, olddn, newi) -> mapping[oldi, Tuple(olddn)...] = newi, slat´)
+
     dim = nsites(sc)
     B = blocktype(ham)
     S = typeof(SparseMatrixBuilder{B}(dim, dim))
     harmonic_builders = HamiltonianHarmonic{L´,B,S}[]
-    foreach_supersite(slat) do s, source_i, source_dn, newcol
+
+    foreach_supersite(slat´) do s, source_i, source_dn, newcol
         for oldh in ham.harmonics
             rows = rowvals(oldh.h)
             vals = nonzeros(oldh.h)
             target_dn = source_dn + oldh.dn
             for p in nzrange(oldh.h, source_i)
                 target_i = rows[p]
-                r = pos[target_i] + br * target_dn
-                super_dn = supercell_dn(r)
-                wrapped_dn = wrap_dn(target_dn, super_dn, sc.matrix)
+                wrapped_dn, super_dn = wrap_super_dn(target_i, target_dn, supercell_dn, br, sc.matrix, pos)
                 # check: wrapped_dn could exit bounding box along non-periodic direction
                 checkbounds(Bool, mapping, target_i, Tuple(wrapped_dn)...) || continue
                 newh = get_or_push!(harmonic_builders, super_dn, dim, newcol)
                 newrow = mapping[target_i, Tuple(wrapped_dn)...]
-                val = applymodifiers(vals[p], slat, (source_i, target_i), (source_dn, target_dn), modifiers´...)
-                iszero(newrow) || pushtocolumn!(newh.h, newrow, val)
+                if !iszero(newrow)
+                    val = applymodifiers(vals[p], slat, (source_i, target_i), (source_dn, target_dn), modifiers´...)
+                    pushtocolumn!(newh.h, newrow, val)
+                end
             end
         end
         foreach(h -> finalizecolumn!(h.h), harmonic_builders)
@@ -1289,6 +1295,54 @@ function unitcell(ham::Hamiltonian{LA,L}; modifiers = ()) where {E,L,T,L´,LA<:S
     unitlat = unitcell(slat)
     orbs = ham.orbitals
     return Hamiltonian(unitlat, harmonics, orbs)
+end
+
+filtered_superlat!(sham, ::Missing, args...) = sham.lattice
+filtered_superlat!(sham, mc::Int, args...) =
+    _filtered_superlat!(sham, mc, expanded_supercell_mask(sham.lattice.supercell), args...)
+
+# function _filtered_superlat!(sham::Hamiltonian{LA,L}, mincoord::Int, mask::OffsetArray, supercell_dn::Function, br::SMatrix, smat::SMatrix, pos::Vector) where {LA,L}
+function _filtered_superlat!(sham::Hamiltonian{LA,L}, mincoord, mask, args...) where {LA,L}
+    slat = sham.lattice
+    sc = slat.supercell
+    mincoord > 0 || return sc
+    delsites = NTuple{L+1,Int}[]
+    while true
+        foreach_supersite(sham.lattice) do _, source_i, source_dn, _
+            nn = num_neighbors_supercell(sham.harmonics, source_i, source_dn, mask, args...)
+            nn >= mincoord || push!(delsites, (source_i, Tuple(source_dn)...))
+        end
+        foreach(p -> mask[p...] = false, delsites)
+        isempty(delsites) && break
+        resize!(delsites, 0)
+    end
+    sc = Supercell(sc.matrix, sc.sites, sc.cells, mask)
+    return Superlattice(slat.bravais, slat.unitcell, sc)
+end
+
+function num_neighbors_supercell(hhs, source_i, source_dn, mask, args...)
+    nn = 0
+    for hh in hhs
+        ptrs = nzrange(hh.h, source_i)
+        rows = rowvals(hh.h)
+        target_dn = source_dn + hh.dn
+        for p in nzrange(hh.h, source_i)
+            target_i = rows[p]
+            # global tmp = (target_i, target_dn, supercell_dn, br, smat, pos)
+            wrapped_dn, _ = wrap_super_dn(target_i, target_dn, args...)
+            isonsite = rows[p] == source_i && iszero(hh.dn)
+            isincell = isinmask(mask, rows[p], Tuple(wrapped_dn)...)
+            nn += !isonsite && isincell
+        end
+    end
+    return nn
+end
+
+function wrap_super_dn(target_i, target_dn, supercell_dn, br, smat, pos)
+    r = pos[target_i] + br * target_dn
+    super_dn = supercell_dn(r)
+    wrapped_dn = target_dn - smat * super_dn
+    return wrapped_dn, super_dn
 end
 
 function get_or_push!(hs::Vector{<:HamiltonianHarmonic{L,B,<:SparseMatrixBuilder}}, dn, dim, currentcol) where {L,B}
@@ -1300,8 +1354,6 @@ function get_or_push!(hs::Vector{<:HamiltonianHarmonic{L,B,<:SparseMatrixBuilder
     push!(hs, newh)
     return newh
 end
-
-wrap_dn(olddn::SVector, newdn::SVector, supercell::SMatrix) = olddn - supercell * newdn
 
 applymodifiers(val, lat, inds, dns) = val
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -360,9 +360,9 @@ function boolean_mask(f, mask1, mask2, indranges)
     return mask
 end
 
-expanded_supercell_mask(s::Supercell{L,L´,Missing}) where {L,L´} =
-    ones(Bool, s.sites, s.cells.indices...)
-expanded_supercell_mask(s::Supercell{L,L´}) where {L,L´} = s.mask
+expand_supercell_mask(s::Supercell{L,L´,Missing}) where {L,L´} =
+    Supercell(s.matrix, s.sites, s.cells, ones(Bool, s.sites, s.cells.indices...))
+expand_supercell_mask(s::Supercell{L,L´}) where {L,L´} = s
 
 #######################################################################
 # Superlattice
@@ -474,6 +474,9 @@ ismasked(lat::Superlattice) = ismasked(lat.supercell)
 
 maskranges(lat::Superlattice) = (1:nsites(lat), lat.supercell.cells.indices...)
 maskranges(lat::Lattice) = (1:nsites(lat),)
+
+expand_supercell_mask(s::Superlattice) =
+    Superlattice(s.bravais, s.unitcell, expand_supercell_mask(s.supercell))
 
 """
     transform!(f::Function, lat::Lattice)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -72,6 +72,15 @@ end
         h´´ = unitcell(h´, 2)
         @test coordination(h´´) ≈ coordination(h´)
     end
+    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell(2) |> unitcell(mincoordination = 2)
+    @test nsites(h) == 6
+    h = LP.cubic() |> hamiltonian(hopping(1)) |> unitcell(4) |> unitcell(mincoordination = 4)
+    @test nsites(h) == 0
+    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell(region = RP.circle(5) & !RP.circle(2)) |> unitcell(mincoordination = 2)
+    @test nsites(h) == 144
+    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell(10, region = !RP.circle(2, (0,8)))
+    h´ = h |> unitcell(1, mincoordination = 2)
+    @test nsites(h´) == nsites(h) - 1
 end
 
 @testset "hamiltonian wrap" begin


### PR DESCRIPTION
Closes #130 

Introduces a new `mincoordination` kwarg in `unitcell(::Hamiltonian,...)`. This removes sites until all remaining have at least `mincoordination` neighbors. The way this works is we iterate over the mask of the supercell to eliminate any sites that have too few neighbors. This pass is repeated until no more sites are removed. As the neighbor searching reused a large part of non-trivial hamiltonian unitcell code, I had to refactor the latter so that functionality could be shared.

Example from tests:
```
h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell(10, region = !RP.circle(2, (0,8)))
h´ = h |> unitcell(1, mincoordination = 2)
vlplot(h, size = 300, maxdiameter = 6)
vlplot(h´, size = 300, maxdiameter = 6)
```
<img width="226" alt="Screen Shot 2020-11-09 at 21 18 48" src="https://user-images.githubusercontent.com/4310809/98591900-38b7a200-22d1-11eb-87d5-1ce784d971cd.png">

<img width="221" alt="Screen Shot 2020-11-09 at 21 18 59" src="https://user-images.githubusercontent.com/4310809/98591908-3c4b2900-22d1-11eb-9184-aaa732c8a026.png">
