### PR TITLE
Fix intrinsic invalidations

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -3,9 +3,6 @@
 # to instantiate types and convert between instances. (For parametric types, unless overridden,
 # you get an implicit internal constructor without parameters, so no need to define that externally)
 
-Base.convert(::Type{T}, l::T) where T<:Tuple{Vararg{Sublat}} = l
-Base.convert(::Type{Tuple{Vararg{Sublat{E,T}}}}, l::Tuple{Vararg{Sublat}}) where {E,T} = Sublat{E,T}.(l)
-
 Base.convert(::Type{T}, l::T) where T<:Sublat = l
 Base.convert(::Type{T}, l::Sublat) where T<:Sublat = T(l)
 
@@ -13,7 +10,6 @@ Base.convert(::Type{T}, l::T) where T<:Bravais = l
 Base.convert(::Type{T}, l::Bravais) where T<:Bravais = T(l)
 
 # Constructors for conversion
-
 Sublat{E,T,V}(s::Sublat, name = s.name) where {E,T,V<:Vector} =
     Sublat([padright(site, zero(T), Val(E)) for site in s.sites], name)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -476,8 +476,8 @@ TightbindingModel(ts::TightbindingModelTerm...) = TightbindingModel(ts)
 
 # External API #
 
-Base.:*(x, m::TightbindingModel) = TightbindingModel(x .* m.terms)
-Base.:*(m::TightbindingModel, x) = x * m
+Base.:*(x::Number, m::TightbindingModel) = TightbindingModel(x .* m.terms)
+Base.:*(m::TightbindingModel, x::Number) = x * m
 Base.:-(m::TightbindingModel) = TightbindingModel((-1) .* m.terms)
 
 Base.:+(m::TightbindingModel, t::TightbindingModel) = TightbindingModel((m.terms..., t.terms...))
@@ -743,10 +743,10 @@ _onlyhoppings(s, t::HoppingTerm, args...) =
     (HoppingTerm(t, merge_non_missing(t.selector, s)), _onlyhoppings(s, args...)...)
 _onlyhoppings(s) = ()
 
-Base.:*(x, o::OnsiteTerm) =
+Base.:*(x::Number, o::OnsiteTerm) =
     OnsiteTerm(o.o, o.selector, x * o.coefficient)
-Base.:*(x, t::HoppingTerm) = HoppingTerm(t.t, t.selector, x * t.coefficient)
-Base.:*(t::TightbindingModelTerm, x) = x * t
+Base.:*(x::Number, t::HoppingTerm) = HoppingTerm(t.t, t.selector, x * t.coefficient)
+Base.:*(t::TightbindingModelTerm, x::Number) = x * t
 Base.:-(t::TightbindingModelTerm) = (-1) * t
 
 Base.adjoint(t::TightbindingModel) = TightbindingModel(adjoint.(terms(t)))
@@ -1003,8 +1003,8 @@ KetModel{2}: model with 2 terms
 """
 ket(f; normalized = true, maporbitals::Bool = false, kw...) = KetModel(onsite(f; kw...), normalized, Val(maporbitals))
 
-Base.:*(x, k::KetModel) = KetModel(k.model * x, k.normalized, k.maporbitals)
-Base.:*(k::KetModel, x) = KetModel(x * k.model, k.normalized, k.maporbitals)
+Base.:*(x::Number, k::KetModel) = KetModel(k.model * x, k.normalized, k.maporbitals)
+Base.:*(k::KetModel, x::Number) = KetModel(x * k.model, k.normalized, k.maporbitals)
 Base.:-(k::KetModel) = KetModel(-k.model, k.normalized, k.maporbitals)
 Base.:-(k1::KetModel, k2::KetModel) = KetModel(k1.model - k2.model, k1.normalized && k2.normalized, _andVal(k1.maporbitals, k2.maporbitals))
 Base.:+(k1::KetModel, k2::KetModel) = KetModel(k1.model + k2.model, k1.normalized && k2.normalized, _andVal(k1.maporbitals, k2.maporbitals))


### PR DESCRIPTION
Following the tutorial in https://www.youtube.com/watch?v=7VbXbI6OmYo by Tim Holy, I found a couple of invalidations, most notably a convert method. This PR fixes them. There are still some other invalidations but they come from dependencies, not Quantica itself.