### PR TITLE
Don't count structural zeros for mincoordination

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1329,13 +1329,15 @@ function num_neighbors_supercell(hhs, source_i, source_dn, mask, args...)
     for hh in hhs
         ptrs = nzrange(hh.h, source_i)
         rows = rowvals(hh.h)
+        nzel = nonzeros(hh.h)
         target_dn = source_dn + hh.dn
         for p in nzrange(hh.h, source_i)
             target_i = rows[p]
             wrapped_dn, _ = wrap_super_dn(target_i, target_dn, args...)
             isonsite = rows[p] == source_i && iszero(hh.dn)
             isincell = isinmask(mask, rows[p], Tuple(wrapped_dn)...)
-            nn += !isonsite && isincell
+            isnonzero = !iszero(nzel[p])
+            nn += !isonsite && isincell && isnonzero
         end
     end
     return nn

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -791,11 +791,15 @@ Convert Superlattice `slat` into a lattice with its unit cell matching `slat`'s 
     unitcell(h::Hamiltonian, v...; mincoordination, modifiers = (), kw...)
 
 Transforms the `Lattice` of `h` to have a larger unitcell, while expanding the Hamiltonian
-accordingly. A nonzero `mincoordination` indicates a minimum number of hopping neighbors
-required for sites to be included in the resulting unit cell. The modifiers (a tuple of
-`ElementModifier`s, either `@onsite!` or `@hopping!` with no free parameters) will be
-applied to onsite and hoppings as the hamiltonian is expanded. See `@onsite!` and
-`@hopping!` for details
+accordingly.
+
+A nonzero `mincoordination` indicates a minimum number of nonzero hopping neighbors required
+for sites to be included in the resulting unit cell. Sites with inferior coordination will
+be removed recursively, until all remaining satisfy `mincoordination`.
+
+The `modifiers` (a tuple of `ElementModifier`s, either `@onsite!` or `@hopping!` with no
+free parameters) will be applied to onsite and hoppings as the hamiltonian is expanded. See
+`@onsite!` and `@hopping!` for details.
 
 Note: for performance reasons, in sparse hamiltonians only the stored onsites and hoppings
 will be transformed by `ElementModifier`s, so you might want to add zero onsites or hoppings

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -81,6 +81,8 @@ end
     h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell(10, region = !RP.circle(2, (0,8)))
     h´ = h |> unitcell(1, mincoordination = 2)
     @test nsites(h´) == nsites(h) - 1
+    h = LP.square() |> hamiltonian(hopping(0)) |> unitcell(4, mincoordination = 2)
+    @test nsites(h) == 0
 end
 
 @testset "hamiltonian wrap" begin


### PR DESCRIPTION
PR #131 computed coordination including structural zeros, unlike the `coordination` reported by `show(::Hamiltonian)`. This PR fixes that, so that a zero hopping does not count towards `mincoordination`