### PR TITLE
Add vlplot option mindiameter

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -33,7 +33,7 @@ export sublat, bravais, lattice, dims, supercell, unitcell,
 
 export RegionPresets, RP, LatticePresets, LP, HamiltonianPresets, HP
 
-export LinearAlgebraPackage, ArpackPackage, KrylovKitPackage
+export LinearAlgebraPackage, ArpackPackage, ArnoldiMethodPackage, KrylovKitPackage
 
 export @SMatrix, @SVector, SMatrix, SVector, SA
 

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -119,7 +119,8 @@ end
 ArnoldiMethodPackage(; kw...) = (checkloaded(:ArnoldiMethod); ArnoldiMethodPackage(values(kw)))
 
 function diagonalize(matrix, method::ArnoldiMethodPackage)
-    ϵ, ψ = Main.ArnoldiMethod.partialschur(matrix; (method.kw)...)
+    p = first(Main.ArnoldiMethod.partialschur(matrix; (method.kw)...))
+    ϵ, ψ = p.eigenvalues, p.Q
     return ϵ, ψ
 end
 


### PR DESCRIPTION
VegaLite struggles with complex plots. This is a problem when plotting eigenstates of large systems. The situation can be alleviated when the eigenstates have many values very close to zero encoded with `sitesize` in `vlplot` that in principle should not be plotted. However, to make `vlplot` faster it is necessary to explicitly exclude these table entries from the data passed to `@vlplot`.

This PR allows one to exclude these entries by passing a `mindiameter`, that is complementary to `maxdiameter`. For it to be useful for performance it probably needs to be used together with `plotlinks = false`.

Without `mindiameter` (slow)
```
vlplot(h, ψ, sitesize = abs, plotlinks = false)
```
<img width="643" alt="Screen Shot 2020-11-20 at 12 30 04" src="https://user-images.githubusercontent.com/4310809/99795484-27219600-2b2c-11eb-9db4-09b82258cddd.png">

With `mindiameter` (fast)
```
vlplot(h, ψ, sitesize = abs, plotlinks = false, mindiameter = 1)
```
<img width="639" alt="Screen Shot 2020-11-20 at 12 30 46" src="https://user-images.githubusercontent.com/4310809/99795576-46202800-2b2c-11eb-84a2-42457c2d833e.png">


This PR adds an unrelated enhacement that allows to pass `ψ` as a `Subspace` (as produced e.g. by `spectrum`). If the subspace is degenerate, the first component is plotted for the moment. In the future we would need to sum over base components.

It also includes a fix for `ArnoldiPackageMethod` (blush!)