### PR TITLE
Support multiple states in vlplot

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -282,7 +282,8 @@ end
 
 ## unflatten ##
 
-unflatten(vflat, h) = unflatten!(similar(vflat, orbitaltype(h), size(vflat)...), vflat, h)
+unflatten(vflat::AbstractVector, h) = unflatten!(similar(vflat, orbitaltype(h), size(h, 2)), vflat, h)
+unflatten(vflat::AbstractMatrix, h) = unflatten!(similar(vflat, orbitaltype(h), size(h, 2), size(vflat, 2)), vflat, h)
 
 function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, h::Hamiltonian) where {T}
     norbs = length.(h.orbitals)
@@ -291,7 +292,7 @@ function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, h::Hamiltonian) w
     check_unflatten_dst_dims(v, h)
     check_unflatten_src_dims(vflat, dimflat)
     check_unflatten_eltypes(v, h)
-    j = 0
+    row = 0
     for col in 1:size(v, 2)
         for s in sublats(h.lattice)
             N = norbs[s]

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -282,9 +282,9 @@ end
 
 ## unflatten ##
 
-unflatten(v, h) = unflatten!(similar(v, orbitaltype(h), size(h, 2)), v, h)
+unflatten(vflat, h) = unflatten!(similar(vflat, orbitaltype(h), size(vflat)...), vflat, h)
 
-function unflatten!(v::AbstractVector{T}, vflat::AbstractArray, h::Hamiltonian) where {T}
+function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, h::Hamiltonian) where {T}
     norbs = length.(h.orbitals)
     offsetsflat = flatoffsets(h.lattice.unitcell.offsets, norbs)
     dimflat = last(offsetsflat)
@@ -292,11 +292,13 @@ function unflatten!(v::AbstractVector{T}, vflat::AbstractArray, h::Hamiltonian) 
     check_unflatten_src_dims(vflat, dimflat)
     check_unflatten_eltypes(v, h)
     j = 0
-    for s in sublats(h.lattice)
-        N = norbs[s]
-        for i in offsetsflat[s]+1:N:offsetsflat[s+1]
-            j += 1
-            v[j] = padright(view(vflat, i:i+N-1), T)
+    for col in 1:size(v, 2)
+        for s in sublats(h.lattice)
+            N = norbs[s]
+            for i in offsetsflat[s]+1:N:offsetsflat[s+1]
+                row += 1
+                v[row, col] = padright(view(vflat, i:i+N-1, col:col), T)
+            end
         end
     end
     return v
@@ -314,15 +316,18 @@ check_unflatten_eltypes(v::AbstractVector{T}, h) where {T} =
     T === orbitaltype(h) ||
         throw(ArgumentError("Eltype of desination array is inconsistent with Hamiltonian"))
 
+valdim(::Type{<:Number}) = Val(1)
+valdim(::Type{S}) where {N,S<:SVector{N}} = Val(N)
+
 ## unflatten_or_reinterpret: call unflatten but only if we cannot do it without copying
 unflatten_or_reinterpret(vflat, h) = _unflatten_or_reinterpret(vflat, h, orbitaltype(h), h.orbitals)
 # source is already of the correct orbitaltype(h)
-function _unflatten_or_reinterpret(v::AbstractVector{T}, h, ::Type{T}, orbs) where {T}
+function _unflatten_or_reinterpret(v::AbstractArray{T}, h, ::Type{T}, orbs) where {T}
     check_unflatten_dst_dims(v, h)
     return v
 end
 # source can be reinterpreted, because the number of orbitals is the same M for all N sublattices
-_unflatten_or_reinterpret(v::AbstractVector{T}, h, ::Type{S}, ::NTuple{N,NTuple{M}}) where {N,M,T<:Number,S<:SVector{M}} =
+_unflatten_or_reinterpret(v::AbstractArray{T}, h, ::Type{S}, ::NTuple{N,NTuple{M}}) where {N,M,T<:Number,S<:SVector{M}} =
     reinterpret(SVector{M,T}, v)
 # otherwise call unflatten
 _unflatten_or_reinterpret(v, h, S, orbs) = unflatten(v, h)

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -114,6 +114,14 @@ shaders: `sitesize`, `siteopacity`, `sitecolor`, `linksize`, `linkopacity` or `l
 (see keywords below). If `psi` is obtained in a flattened form, it will be automatically
 "unflattened" to restore the orbital structure of `h`.
 
+    vlplot(h::Hamiltonian, psi::AbstractMatrix; kw...)
+
+Same as above, but columns of psi will be summed over after applying shaders to each.
+
+    vlplot(h::Hamiltonian, psi::Subspace; kw...)
+
+Equivalent to `vlplot(h, psi.basis; kw...)`.
+
 # Keyword arguments and defaults
 
 ## Common

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -98,6 +98,7 @@ padright(sv::StaticVector{E,T}, ::Val{E}) where {E,T} = sv
 padright(t::NTuple{N´,Any}, x, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? x : t[i], Val(N))
 padright(t::NTuple{N´,Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 : t[i], Val(N))
 
+padright(v, ::Type{<:Number}) = first(v)
 padright(v, ::Type{S}) where {E,T,S<:SVector{E,T}} = padright(v, zero(T), S)
 padright(v, x::T, ::Type{S}) where {E,T,S<:SVector{E,T}} =
     SVector{E,T}(ntuple(i -> i > length(v) ? x : convert(T, v[i]), Val(E)))


### PR DESCRIPTION
When passing a multiply degenerate subspace `s::Subspace` or a matrix `s::AbstractMatrix` to `vlplot(h, s; shaders...)`, each  basis vector or column of `s` will now be summed over after applying shaders to each. This allows to visualize observables integrated over a whole subspace (e.g. summing local density over all spin flavors).