### PR TITLE
Fix in vlplot: make CurrentShader and DensityShader work with multiple states

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -750,7 +750,7 @@ function bandstructure_collect(subspaces::Array{Vector{Subspace{C,T,S}},D}, band
     nsimps = isempty(bands) ? 0 : sum(nsimplices, bands)
     sverts = Vector{NTuple{D+1,SVector{D+1,T}}}(undef, nsimps)
     sbases = Vector{NTuple{D+1,S}}(undef, nsimps)
-    sptrs = fill(1:0, size(subspaces) .- 1)                  # assuming non-periodic basemesh
+    sptrs = fill(1:0, size(subspaces) .- 1)               # assuming non-periodic basemesh
     s0inds = Vector{CartesianIndex{D}}(undef, nsimps)    # base cuboid index for reference vertex in simplex, for sorting
 
     scounter = 0
@@ -761,7 +761,7 @@ function bandstructure_collect(subspaces::Array{Vector{Subspace{C,T,S}},D}, band
             let ioffset = ioffset  # circumvent boxing, JuliaLang/#15276
                 baseinds = (i -> cuboidinds[ioffset + i].baseidx).(s)
                 pbase = sortperm(SVector(baseinds))
-                s0inds[scounter] = baseinds[first(pbase)] # equivalent to minimum(baseinds)
+                s0inds[scounter] = minimum(baseinds) # or equivalently, baseinds[first(pbase)]
                 sverts[scounter] = ntuple(i -> band.verts[s[pbase[i]]], Val(D+1))
                 sbases[scounter] = ntuple(Val(D+1)) do i
                     c = cuboidinds[ioffset + s[pbase[i]]]
@@ -778,7 +778,9 @@ function bandstructure_collect(subspaces::Array{Vector{Subspace{C,T,S}},D}, band
     permute!(sbases, psimps)
 
     for rng in equalruns(s0inds)
-        sptrs[s0inds[first(rng)]] = rng
+        baseind = s0inds[first(rng)]
+        baseind in CartesianIndices(sptrs) || continue
+        sptrs[baseind] = rng
     end
 
     return sverts, sbases, sptrs

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -779,7 +779,7 @@ function bandstructure_collect(subspaces::Array{Vector{Subspace{C,T,S}},D}, band
 
     for rng in equalruns(s0inds)
         baseind = s0inds[first(rng)]
-        baseind in CartesianIndices(sptrs) || continue
+        baseind in CartesianIndices(sptrs) || continue  # TODO: should not be necessary
         sptrs[baseind] = rng
     end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -292,8 +292,8 @@ function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, h::Hamiltonian) w
     check_unflatten_dst_dims(v, h)
     check_unflatten_src_dims(vflat, dimflat)
     check_unflatten_eltypes(v, h)
-    row = 0
     for col in 1:size(v, 2)
+        row = 0
         for s in sublats(h.lattice)
             N = norbs[s]
             for i in offsetsflat[s]+1:N:offsetsflat[s+1]
@@ -313,7 +313,7 @@ check_unflatten_src_dims(vflat, dimflat) =
     size(vflat, 1) == dimflat ||
         throw(ArgumentError("Dimension of source array is inconsistent with Hamiltonian"))
 
-check_unflatten_eltypes(v::AbstractVector{T}, h) where {T} =
+check_unflatten_eltypes(v::AbstractArray{T}, h) where {T} =
     T === orbitaltype(h) ||
         throw(ArgumentError("Eltype of desination array is inconsistent with Hamiltonian"))
 
@@ -800,7 +800,7 @@ Base.getindex(h::Hamiltonian, dn::NTuple) = getindex(h, SVector(dn))
     nh === nothing && throw(BoundsError(h, dn))
     return h.harmonics[nh].h
 end
-Base.getindex(h::Hamiltonian, dn::NTuple, i::Vararg{Int}) = h[dn][i...]
+Base.getindex(h::Hamiltonian, dn::Union{NTuple,SVector}, i0, i::Vararg{Int}) = h[dn][i0, i...]
 Base.getindex(h::Hamiltonian{LA, L}, i::Vararg{Int}) where {LA,L} = h[zero(SVector{L,Int})][i...]
 
 Base.deleteat!(h::Hamiltonian{<:Any,L}, dn::Vararg{Int,L}) where {L} =


### PR DESCRIPTION
This completes #140 by adding support for multiple states in current and density shaders. Thanks to @fernandopenaranda for the heads up!

This PR also tries to make CurrentShader more correct in open systems. In doing so I realized we have a serious problem here: we cannot compute currents *across* unit cell boundaries from the Bloch eigenstate alone. We also need its Bloch phases. Solving this issue requires some thought about design (e.g. what information should we store and provide about a generic eigenstate?), so I do not attempt to fix that here. For the moment, therefore, be aware that current density plots is not going to be correct in open systems.

This also introduces a stopgap fix for a problem also reported by @fernandopenaranda:
```
julia> h = LatticePresets.honeycomb() |> hamiltonian(hopping(I)) |> unitcell(10, region = !RP.circle(2, (0,6)));

julia> bs = bandstructure(h, subticks = 13);
Step 1/2 - Diagonalising: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:01
Step 2/2 - Knitting bands: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:02
ERROR: BoundsError: attempt to access 12×12 Array{UnitRange{Int64},2} at index [13, 1]
```
It it not worthwhile to dig deeper into this issue to make a better fix than the one included here, as there is a pending refactor of the bandstructure machinery that will make the corresponding code obsolete