### PR TITLE
Fix combine + curried transform!

### DIFF
--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -479,10 +479,16 @@ maskranges(lat::Superlattice) = (1:nsites(lat), lat.supercell.cells.indices...)
 maskranges(lat::Lattice) = (1:nsites(lat),)
 
 """
+    x |> transform!(f::Function)
+
+Curried version of `transform!`, equivalent to `transform!(f, x)`
+
     transform!(f::Function, lat::Lattice)
 
 Transform the site positions of `lat` by applying `f` to them in place.
 """
+transform!(f::Function) = x -> transform!(f, x)
+
 function transform!(f::Function, lat::Lattice)
     transform!(f, lat.unitcell)
     bravais´ = transform(f, lat.bravais)

--- a/src/model.jl
+++ b/src/model.jl
@@ -155,6 +155,8 @@ Additionally, indices or sublattices can be wrapped in `not` to exclude them (se
 """
 siteselector(; region = missing, sublats = missing, indices = missing) =
     SiteSelector(region, sublats, indices)
+siteselector(s::SiteSelector; region = s.region, sublats = s.sublats, indices = s.indices) =
+    SiteSelector(region, sublats, indices)
 
 """
     hopselector(; range = missing, dn = missing, sublats = missing, indices = missing, region = missing)
@@ -204,6 +206,8 @@ Additionally, indices or sublattices can be wrapped in `not` to exclude them (se
 
 """
 hopselector(; region = missing, sublats = missing, dn = missing, range = missing, indices = missing) =
+    HopSelector(region, sublats, sanitize_dn(dn), sanitize_range(range), indices)
+hopselector(s::HopSelector; region = s.region, sublats = s.sublats, dn = s.dns, range = s.range, indices = s.indices) =
     HopSelector(region, sublats, sanitize_dn(dn), sanitize_range(range), indices)
 
 ensurenametype((s1, s2)::Pair) = nametype(s1) => nametype(s2)
@@ -255,6 +259,7 @@ resolve_sublat_name(s, lat) =
 resolve_sublat_pairs(::Missing, lat) = missing
 resolve_sublat_pairs(n::Not, lat) = Not(resolve_sublat_pairs(n.i, lat))
 resolve_sublat_pairs(s::Tuple, lat) = resolve_sublat_pairs.(s, Ref(lat))
+resolve_sublat_pairs(s::Vector, lat) = resolve_sublat_pairs.(s, Ref(lat))
 resolve_sublat_pairs((src, dst)::Pair, lat) = _resolve_sublat_pairs(src, lat) => _resolve_sublat_pairs(dst, lat)
 _resolve_sublat_pairs(n::Not, lat) = Not(_resolve_sublat_pairs(n.i, lat))
 _resolve_sublat_pairs(p, lat) = resolve_sublat_name.(p, Ref(lat))
@@ -771,11 +776,12 @@ offdiagonal(o::OnsiteTerm, lat, nsublats) =
     throw(ArgumentError("No onsite terms allowed in off-diagonal coupling"))
 
 function offdiagonal(t::HoppingTerm, lat, nsublats)
-    selector´ = resolve(t.selector, lat)
-    s = selector´.sublats
+    rs = resolve(t.selector, lat)
+    s = collect(sublats(rs))
     sr = sublatranges(nsublats...)
-    filter!(spair ->  findblock(first(spair), sr) != findblock(last(spair), sr), s)
-    return HoppingTerm(t.t, selector´, t.coefficient)
+    filter!(spair -> findblock(first(spair), sr) != findblock(last(spair), sr), s)
+    rs´ = ResolvedSelector(hopselector(rs.selector, sublats = s), lat)
+    return HoppingTerm(t.t, rs´, t.coefficient)
 end
 
 sublatranges(i::Int, is::Int...) = _sublatranges((1:i,), is...)

--- a/src/model.jl
+++ b/src/model.jl
@@ -755,9 +755,9 @@ Base.:*(t::TightbindingModelTerm, x::Number) = x * t
 Base.:-(t::TightbindingModelTerm) = (-1) * t
 
 Base.adjoint(t::TightbindingModel) = TightbindingModel(adjoint.(terms(t)))
-Base.adjoint(t::OnsiteTerm{Function}) = OnsiteTerm(r -> t.o(r)', t.selector, t.coefficient')
+Base.adjoint(t::OnsiteTerm{<:Function}) = OnsiteTerm(r -> t.o(r)', t.selector, t.coefficient')
 Base.adjoint(t::OnsiteTerm) = OnsiteTerm(t.o', t.selector, t.coefficient')
-Base.adjoint(t::HoppingTerm{Function}) = HoppingTerm((r, dr) -> t.t(r, -dr)', t.selector', t.coefficient')
+Base.adjoint(t::HoppingTerm{<:Function}) = HoppingTerm((r, dr) -> t.t(r, -dr)', t.selector', t.coefficient')
 Base.adjoint(t::HoppingTerm) = HoppingTerm(t.t', t.selector', t.coefficient')
 
 #######################################################################

--- a/src/presets.jl
+++ b/src/presets.jl
@@ -68,8 +68,8 @@ function twisted_bilayer_graphene(;
         scbot = SA[m+r÷3 -r÷3; r÷3 m+2r÷3] * SA[1 0; -1 1]
         sctop = SA[m+2r÷3 r÷3; -r÷3 m+r÷3] * SA[1 0; -1 1]
     end
-    latbot = lattice(brbot, sAbot, sBbot)
-    lattop = lattice(brtop, sAtop, sBtop)
+    latbot = lattice(sAbot, sBbot; bravais = brbot)
+    lattop = lattice(sAtop, sBtop; bravais = brtop)
     htop = hamiltonian(lattop, modelintra; kw...) |> unitcell(sctop)
     hbot = hamiltonian(latbot, modelintra; kw...) |> unitcell(scbot)
     let R = SA[cos(θ/2) -sin(θ/2) 0; sin(θ/2) cos(θ/2) 0; 0 0 1]

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -472,3 +472,25 @@ end
     @test Quantica.check_orbital_consistency(h´) === nothing
     @test bloch(flatten(h´), phis) ≈ 2.3bloch(flatten(h1), phis)^3 - 2bloch(flatten(h2), phis)*bloch(flatten(h1), phis) - 3I
 end
+
+@testset "transform! hamiltonians" begin
+    h = LP.honeycomb(dim = 3) |> hamiltonian(hopping(1))
+    h1 = copy(h)
+    h2 = transform!(r -> r + SA[0,0,1], h1)
+    h3 = h1 |> transform!(r -> r + SA[0,0,1])
+    @test h1 === h2 === h3
+    @test all(r->r[3] == 2.0, allsitepositions(h3.lattice))
+    @test bloch(h, (1,2)) == bloch(h3, (1,2))
+end
+
+@testset "combine hamiltonians" begin
+    h1 = LP.square(dim = Val(3)) |> hamiltonian(hopping(1))
+    h2 = transform!(r -> r + SA[0,0,1], copy(h1))
+    h = combine(h1, h2; coupling = hopping((r,dr) -> exp(-norm(dr)), range = √2))
+    @test coordination(h) == 9
+    h1 = LP.honeycomb(dim = Val(3), names = (:Ab, :Bb)) |> hamiltonian(hopping(1))
+    h2 = LP.honeycomb(dim = Val(3), names = (:At, :Bt)) |> hamiltonian(hopping(1)) |> transform!(r -> r + SA[0,1/√3,1])
+    h = combine(h1, h2; coupling = hopping((r,dr) -> exp(-norm(dr)), range = 1))
+    @test coordination(h) == 3.5
+
+end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -488,9 +488,12 @@ end
     h2 = transform!(r -> r + SA[0,0,1], copy(h1))
     h = combine(h1, h2; coupling = hopping((r,dr) -> exp(-norm(dr)), range = √2))
     @test coordination(h) == 9
-    h1 = LP.honeycomb(dim = Val(3), names = (:Ab, :Bb)) |> hamiltonian(hopping(1))
-    h2 = LP.honeycomb(dim = Val(3), names = (:At, :Bt)) |> hamiltonian(hopping(1)) |> transform!(r -> r + SA[0,1/√3,1])
-    h = combine(h1, h2; coupling = hopping((r,dr) -> exp(-norm(dr)), range = 1))
-    @test coordination(h) == 3.5
-
+    h0 = LP.honeycomb(dim = Val(3), names = (:A, :B)) |> hamiltonian(hopping(1))
+    ht = LP.honeycomb(dim = Val(3), names = (:At, :Bt)) |> hamiltonian(hopping(1)) |> transform!(r -> r + SA[0,1/√3,1])
+    hb = LP.honeycomb(dim = Val(3), names = (:Ab, :Bb)) |> hamiltonian(hopping(1)) |> transform!(r -> r + SA[0,1/√3,-1])
+    h = combine(hb, h0, ht; coupling = hopping((r,dr) -> exp(-norm(dr)), range = 2,
+        sublats = ((:A,:B) => (:At, :Bt), (:A,:B) => (:Ab, :Bb)),  plusadjoint = true))
+    @test iszero(bloch(h)[1:2, 5:6])
+    h = combine(hb, h0, ht; coupling = hopping((r,dr) -> exp(-norm(dr)), range = 2))
+    @test !iszero(bloch(h)[1:2, 5:6])
 end


### PR DESCRIPTION
The `combine` function was outdated. This updates it to properly make use of `ResolvedSelector`s when applying a `coupling` between combined Hamiltonians.

When writing tests I realized we didn't have the curried version of `transform!`, i.e. `h |> transform!(function)`, so I added that here too. Also corrected a couple of bugs in `HamiltonianPresets.twisted_graphene_bilayer` and `plusadjoint`.