### PR TITLE
Enforce harmonics invariants

### DIFF
--- a/src/tools.jl
+++ b/src/tools.jl
@@ -127,8 +127,6 @@ padright(v, x::T, ::Type{S}) where {E,T,S<:SVector{E,T}} =
 negative(s::SVector{L,<:Number}) where {L} = -s
 negative(s::SVector{0,<:Number}) = s
 
-empty_sparse(::Type{M}, n, m) where {M} = sparse(Int[], Int[], M[], n, m)
-
 display_as_tuple(v, prefix = "") = isempty(v) ? "()" :
     string("(", prefix, join(v, string(", ", prefix)), ")")
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -83,6 +83,9 @@ end
     @test nsites(h´) == nsites(h) - 1
     h = LP.square() |> hamiltonian(hopping(0)) |> unitcell(4, mincoordination = 2)
     @test nsites(h) == 0
+    # check dn=0 invariant
+    h = LP.linear() |> hamiltonian(hopping(1)) |> unitcell((1,))
+    @test length(h.harmonics) == 3 && iszero(first(h.harmonics).dn)
 end
 
 @testset "hamiltonian wrap" begin


### PR DESCRIPTION
This enforces that the first `dn = zero(SVector{L,Int})` harmonic exists in a Hamiltonian. We do this through an inner constructor, that also checks the dimensionality and sorting of all harmonics.

(Before this `h = LP.linear() |> hamiltonian(hopping(1)) |> unitcell((1,))` would end up without a first zero-dn harmonic)