### PR TITLE
Single shot Greens function in 1D

### DIFF
--- a/docs/devdocs/singleshot.md
+++ b/docs/devdocs/singleshot.md
@@ -1,0 +1,80 @@
+# SingleShot1DGreensSolver
+
+Goal: solve the semi-infinite Green's function [g₀⁻¹ -V'GV]G = 1, where GV = ∑ₖφᵢᵏ λᵏ (φ⁻¹)ᵏⱼ.
+It involves solving retarded solutions to
+    [(ωI-H₀)λ - V - V'λ²] φ = 0
+We do a SVD of
+    V = WSU'
+    V' = US'W'
+where U and W are unitary, and S is diagonal with perhaps some zero
+singlular values. We write [φₛ, φᵦ] = U'φ, where the β sector has zero singular values,
+    SPᵦ = 0
+    U' = [Pₛ; Pᵦ]
+    [φₛ; φᵦ] = U'φ = [Pₛφ; Pᵦφ]
+    [Cₛₛ Cₛᵦ; Cᵦₛ Cᵦᵦ] = U'CU for any operator C
+Then
+    [λU'(ωI-H₀)U - U'VU - λ²U'VU] Uφ = 0
+    U'VU = U'WS = [Vₛₛ 0; Vᵦₛ 0]
+    U'V'U= S'W'U= [Vₛₛ' Vᵦₛ; 0 0]
+    U'(ωI-H₀)U = U'(g₀⁻¹)U = [g₀⁻¹ₛₛ g₀⁻¹ₛᵦ; g₀⁻¹ᵦₛ g₀⁻¹ᵦᵦ] = ωI - [H₀ₛₛ H₀ₛᵦ; H₀ᵦₛ H₀ᵦᵦ]
+
+The [λ(ωI-H₀) - V - λ²V'] φ = 0 problem can be solved by defining φχ = [φ,χ] = [φ, λφ] and
+solving eigenpairs A*φχ = λ B*φχ, where
+    A = [0 I; -V g₀⁻¹]
+    B = [I 0; 0 V']
+To eliminate zero or infinite λ, we reduce the problem to the s sector
+    Aₛₛ [φₛ,χₛ] = λ Bₛₛ [φₛ,χₛ]
+    Aₛₛ = [0 I; -Vₛₛ g₀⁻¹ₛₛ] + [0 0; -Σ₁ -Σ₀]
+    Bₛₛ = [I 0; 0 Vₛₛ'] + [0 0; 0 Σ₁']
+where
+    Σ₀ = g₀⁻¹ₛᵦ g₀ᵦᵦ g₀⁻¹ᵦₛ + V'ₛᵦ g₀ᵦᵦ Vᵦₛ = H₀ₛᵦ g₀ᵦᵦ H₀ᵦₛ + Vₛᵦ g₀ᵦᵦ Vᵦₛ
+    Σ₁ = - g₀⁻¹ₛᵦ g₀ᵦᵦ Vᵦₛ = H₀ₛᵦ g₀ᵦᵦ Vᵦₛ
+    g₀⁻¹ₛₛ = ωI - H₀ₛₛ
+    g₀⁻¹ₛᵦ = - H₀ₛᵦ
+Here g₀ᵦᵦ is the inverse of the bulk part of g₀⁻¹, g₀⁻¹ᵦᵦ = ωI - H₀ᵦᵦ. To compute this inverse
+efficiently, we store the Hessenberg factorization `hessbb = hessenberg(-H₀ᵦᵦ)` and use shifts.
+Then, g₀ᵦᵦ H₀ᵦₛ = (hess + ω I) \ H₀ᵦₛ and g₀ᵦᵦ Vᵦₛ = (hess + ω I) \ Vᵦₛ.
+Diagonalizing (Aₛₛ, Bₛₛ) we obtain the surface projection φₛ = Pₛφ of eigenvectors φ. The
+bulk part is
+    φᵦ = g₀ᵦᵦ (λ⁻¹Vᵦₛ - g₀⁻¹ᵦₛ) φₛ = g₀ᵦᵦ(λ⁻¹Vᵦₛ + H₀ᵦₛ) φₛ
+so that the full φ's with non-zero λ read
+    φ = U[φₛ; φᵦ] = [Pₛ' Pᵦ'][φₛ; φᵦ] = [Pₛ' + Pᵦ' g₀ᵦᵦ(λ⁻¹Vᵦₛ + H₀ᵦₛ)] φₛ = Z[λ] φₛ
+    Z[λ] = [Pₛ' + Pᵦ' g₀ᵦᵦ(λ⁻¹Vᵦₛ + H₀ᵦₛ)]
+We can complete the set with the λ=0 solutions, Vφᴿ₀ = 0 and the λ=∞ solutions V'φᴬ₀ = 0.
+Its important to note that U'φᴿ₀ = [0; φ₀ᵦᴿ] and W'φᴬ₀ = [0; φ₀ᵦ´ᴬ]
+
+By computing the velocities vᵢ = im * φᵢ'(V'λᵢ-Vλᵢ')φᵢ / φᵢ'φᵢ = 2*imag(χᵢ'Vφᵢ)/φᵢ'φᵢ we
+classify φ into retarded (|λ|<1 or v > 0) and advanced (|λ|>1 or v < 0). Then
+    φᴿ = Z[λᴿ]φₛᴿ = [φₛᴿ; φᵦᴿ]
+    U'φᴿ = [φₛᴿ; φᵦᴿ]
+    φᴬ = Z[λᴬ]φₛᴬ = [φₛᴬ; φᵦᴬ]
+    Wφᴬ = [φₛ´ᴬ; φᵦ´ᴬ]  (different from [φₛᴬ; φᵦᴬ])
+The square matrix of all retarded and advanced modes read [φᴿ φᴿ₀] and [φᴬ φᴬ₀].
+We now return to the Green's functions. The right and left semiinfinite GrV and GlV' read
+    GrV = [φᴿ φ₀ᴿ][λ 0; 0 0][φᴿ φ₀ᴿ]⁻¹ = φᴿ λ (φₛᴿ)⁻¹Pₛ
+        (used [φᴿ φ₀ᴿ] = U[φₛᴿ 0; φᵦᴿ φᴿ₀ᵦ] => [φᴿ φ₀ᴿ]⁻¹ = [φₛᴿ⁻¹ 0; -φᵦᴿ(φₛᴿ)⁻¹ (φᴿ₀ᵦ)⁻¹]U')
+    GlV´ = [φᴬ φ₀ᴬ][(λᴬ)⁻¹ 0; 0 0][φᴬ φ₀ᴬ]⁻¹ = φᴬ λ (φₛ´ᴬ)⁻¹Pₛ´
+        (used [φᴬ φᴬ₀]⁻¹ = W[φₛ´ᴬ 0; φᵦ´ᴬ φ₀ᵦ´ᴬ] => [φᴬ φ₀ᴬ]⁻¹ = [(φₛ´ᴬ)⁻¹ 0; -φᵦ´ᴬ(φₛ´ᴬ)⁻¹ (φ₀ᵦ´ᴬ)⁻¹]W')
+
+We can then write the local Green function G∞_{0} of the semiinfinite and infinite lead as
+    Gr_{1,1} = Gr = [g₀⁻¹ - V'GrV]⁻¹
+    Gl_{-1,-1} = Gl = [g₀⁻¹ - VGlV']⁻¹
+    G∞_{0} = [g₀⁻¹ - VGlV' - V'GrV]⁻¹
+    (GrV)ᴺ  = φᴿ (λᴿ)ᴺ  (φₛᴿ)⁻¹ Pₛ = χᴿ (λᴿ)ᴺ⁻¹  (φₛᴿ)⁻¹ Pₛ
+    (GlV´)ᴺ = φᴬ (λᴬ)⁻ᴺ (φₛᴬ)⁻¹ Pₛₚ = φᴬ (λᴬ)¹⁻ᴺ(χₛᴬ)⁻¹ Pₛₚ
+    φᴿ = [Pₛ' + Pᵦ' g₀ᵦᵦ ((λᴿ)⁻¹Vᵦₛ + H₀ᵦₛ)]φₛᴿ
+    φᴬ = [Pₛ' + Pᵦ' g₀ᵦᵦ ((λᴬ)Vᵦₛ + H₀ᵦₛ)]φₛᴬ
+where φₛᴿ and φₛᴬ are retarded/advanced eigenstates with eigenvalues λᴿ and λᴬ. Here Pᵦ is
+the projector onto the uncoupled V sites, VPᵦ = 0, Pₛ = 1 - Pᵦ is the surface projector of V
+and Pₛₚ is the surface projector of V'.
+
+Defining
+    GVᴺ = (GrV)ᴺ for N>0 and (GlV´)⁻ᴺ for N<0
+we have
+    Semiinifinite: G_{N,M} = (GVᴺ⁻ᴹ - GVᴺGV⁻ᴹ)G∞_{0}
+    Infinite:      G∞_{N}  = GVᴺ G∞_{0}
+Spelling it out
+    Semiinfinite right  (N,M > 0): G_{N,M} = G∞_(N-M) - (GrV)ᴺ G∞_(-M) = [GVᴺ⁻ᴹ - (GrV)ᴺ (GlV´)ᴹ]G∞_0.
+    At surface (N=M=1), G_{1,1} = Gr = (1- GrVGlV´)G∞_0 = [g₀⁻¹ - V'GrV]⁻¹
+    Semiinfinite left   (N,M < 0): G_{N,M} = G∞_(N-M) - (GlV´)⁻ᴺ G∞_(-M) = [GVᴺ⁻ᴹ - (GlV´)⁻ᴺ(GrV)⁻ᴹ]G∞_0.
+    At surface (N=M=-1), G_{1,1} = Gl = (1- GrVGlV´)G∞_0 = [g₀⁻¹ - VGlV']⁻¹

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -29,7 +29,7 @@ export sublat, bravais, lattice, dims, supercell, unitcell,
        bands, vertices,
        energies, states, degeneracy,
        momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM,
-       greens, greensolver
+       greens, greensolver, SingleShot1D
 
 export RegionPresets, RP, LatticePresets, LP, HamiltonianPresets, HP
 

--- a/src/greens.jl
+++ b/src/greens.jl
@@ -90,7 +90,7 @@ const SVectorPair{L} = Pair{SVector{L,Int},SVector{L,Int}}
 # SingleShot1DGreensSolver
 #######################################################################
 """
-    SingleShot1D(; direct = false)
+    SingleShot1D(; direct = true)
 
 Return a Greens function solver using the generalized eigenvalue approach, whereby given the
 energy `ω`, the eigenmodes of the infinite 1D Hamiltonian, and the corresponding infinite
@@ -111,8 +111,12 @@ imaginary part to `ω`.
 
 To avoid singular solutions `λ=0,∞`, the nullspace of `V` is projected out of the problem.
 Sometimes, however, some linear algebra implementations of the eigensolver can lead to
-incomplete convergence, signaled by a `LAPACKException(n)`. If that happens one can try the
-option `direct = true` that turns the generalized eigenproblem into a standard eigenproblem.
+incomplete convergence, signaled by a `LAPACKException(n)`. This problem does not arise if
+we the generalized eigenproblem into a standard eigenproblem. This is achieved with `direct
+= true`. The performance is also slightly improved. Such approach, however, is not possible
+for some special infinite 1D lattices that have bound states embedded in a continuum even in
+the absence of boundaries. A `SingularExcepcion` error is then thrown. In such cases, try
+`direct = false`.
 
 # Examples
 ```jldoctest
@@ -138,7 +142,7 @@ struct SingleShot1D
     invert_B::Bool
 end
 
-SingleShot1D(; direct = false) = SingleShot1D(direct)
+SingleShot1D(; direct = true) = SingleShot1D(direct)
 
 struct SingleShot1DTemporaries{T}
     b2s::Matrix{T}      # size = dim_b, 2dim_s

--- a/src/greens.jl
+++ b/src/greens.jl
@@ -158,7 +158,7 @@ Base.summary(g::GreensFunction{<:SingleShot1DGreensSolver}) =
 hasbulk(gs::SingleShot1DGreensSolver) = !iszero(size(gs.Pb, 1))
 
 function greensolver(::SingleShot1D, h)
-    latdim(h) == 1 || throw(ArgumentError("Cannot use a SingleShot1D Green function solver with an $L-dimensional Hamiltonian"))
+    latdim(h) == 1 || throw(ArgumentError("Cannot use a SingleShot1D Green function solver with an $(latdim(h))-dimensional Hamiltonian"))
     return SingleShot1DGreensSolver(h)
 end
 

--- a/src/greens.jl
+++ b/src/greens.jl
@@ -202,7 +202,10 @@ function bulk_surface_projectors(H0::AbstractMatrix{T}, V, V´) where {T}
 end
 
 function filter_projectors(V::AbstractMatrix{T}, H0, Pb, Ps) where {T}
-    Σ1´ = Ps * V' * Pb' * pinv(Pb * H0 * Pb') * Pb * H0 * Ps'
+    # Σ1´ = Ps * V' * Pb' * pinv(Pb * H0 * Pb') * Pb * H0 * Ps'
+    PbH0Pb´ = Pb * H0 * Pb'
+    ω0 = one(T) + eigmax(PbH0Pb´)
+    Σ1´ = Ps * V' * Pb' * ldiv!(lu!(ω0*I - PbH0Pb´), Pb * H0 * Ps')
     SVD = svd(Matrix(Σ1´), full = true)
     W, S, U = SVD.U, SVD.S, SVD.V
     dim_b´ = count(s -> iszero(chop(s)), S)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1740,7 +1740,7 @@ bloch!(matrix, h::Hamiltonian, ϕs, axis = 0) = _bloch!(matrix, h, toSVector(ϕs
 bloch!(matrix, h::Hamiltonian, ϕs::Tuple{SVector,NamedTuple}, args...) = bloch!(matrix, h, first(ϕs), args...)
 
 function bloch!(matrix, h::Hamiltonian)
-    _copy!(parent(matrix), first(h.harmonics).h, h) # faster copy!(dense, sparse) specialization
+    _copy!(parent(matrix), first(h.harmonics).h, h.orbstruct) # faster copy!(dense, sparse) specialization
     return matrix
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -66,6 +66,8 @@ sublats(o::OrbitalStructure) = 1:length(o.orbitals)
 
 orbitals(o::OrbitalStructure) = o.orbitals
 
+siterange(o::OrbitalStructure, sublat) = (1+o.offsets[sublat]):o.offsets[sublat+1]
+
 # sublat offsets after flattening (without padding zeros)
 flatoffsets(offsets, norbs) = _flatoffsets((0,), offsets, norbs...)
 _flatoffsets(offsets´::NTuple{N,Any}, offsets, n, ns...) where {N} =
@@ -77,7 +79,7 @@ _flatoffsets(offsets´, offsets) = offsets´
 
 function flatoffsetorbs_site(i, orbstruct)
     s = sublat_site(i, orbstruct)
-    N = length(orbstruct.orbitals[s])
+    N = length(orbitals(orbstruct)[s])
     offset = orbstruct.offsets[s]
     offset´ = orbstruct.flatoffsets[s]
     Δi = i - offset
@@ -194,7 +196,7 @@ _flatten(src::AbstractArray{T}, orbstruct, ::Type{T}) where {T<:Number} = src
 _flatten(src::AbstractArray{T}, orbstruct, ::Type{T´}) where {T<:Number,T´<:Number} = T´.(src)
 
 function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
-    norbs = length.(orbstruct.orbitals)
+    norbs = length.(orbitals(orbstruct))
     offsets´ = orbstruct.flatoffsets
     dim´ = last(offsets´)
 
@@ -220,7 +222,7 @@ function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´}
 end
 
 function _flatten(src::StridedMatrix{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
-    norbs = length.(orbstruct.orbitals)
+    norbs = length.(orbitals(orbstruct))
     offsets´ = orbstruct.flatoffsets
     dim´ = last(offsets´)
     matrix = similar(src, T´, dim´, dim´)
@@ -240,7 +242,7 @@ end
 
 # for Subspace bases
 function _flatten(src::StridedMatrix{<:SVector{N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
-    norbs = length.(orbstruct.orbitals)
+    norbs = length.(orbitals(orbstruct))
     offsets´ = orbstruct.flatoffsets
     dim´ = last(offsets´)
     matrix = similar(src, T´, dim´, size(src, 2))
@@ -258,15 +260,15 @@ function _flatten(src::StridedMatrix{<:SVector{N,T}}, orbstruct, ::Type{T´} = T
 end
 
 function flatten(lat::Lattice, orbstruct)
-    length(orbstruct.orbitals) == nsublats(lat) || throw(ArgumentError("Mismatch between sublattices and orbitals"))
-    unitcell´ = flatten(lat.unitcell, orbstruct) #length.(orbstruct.orbitals))
+    length(orbitals(orbstruct)) == nsublats(lat) || throw(ArgumentError("Mismatch between sublattices and orbitals"))
+    unitcell´ = flatten(lat.unitcell, orbstruct)
     bravais´ = lat.bravais
     lat´ = Lattice(bravais´, unitcell´)
 end
 
 function flatten(unitcell::Unitcell, orbstruct) # orbs::NTuple{S,Any}) where {S}
-    norbs = length.(orbstruct.orbitals)
-    nsublats = length(orbstruct.orbitals)
+    norbs = length.(orbitals(orbstruct))
+    nsublats = length(sublats(orbstruct))
     offsets´ = orbstruct.flatoffsets
     ns´ = last(offsets´)
     sites´ = similar(unitcell.sites, ns´)
@@ -280,17 +282,17 @@ function flatten(unitcell::Unitcell, orbstruct) # orbs::NTuple{S,Any}) where {S}
     return unitcell´
 end
 
-function flatten_sparse_copy!(dst, src, h)
+function flatten_sparse_copy!(dst, src, o::OrbitalStructure)
     fill!(dst, zero(eltype(dst)))
-    norbs = length.(orbitals(h))
+    norbs = length.(orbitals(o))
     coloffset = 0
-    for s´ in sublats(h.lattice)
+    for s´ in sublats(o)
         N´ = norbs[s´]
-        for col in siterange(h.lattice, s´)
+        for col in siterange(o, s´)
             for p in nzrange(src, col)
                 val = nonzeros(src)[p]
                 row = rowvals(src)[p]
-                rowoffset, M´ = flatoffsetorbs_site(row, h.orbstruct)
+                rowoffset, M´ = flatoffsetorbs_site(row, o)
                 for j in 1:N´, i in 1:M´
                     dst[i + rowoffset, j + coloffset] = val[i, j]
                 end
@@ -301,16 +303,16 @@ function flatten_sparse_copy!(dst, src, h)
     return dst
 end
 
-function flatten_sparse_muladd!(dst, src, h, α = I)
-    norbs = length.(orbitals(h))
+function flatten_sparse_muladd!(dst, src, o::OrbitalStructure, α = I)
+    norbs = length.(orbitals(o))
     coloffset = 0
-    for s´ in sublats(h.lattice)
+    for s´ in sublats(o)
         N´ = norbs[s´]
-        for col in siterange(h.lattice, s´)
+        for col in siterange(o, s´)
             for p in nzrange(src, col)
                 val = α * nonzeros(src)[p]
                 row = rowvals(src)[p]
-                rowoffset, M´ = flatoffsetorbs_site(row, h.orbstruct)
+                rowoffset, M´ = flatoffsetorbs_site(row, o)
                 for j in 1:N´, i in 1:M´
                     dst[i + rowoffset, j + coloffset] += val[i, j]
                 end
@@ -321,16 +323,16 @@ function flatten_sparse_muladd!(dst, src, h, α = I)
     return dst
 end
 
-function flatten_dense_muladd!(dst, src, h, α = I)
-    norbs = length.(orbitals(h))
+function flatten_dense_muladd!(dst, src, o::OrbitalStructure, α = I)
+    norbs = length.(orbitals(o))
     coloffset = 0
-    for s´ in sublats(h.lattice)
+    for s´ in sublats(o)
         N´ = norbs[s´]
-        for col in siterange(h.lattice, s´)
+        for col in siterange(o, s´)
             rowoffset = 0
-            for s in sublats(h.lattice)
+            for s in sublats(o)
                 M´ = norbs[s]
-                for row in siterange(h.lattice, s)
+                for row in siterange(o, s)
                     val = α * src[row, col]
                     for j in 1:N´, i in 1:M´
                         dst[i + rowoffset, j + coloffset] += val[i, j]
@@ -344,9 +346,9 @@ function flatten_dense_muladd!(dst, src, h, α = I)
     return dst
 end
 
-function flatten_dense_copy!(dst, src, h)
+function flatten_dense_copy!(dst, src, o::OrbitalStructure)
     fill!(dst, zero(eltype(dst)))
-    return flatten_dense_muladd!(dst, src, h, I)
+    return flatten_dense_muladd!(dst, src, o, I)
 end
 
 ## unflatten ##
@@ -391,7 +393,7 @@ unflatten(vflat::AbstractMatrix, o::OrbitalStructure{T}) where {T} =
     unflatten!(similar(vflat, T, dimh(o), size(vflat, 2)), vflat, o)
 
 function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, o::OrbitalStructure) where {T}
-    norbs = length.(o.orbitals)
+    norbs = length.(orbitals(o))
     flatoffsets = o.flatoffsets
     dimflat = last(flatoffsets)
     check_unflatten_dst_dims(v, dimh(o))
@@ -1740,7 +1742,7 @@ end
 function _bloch!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,L,M}, ϕs::SVector{L}, axis::Number) where {L,M}
     rawmatrix = parent(matrix)
     if iszero(axis)
-        _copy!(rawmatrix, first(h.harmonics).h, h) # faster copy!(dense, sparse) specialization
+        _copy!(rawmatrix, first(h.harmonics).h, h.orbstruct) # faster copy!(dense, sparse) specialization
         add_harmonics!(rawmatrix, h, ϕs, dn -> 1)
     else
         fill!(rawmatrix, zero(M)) # There is no guarantee of same structure
@@ -1755,7 +1757,7 @@ function _bloch!(matrix::AbstractMatrix, h::Hamiltonian{<:Lattice,L,M}, ϕs::SVe
     if iszero(prefactor0)
         fill!(rawmatrix, zero(eltype(rawmatrix)))
     else
-        _copy!(rawmatrix, first(h.harmonics).h, h)
+        _copy!(rawmatrix, first(h.harmonics).h, h.orbstruct)
         rmul!(rawmatrix, prefactor0)
     end
     add_harmonics!(rawmatrix, h, ϕs, dnfunc)
@@ -1774,24 +1776,24 @@ function add_harmonics!(zerobloch, h::Hamiltonian{<:Lattice,L}, ϕs::SVector{L},
         prefactor = dnfunc(hh.dn)
         iszero(prefactor) && continue
         ephi = prefactor * cis(-ϕs´ * hh.dn)
-        _add!(zerobloch, hhmatrix, h, ephi)
+        _add!(zerobloch, hhmatrix, h.orbstruct, ephi)
     end
     return zerobloch
 end
 
 ############################################################################################
-######## _copy! and _add! call specialized methods in tools.jl #############################
+######## _copy! and _add! call specialized methods #########################################
 ############################################################################################
 
 _copy!(dest, src, h) = copy!(dest, src)
-_copy!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, h) = _fast_sparse_copy!(dst, src)
-_copy!(dst::StridedMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, h) = _fast_sparse_copy!(dst, src)
-_copy!(dst::StridedMatrix{<:SMatrix{N,N}}, src::SparseMatrixCSC{<:SMatrix{N,N}}, h) where {N} = _fast_sparse_copy!(dst, src)
-_copy!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:SMatrix}, h) = flatten_sparse_copy!(dst, src, h)
-_copy!(dst::StridedMatrix{<:Number}, src::StridedMatrix{<:SMatrix}, h) = flatten_dense_copy!(dst, src, h)
+_copy!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, o) = _fast_sparse_copy!(dst, src)
+_copy!(dst::StridedMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, o) = _fast_sparse_copy!(dst, src)
+_copy!(dst::StridedMatrix{<:SMatrix{N,N}}, src::SparseMatrixCSC{<:SMatrix{N,N}}, o) where {N} = _fast_sparse_copy!(dst, src)
+_copy!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:SMatrix}, o) = flatten_sparse_copy!(dst, src, o)
+_copy!(dst::StridedMatrix{<:Number}, src::StridedMatrix{<:SMatrix}, o) = flatten_dense_copy!(dst, src, o)
 
-_add!(dest, src, h, α) = _plain_muladd!(dest, src, α)
-_add!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, h, α = 1) = _fast_sparse_muladd!(dst, src, α)
-_add!(dst::AbstractMatrix{<:SMatrix{N,N}}, src::SparseMatrixCSC{<:SMatrix{N,N}}, h, α = I) where {N} = _fast_sparse_muladd!(dst, src, α)
-_add!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:SMatrix}, h, α = I) = flatten_sparse_muladd!(dst, src, h, α)
-_add!(dst::StridedMatrix{<:Number}, src::StridedMatrix{<:SMatrix}, h, α = I) = flatten_dense_muladd!(dst, src, h, α)
+_add!(dest, src, o, α) = _plain_muladd!(dest, src, α)
+_add!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:Number}, o, α = 1) = _fast_sparse_muladd!(dst, src, α)
+_add!(dst::AbstractMatrix{<:SMatrix{N,N}}, src::SparseMatrixCSC{<:SMatrix{N,N}}, o, α = I) where {N} = _fast_sparse_muladd!(dst, src, α)
+_add!(dst::AbstractMatrix{<:Number}, src::SparseMatrixCSC{<:SMatrix}, o, α = I) = flatten_sparse_muladd!(dst, src, o, α)
+_add!(dst::StridedMatrix{<:Number}, src::StridedMatrix{<:SMatrix}, o, α = I) = flatten_dense_muladd!(dst, src, o, α)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -370,8 +370,8 @@ struct Runs{T,F}
     istogether::F
 end
 
-approxruns(xs::Vector{T}) where {T<:Number} = Runs(xs, (x, y) -> isapprox(x, y; atol = sqrt(eps(real(T)))))
 equalruns(xs) = Runs(xs, ==)
+approxruns(xs::Vector{T}) where {T<:Number} = Runs(xs, (x, y) -> isapprox(x, y; atol = sqrt(eps(real(T)))))
 
 function last_in_run(xs::Vector{T}, i, istogether) where {T}
     xi = xs[i]

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -299,9 +299,8 @@ needslegend(x::Number) = nothing
 needslegend(x) = true
 
 unflatten_or_reinterpret_or_missing(psi::Missing, h) = missing
-unflatten_or_reinterpret_or_missing(psi::AbstractArray, h) = unflatten_or_reinterpret(psi, h)
-
-unflatten_or_reinterpret_or_missing(s::Subspace, h) = unflatten_or_reinterpret(s.basis, h)
+unflatten_or_reinterpret_or_missing(psi::AbstractArray, h) = unflatten_or_reinterpret(psi, h.orbstruct)
+unflatten_or_reinterpret_or_missing(s::Subspace, h) = unflatten_or_reinterpret(s.basis, h.orbstruct)
 
 checkdims_psi(h, psi) = size(h, 2) == size(psi, 1) ||
     throw(ArgumentError("The eigenstate length $(size(psi,1)) must match the Hamiltonian dimension $(size(h, 2))"))

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -135,6 +135,8 @@ displayvectors(mat::SMatrix{E,L,<:AbstractFloat}; kw...) where {E,L} =
 displayvectors(mat::SMatrix{E,L,<:Integer}; kw...) where {E,L} =
     ntuple(l -> Tuple(mat[:,l]), Val(L))
 
+chop(x::T) where {T} = ifelse(abs2(x) < eps(real(T)), zero(T), x)
+
 # pseudoinverse of supercell s times an integer n, so that it is an integer matrix (for accuracy)
 pinvmultiple(s::SMatrix{L,0}) where {L} = (SMatrix{0,0,Int}(), 0)
 function pinvmultiple(s::SMatrix{L,L´}) where {L,L´}

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -157,6 +157,8 @@ function pinverse(m::SMatrix)
     return inv(qrm.R) * qrm.Q'
 end
 
+issquare(a::AbstractMatrix) = size(a, 1) == size(a, 2)
+
 # normalize_axis_directions(q::SMatrix{M,N}) where {M,N} = hcat(ntuple(i->q[:,i]*sign(q[i,i]), Val(N))...)
 
 padprojector(::Type{S}, ::Val{N}) where {M,N,S<:SMatrix{M,M}} = S(Diagonal(SVector(padright(filltuple(1, Val(N)), Val(M)))))

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -1,9 +1,44 @@
 using LinearAlgebra: tr
 
-@testset "basic green's function" begin
+@testset "basic greens function" begin
     g = LatticePresets.square() |> hamiltonian(hopping(-1)) |> unitcell((2,0), (0,1)) |>
         greens(bandstructure(resolution = 17))
     @test g(0.2) ≈ transpose(g(0.2))
     @test imag(tr(g(1))) < 0
     @test Quantica.chop(imag(tr(g(5)))) == 0
 end
+
+@testset "greens functions spectra" begin
+    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+    g = greens(h, SingleShot1D())
+    @test_throws ArgumentError g(0)
+    dos = [-imag(tr(g(w + 1.0e-6im))) for w in range(-3.2, 3.2, length = 1001)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
+
+    h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+    g = greens(h, SingleShot1D())
+    dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 1001)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
+
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(3,3)) |> wrap(2)
+    g = greens(h, SingleShot1D())
+    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 1001)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
+
+    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((2,-2),(3,3)) |> unitcell(1, 1, indices = not(1)) |> wrap(2)
+    g = greens(h, SingleShot1D())
+    @test_broken imag(tr(g(0.2))) < 0
+    g = greens(h, SingleShot1D(direct = false))
+    @test imag(tr(g(0.2))) < 0
+    dos = [-imag(tr(g(w + 1.0e-6im))) for w in range(-3.2, 3.2, length = 1001)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
+end
+
+@testset "greens functions spatial" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(3,3)) |> unitcell((1,0))
+    g = greens(h, SingleShot1D(), boundaries = (0,))
+    g0 = g(0.01, missing)
+    ldos = [-imag(tr(g0(n=>n))) for n in 1:200]
+    @test all(x -> Quantica.chop(x) >= 0, ldos)
+end
+


### PR DESCRIPTION
We add a new solver for the Greens function of quasi-1D Hamiltonians based on the generalized eigenvalue algorithm. 

Advantages:
- It can compute the Greens function at a fixed ω without solving all ω
- Once `g(ω, cells)` is computed for some `cells = src => dst`, any other `cells` is easy to compute.  

Disadvantages:
- It only works in 1D
- It does not exploit the sparsity of the Bloch Hamiltonian, so it scales badly with system width.

Example for the DOS of an infinite carbon nanotube
```
julia> using Plots, ProgressMeter, LinearAlgebra, Quantica

julia> h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(30,30)) |> Quantica.wrap(2)
Hamiltonian{<:Lattice} : Hamiltonian on a 1D Lattice in 2D space
  Bloch harmonics  : 3 (SparseMatrixCSC, sparse)
  Harmonic size    : 120 × 120
  Orbitals         : ((:a,), (:a,))
  Element type     : scalar (ComplexF64)
  Onsites          : 0
  Hoppings         : 360
  Coordination     : 3.0

julia> g = greens(h, Quantica.SingleShot1D())
GreensFunction{SingleShot1DGreensSolver}: Green's function using the single-shot 1D method
  Matrix size    : 120 × 120
  Element type   : scalar (ComplexF64)
  Boundaries     : (missing,)
  Reduced dims   : 60

julia> dos = @showprogress [(w, -imag(tr(g(w)))) for w in range(-3.5,3.5,length = 1001)];
Progress: 100%|████████████████████████████████████████| Time: 0:00:22

julia> plot(dos)
```

![image](https://user-images.githubusercontent.com/4310809/104630954-cfbb2480-569b-11eb-8176-5d4b05076515.png)

Example for the DOS at edge of semi-infinite nanotube
```
julia> g = greens(h, Quantica.SingleShot1D(), boundaries = (0,))
GreensFunction{SingleShot1DGreensSolver}: Green's function using the single-shot 1D method
  Matrix size    : 120 × 120
  Element type   : scalar (ComplexF64)
  Boundaries     : (0,)
  Reduced dims   : 60

julia> dos = @showprogress [(w, -imag(tr(g(w, 1=>1)))) for w in range(-3.5,3.5,length = 1001)];
Progress: 100%|████████████████████████████████████████| Time: 0:00:22
```
![image](https://user-images.githubusercontent.com/4310809/104631602-c2eb0080-569c-11eb-956e-8c512a65b4ba.png)

The same 10 cells away from the edge
```
julia> dos = @showprogress [(w, -imag(tr(g(w, 10=>10)))) for w in range(-3.5,3.5,length = 1001)];
Progress: 100%|████████████████████████████████████████| Time: 0:00:22
```

![image](https://user-images.githubusercontent.com/4310809/104631742-f7f75300-569c-11eb-8bf9-e5b268af475e.png)

Efficiently computing the DOS at ω = 0.01 as a function of distance to the edge by precomputing a closure `g0` at said ω (see docstring)
```
julia> g0 = g(0.01, missing)
#391 (generic function with 1 method)

julia> dos = @showprogress [(n, -imag(tr(g0(n=>n)))) for n in 1:1000];
Progress: 100%|████████████████████████████████████████| Time: 0:00:01
```

![image](https://user-images.githubusercontent.com/4310809/104632270-bc10bd80-569d-11eb-8d2d-c570e8028dd5.png)

