### PR TITLE
Green function fix: B22 = -A12' is not really correct

### DIFF
--- a/src/greens.jl
+++ b/src/greens.jl
@@ -348,8 +348,14 @@ function single_shot_surface_matrices(gs::SingleShot1DGreensSolver{T}, ω) where
         mul!(A21, gs.H0bs', tmp, -1, 1)
     end
 
-    # B22 = -A21'
-    B22 .= .- A21'
+    # B22 = Vₛₛ + Vᵦₛ' g₀ᵦᵦ H₀ᵦₛ
+    B22 .= gs.Vss
+    if hasbulk(gs)
+        copy!(tmp, gs.H0bs)
+        ldiv!(gs.hessbb + ω*I, tmp)
+        mul!(B22, gs.Vbs', tmp, 1, 1)
+    end
+    # B22 .= .- A21'
 
     chkfinite(A)
     chkfinite(B)


### PR DESCRIPTION
This builds the 22 block of B in the SingleShot1D algorithm in a different way, as it is not strictly true that B22 = -A12' (when  ω is complex)