### PR TITLE
Update to work with GLMakie

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -6,7 +6,7 @@ module Quantica
 using Requires
 
 function __init__()
-      @require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("plot_makie.jl")
+      @require GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a" include("plot_makie.jl")
       @require VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a" include("plot_vegalite.jl")
 end
 

--- a/src/plot_makie.jl
+++ b/src/plot_makie.jl
@@ -1,9 +1,9 @@
 using GeometryBasics
-using .Makie: AbstractPlotting
-using .Makie.AbstractPlotting: to_value, RGBAf0, Vec3f0, FRect, @recipe, LineSegments, Theme,
+using .GLMakie: AbstractPlotting
+using .GLMakie.AbstractPlotting: to_value, RGBAf0, Vec3f0, FRect, @recipe, LineSegments, Theme,
     lift, campixel, SceneSpace, Node, Axis, text!, on, mouse_selection, poly!, scale!,
     translate!, linesegments!, mesh!, scatter!, meshscatter!
-import .Makie.AbstractPlotting: plot!, plot
+import .GLMakie.AbstractPlotting: plot!, plot
 
 """
     plot(h::Hamiltonian)
@@ -61,14 +61,14 @@ end
 # plot(::Hamiltonian)
 #######################################################################
 function plot(h::Hamiltonian{<:Lattice}; resolution = (1000, 1000), kw...)
-    scene = hamiltonianplot(h; resolution = resolution, scale_plot = false, kw...)
-    plot = scene[end]
-    plot[:tooltips][] && addtooltips!(scene, h)
-    scale!(scene)
-    return scene
+    figaxisplot = hamiltonianplot(h; resolution = resolution, scale_plot = false, kw...)
+    _, axis, plot = figaxisplot
+    plot[:tooltips][] && addtooltips!(axis.scene, h)
+    scale!(axis.scene)
+    return figaxisplot
 end
 
-@recipe(HamiltonianPlot, hamiltonian) do scene
+@recipe(HamiltonianPlot) do scene
     Theme(
         allintra = false, allcells = true, showsites = true, showlinks = true,
         shadedsites = false, shadedlinks = false, dimming = 0.75,
@@ -204,11 +204,10 @@ function addtooltips!(scene, h)
         Vec3f0((mp .+ 5 .+ (0, -50))..., 0)
     end
     popup = poly!(campixel(scene), poprect, raw = true, color = RGBAf0(1,1,1,0), visible = visible)
-    rect = popup[end]
     translate!(popup, Vec3f0(0, 0, 10000))
     text!(popup, " ", textsize = 30, position = textpos, align = (:center, :center),
         color = :black, strokewidth = 4, strokecolor = :white, raw = true, visible = visible)
-    text_field = popup[end]
+    text_field = popup.plots[end]
     on(scene.events.mouseposition) do event
         subplot, idx = mouse_selection(scene)
         layer = findfirst(isequal(subplot), sceneplot.plots)


### PR DESCRIPTION
Makie is getting deprecated in favor of backend-specific packages. 

This replaces the Makie functionality with GLMakie functionality. For the end user all should remain the same, but instead of doing
```
] add Makie
using Makie
plot(ham)
```
one should now do
```
] add GLMakie
using GLMakie
plot(ham)
```