### PR TITLE
Deflating Schur algorithm for quasi1D Green functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
 ExprTools = "^0.1"
@@ -26,7 +26,6 @@ NearestNeighbors = "0.4"
 OffsetArrays = "1.0"
 ProgressMeter = "1.2"
 Requires = "1.0"
-SpecialFunctions = "0.10, 1.0"
 StaticArrays = "0.12.3, 0.13, 1.0"
 julia = "1.5"
 

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -11,7 +11,7 @@ function __init__()
 end
 
 using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
-      ProgressMeter, LinearMaps, Random, SpecialFunctions
+      ProgressMeter, LinearMaps, Random, SuiteSparse
 
 using ExprTools
 
@@ -29,7 +29,7 @@ export sublat, bravais, lattice, dims, supercell, unitcell,
        bands, vertices,
        energies, states, degeneracy,
        momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM,
-       greens, greensolver, SingleShot1D
+       greens, greensolver, Schur1D
 
 export RegionPresets, RP, LatticePresets, LP, HamiltonianPresets, HP
 

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -11,7 +11,7 @@ Subspace(h::Hamiltonian, args...) = Subspace(h.orbstruct, args...)
 Subspace(::Missing, energy, basis, basevert...) =
     Subspace(OrbitalStructure(eltype(basis), size(basis, 1)), energy, basis, basevert...)
 Subspace(o::OrbitalStructure, energy, basis, basevert...) =
-    Subspace(energy, unflatten_or_reinterpret(basis, o), o, basevert...)
+    Subspace(energy, unflatten_orbitals_or_reinterpret(basis, o), o, basevert...)
 Subspace(energy::T, basis, orbstruct) where {T} = Subspace(energy, basis, orbstruct, SVector{0,T}())
 Subspace(energy::T, basis, orbstruct, basevert) where {T} = Subspace(energy, basis, orbstruct, SVector(T.(basevert)))
 
@@ -38,9 +38,10 @@ degeneracy(m::AbstractMatrix) = isempty(m) ? 1 : size(m, 2)  # To support sentin
 
 orbitalstructure(s::Subspace) = s.orbstruct
 
-flatten(s::Subspace) = Subspace(s.energy, _flatten(s.basis, s.orbstruct), s.orbstruct, s.basevert)
+flatten(s::Subspace) =
+    Subspace(s.energy, flatten(s.basis, s.orbstruct), s.orbstruct, s.basevert)
 
-unflatten(s::Subspace, o::OrbitalStructure) = Subspace(s.energy, unflatten(s.basis, o), o, s.basevert)
+unflatten(s::Subspace, o::OrbitalStructure) = Subspace(s.energy, unflatten_orbitals(s.basis, o), o, s.basevert)
 
 # destructuring
 Base.iterate(s::Subspace) = s.energy, Val(:basis)
@@ -50,6 +51,8 @@ Base.IteratorSize(::Subspace) = Base.HasLength()
 Base.first(s::Subspace) = s.energy
 Base.last(s::Subspace) = s.basis
 Base.length(s::Subspace) = 2
+
+Base.copy(s::Subspace) = deepcopy(s)
 
 #######################################################################
 # Spectrum

--- a/src/diagonalizer.jl
+++ b/src/diagonalizer.jl
@@ -77,7 +77,7 @@ end
 
 function (d::Diagonalizer)(φs)
     ϵ, ψ = d(φs, NoUnflatten())
-    ψ´ = unflatten_or_reinterpret(ψ, d.orbstruct)
+    ψ´ = unflatten_orbitals_or_reinterpret(ψ, d.orbstruct)
     return ϵ, ψ´
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -154,6 +154,11 @@ Rebuild `s` by flattening its basis to have a scalar eltype.
 Curried form equivalent to `flatten(h)` of `h |> flatten` (included for consistency with
 the rest of the API).
 
+    flatten(x, o::OrbitalStructure)
+
+Flatten object x, if applicable, using the orbital structure o, as obtained from a
+Hamiltonian `h` with `orbitalstructure(h)`
+
 # Examples
 
 ```jldoctest
@@ -186,21 +191,49 @@ Hamiltonian{<:Lattice} : Hamiltonian on a 2D Lattice in 2D space
 flatten() = h -> flatten(h)
 
 function flatten(h::Hamiltonian)
-    all(isequal(1), norbitals(h)) && return copy(h)
+    isflat(h) && return copy(h)
     harmonics´ = [flatten(har, h.orbstruct) for har in h.harmonics]
     lattice´ = flatten(h.lattice, h.orbstruct)
     orbs´ = (_ -> (:flat, )).(orbitals(h))
     return Hamiltonian(lattice´, harmonics´, orbs´)
 end
 
+# special method: if already flat, don't make a copy
+maybeflatten(h, args...) = isflat(h) ? h : flatten(h, args...)
+
+isflat(h::Hamiltonian) = all(isequal(1), norbitals(h))
+
 flatten(h::HamiltonianHarmonic, orbstruct) =
-    HamiltonianHarmonic(h.dn, _flatten(h.h, orbstruct))
+    HamiltonianHarmonic(h.dn, flatten(h.h, orbstruct))
 
-_flatten(src::AbstractArray{<:Number}, orbstruct) = src
-_flatten(src::AbstractArray{T}, orbstruct, ::Type{T}) where {T<:Number} = src
-_flatten(src::AbstractArray{T}, orbstruct, ::Type{T´}) where {T<:Number,T´<:Number} = T´.(src)
+function flatten(lat::Lattice, orbstruct)
+    length(orbitals(orbstruct)) == nsublats(lat) || throw(ArgumentError("Mismatch between sublattices and orbitals"))
+    unitcell´ = flatten(lat.unitcell, orbstruct)
+    bravais´ = lat.bravais
+    lat´ = Lattice(bravais´, unitcell´)
+end
 
-function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
+function flatten(unitcell::Unitcell, orbstruct) # orbs::NTuple{S,Any}) where {S}
+    norbs = length.(orbitals(orbstruct))
+    nsublats = length(sublats(orbstruct))
+    offsets´ = orbstruct.flatoffsets
+    ns´ = last(offsets´)
+    sites´ = similar(unitcell.sites, ns´)
+    i = 1
+    for sl in 1:nsublats, site in sitepositions(unitcell, sl), rep in 1:norbs[sl]
+        sites´[i] = site
+        i += 1
+    end
+    names´ = unitcell.names
+    unitcell´ = Unitcell(sites´, names´, offsets´)
+    return unitcell´
+end
+
+flatten(src::AbstractArray{<:Number}, orbstruct) = src
+flatten(src::AbstractArray{T}, orbstruct, ::Type{T}) where {T<:Number} = src
+flatten(src::AbstractArray{T}, orbstruct, ::Type{T´}) where {T<:Number,T´<:Number} = T´.(src)
+
+function flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
     norbs = length.(orbitals(orbstruct))
     offsets´ = orbstruct.flatoffsets
     dim´ = last(offsets´)
@@ -226,7 +259,7 @@ function _flatten(src::SparseMatrixCSC{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´}
     return matrix
 end
 
-function _flatten(src::StridedMatrix{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
+function flatten(src::StridedMatrix{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
     norbs = length.(orbitals(orbstruct))
     offsets´ = orbstruct.flatoffsets
     dim´ = last(offsets´)
@@ -246,7 +279,7 @@ function _flatten(src::StridedMatrix{<:SMatrix{N,N,T}}, orbstruct, ::Type{T´} =
 end
 
 # for Subspace bases
-function _flatten(src::StridedMatrix{<:SVector{N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
+function flatten(src::StridedMatrix{<:SVector{N,T}}, orbstruct, ::Type{T´} = T) where {N,T,T´}
     norbs = length.(orbitals(orbstruct))
     offsets´ = orbstruct.flatoffsets
     dim´ = last(offsets´)
@@ -262,29 +295,6 @@ function _flatten(src::StridedMatrix{<:SVector{N,T}}, orbstruct, ::Type{T´} = T
         end
     end
     return matrix
-end
-
-function flatten(lat::Lattice, orbstruct)
-    length(orbitals(orbstruct)) == nsublats(lat) || throw(ArgumentError("Mismatch between sublattices and orbitals"))
-    unitcell´ = flatten(lat.unitcell, orbstruct)
-    bravais´ = lat.bravais
-    lat´ = Lattice(bravais´, unitcell´)
-end
-
-function flatten(unitcell::Unitcell, orbstruct) # orbs::NTuple{S,Any}) where {S}
-    norbs = length.(orbitals(orbstruct))
-    nsublats = length(sublats(orbstruct))
-    offsets´ = orbstruct.flatoffsets
-    ns´ = last(offsets´)
-    sites´ = similar(unitcell.sites, ns´)
-    i = 1
-    for sl in 1:nsublats, site in sitepositions(unitcell, sl), rep in 1:norbs[sl]
-        sites´[i] = site
-        i += 1
-    end
-    names´ = unitcell.names
-    unitcell´ = Unitcell(sites´, names´, offsets´)
-    return unitcell´
 end
 
 function flatten_sparse_copy!(dst, src, o::OrbitalStructure)
@@ -308,6 +318,7 @@ function flatten_sparse_copy!(dst, src, o::OrbitalStructure)
     return dst
 end
 
+# Specialized flattening copy! and muladd!
 function flatten_sparse_muladd!(dst, src, o::OrbitalStructure, α = I)
     norbs = length.(orbitals(o))
     coloffset = 0
@@ -358,10 +369,9 @@ end
 
 ## unflatten ##
 """
-    unflatten(v::AbstractArray, o::OrbitalStructure{T})
+    unflatten(x, o::OrbitalStructure)
 
-Rebuild `v` to have element type `T` and orbital structure `o` by performing the inverse of
-`flatten(v)`.
+Rebuild object `x` performing the inverse of `flatten(x)` or `flatten(x, o)`.
 
 # Examples
 ```jldoctest
@@ -392,10 +402,22 @@ Subspace{0}: eigenenergy subspace on a 0D manifold
 # See also
     `flatten`, `orbitalstructure`
 """
-unflatten(vflat::AbstractVector, o::OrbitalStructure{T}) where {T} =
-    unflatten!(similar(vflat, T, dimh(o)), vflat, o)
-unflatten(vflat::AbstractMatrix, o::OrbitalStructure{T}) where {T} =
-    unflatten!(similar(vflat, T, dimh(o), size(vflat, 2)), vflat, o)
+unflatten
+
+# Pending implementation for Hamiltonian, Lattice, Unitcell
+
+unflatten_orbitals(v::AbstractVector, o::OrbitalStructure) =
+    isunflat_orbitals(v, o) ? copy(v) : unflatten!(similar(v, orbitaltype(o), dimh(o)), v, o)
+unflatten_orbitals(m::AbstractMatrix, o::OrbitalStructure) =
+    isunflat_orbitals(m, o) ? copy(m) : unflatten!(similar(m, orbitaltype(o), dimh(o), size(m, 2)), m, o)
+unflatten_blocks(m::AbstractMatrix, o::OrbitalStructure) =
+    isunflat_blocks(m, o) ? copy(m) : unflatten!(similar(m, blocktype(o), dimh(o), dimh(o)), m, o)
+
+maybeunflatten_orbitals(x, o) = isunflat_orbitals(x, o) ? x : unflatten_orbitals(x, o)
+maybeunflatten_blocks(x, o) = isunflat_blocks(x, o) ? x : unflatten_blocks(x, o)
+
+isunflat_orbitals(m, o) = orbitaltype(o) == eltype(m) && size(m, 1) == dimh(o)
+isunflat_blocks(m, o) = blocktype(o) == eltype(m) && size(m, 1) == dimh(o)
 
 function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, o::OrbitalStructure) where {T}
     norbs = length.(orbitals(o))
@@ -404,51 +426,68 @@ function unflatten!(v::AbstractArray{T}, vflat::AbstractArray, o::OrbitalStructu
     check_unflatten_dst_dims(v, dimh(o))
     check_unflatten_src_dims(vflat, dimflat)
     check_unflatten_eltypes(v, o)
-    for col in 1:size(v, 2)
-        row = 0
-        for s in sublats(o)
-            N = norbs[s]
-            for i in flatoffsets[s]+1:N:flatoffsets[s+1]
-                row += 1
-                v[row, col] = padright(view(vflat, i:i+N-1, col:col), T)
+    col = 0
+    for scol in sublats(o)
+        M = colstride(norbs, scol, T)
+        for j in flatoffsets[scol]+1:M:flatoffsets[scol+1]
+            col +=1
+            row = 0
+            for srow in sublats(o)
+                N = rowstride(norbs, srow)
+                for i in flatoffsets[srow]+1:N:flatoffsets[srow+1]
+                    row += 1
+                    val = view(vflat, i:i+N-1, j:j+M-1)
+                    v[row, col] = padtotype(val, T)
+                end
             end
         end
     end
     return v
 end
 
-## unflatten_or_reinterpret: call unflatten but only if we cannot unflatten via reinterpret
-unflatten_or_reinterpret(vflat, ::Missing) = vflat
+rowstride(norbs, s) = norbs[s]
+colstride(norbs, s, ::Type{<:SVector}) = 1
+colstride(norbs, s, ::Type{<:SMatrix}) = rowstride(norbs, s)
+
+# dest v should be a vector or matrix such that H*v is possible
+check_unflatten_dst_dims(v, dimh) =
+    size(v, 1) == dimh ||
+        throw(ArgumentError("Dimension of destination array is inconsistent with orbital structure"))
+
+# dest v should be a square matrix like the Hamiltonian
+check_unflatten_dst_dims(v::AbstractArray{<:SMatrix}, dimh) =
+    size(v, 1) == dimh && size(v, 2) == dimh ||
+        throw(ArgumentError("Dimension of destination array is inconsistent with orbital structure"))
+
+check_unflatten_src_dims(vflat, dimflat) =
+    size(vflat, 1) == dimflat ||
+        throw(ArgumentError("Dimension of source array is inconsistent with orbital structure"))
+
+check_unflatten_eltypes(::AbstractArray{T}, o::OrbitalStructure) where {T} =
+    T === orbitaltype(o) || T === blocktype(o) ||
+        throw(ArgumentError("Eltype of desination array is inconsistent with orbital structure"))
+
+## unflatten_orbitals_or_reinterpret: call unflatten_orbitals but only if we cannot unflatten via reinterpret
+unflatten_orbitals_or_reinterpret(vflat, ::Missing) = vflat
 # source is already of the correct orbitaltype(h)
-function unflatten_or_reinterpret(vflat::AbstractArray{T}, o::OrbitalStructure{T}) where {T}
+function unflatten_orbitals_or_reinterpret(vflat::AbstractArray{T}, o::OrbitalStructure{T}) where {T}
     check_unflatten_dst_dims(vflat, dimh(o))
     return vflat
 end
 
-function unflatten_or_reinterpret(vflat::AbstractArray{<:Number}, o::OrbitalStructure{<:Number})
+function unflatten_orbitals_or_reinterpret(vflat::AbstractArray{<:Number}, o::OrbitalStructure{<:Number})
     check_unflatten_dst_dims(vflat, dimh(o))
     return vflat
 end
 
 # source can be reinterpreted, because the number of orbitals is the same M for all N sublattices
-unflatten_or_reinterpret(vflat::AbstractArray{T}, o::OrbitalStructure{S,N,<:NTuple{N,NTuple{M}}}) where {T,S,N,M} =
+unflatten_orbitals_or_reinterpret(vflat::AbstractArray{T}, o::OrbitalStructure{S,N,<:NTuple{N,NTuple{M}}}) where {T,S,N,M} =
     reinterpret(SVector{M,T}, vflat)
-# otherwise call unflatten
-unflatten_or_reinterpret(vflat, o) = unflatten(vflat, o)
+# otherwise call unflatten_orbitals
+unflatten_orbitals_or_reinterpret(vflat, o) = unflatten_orbitals(vflat, o)
 
-check_unflatten_dst_dims(v, dimh) =
-    size(v, 1) == dimh ||
-        throw(ArgumentError("Dimension of destination array is inconsistent with Hamiltonian"))
-
-check_unflatten_src_dims(vflat, dimflat) =
-    size(vflat, 1) == dimflat ||
-        throw(ArgumentError("Dimension of source array is inconsistent with Hamiltonian"))
-
-check_unflatten_eltypes(::AbstractArray{T}, ::OrbitalStructure{S}) where {T,S} =
-    T === S || throw(ArgumentError("Eltype of desination array is inconsistent with Hamiltonian"))
-
-valdim(::Type{<:Number}) = Val(1)
-valdim(::Type{S}) where {N,S<:SVector{N}} = Val(N)
+# valdim(::Type{<:Number}) = Val(1)
+# valdim(::Type{S}) where {N,S<:SVector{N}} = Val(N)
 
 #######################################################################
 # similarmatrix
@@ -506,7 +545,7 @@ _similarmatrix(::Type{A}, ::Type{A´}, h) where {T<:Number,A<:AbstractSparseMatr
 _similarmatrix(::Type{A}, ::Type{A´}, h) where {N,T<:SMatrix{N,N},A<:AbstractSparseMatrix{T},T´<:SMatrix{N,N},A´<:AbstractSparseMatrix{T´}} =
     similar_merged(h.harmonics, T)
 _similarmatrix(::Type{A}, ::Type{A´}, h) where {N,T<:Number,A<:AbstractSparseMatrix{T},T´<:SMatrix{N,N},A´<:AbstractSparseMatrix{T´}} =
-    _flatten(similar_merged(h.harmonics), h.orbstruct, T)
+    flatten(similar_merged(h.harmonics), h.orbstruct, T)
 _similarmatrix(::Type{A}, ::Type{A´}, h) where {T<:Number,A<:Matrix{T},T´<:Number,A´<:AbstractMatrix{T´}} =
     similar(A, size(h))
 _similarmatrix(::Type{A}, ::Type{A´}, h) where {N,T<:SMatrix{N,N},A<:Matrix{T},T´<:SMatrix{N,N},A´<:AbstractMatrix{T´}} =
@@ -744,6 +783,7 @@ _blocktype(::Type{S}) where {N,Tv,S<:SVector{N,Tv}} = SMatrix{N,N,Tv,N*N}
 _blocktype(::Type{S}) where {S<:Number} = S
 
 blocktype(h::Hamiltonian{LA,L,M}) where {LA,L,M} = M
+blocktype(o::OrbitalStructure) = _blocktype(orbitaltype(o))
 
 promote_blocktype(hs::Hamiltonian...) = promote_blocktype(blocktype.(hs)...)
 promote_blocktype(s1::Type, s2::Type, ss::Type...) =
@@ -758,9 +798,7 @@ blockdim(::Type{S}) where {N,S<:SMatrix{N,N}} = N
 blockdim(::Type{T}) where {T<:Number} = 1
 
 orbitaltype(h::Hamiltonian) = orbitaltype(h.orbstruct)
-
-orbitaltype(o::OrbitalStructure{T}) where {T} = T
-
+orbitaltype(o::OrbitalStructure) = o.orbtype
 orbitaltype(::Type{M}) where {M<:Number} = M
 orbitaltype(::Type{S}) where {N,T,S<:SMatrix{N,N,T}} = SVector{N,T}
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -676,8 +676,8 @@ supercell_center(lat::AbstractLattice{E,L,T}) where {E,L,T} =
 # supplements supercell with most orthogonal bravais axes
 function extended_supercell(bravais, supercell::SMatrix{L,L´}) where {L,L´}
     L == L´ && return supercell
-    bravais_new_norm = normalize_cols(bravais * supercell)
-    bravais_norm = normalize_cols(bravais)
+    bravais_new_norm = normalize_columns(bravais * supercell)
+    bravais_norm = normalize_columns(bravais)
     # νnorm are the L projections of old bravais on new bravais axis subspace
     ν = bravais_norm' * bravais_new_norm  # L×L´
     νnorm = SVector(ntuple(row -> norm(ν[row,:]), Val(L)))
@@ -686,10 +686,6 @@ function extended_supercell(bravais, supercell::SMatrix{L,L´}) where {L,L´}
     ext_supercell = hcat(supercell, ext_axes)
     return ext_supercell
 end
-
-normalize_cols(s::SMatrix{L,0}) where {L} = s
-normalize_cols(s::SMatrix{0,L}) where {L} = s
-normalize_cols(s) = mapslices(v -> v/norm(v), s, dims = 1)
 
 function _superlat(lat, scmatrix, pararegion, selector_perp, seed)
     br = bravais(lat)

--- a/src/plot_vegalite.jl
+++ b/src/plot_vegalite.jl
@@ -300,9 +300,9 @@ sanitize_colorrange(r::Tuple, table) = [first(r), last(r)]
 needslegend(x::Number) = nothing
 needslegend(x) = true
 
-unflatten_or_reinterpret_or_missing(psi::Missing, h) = missing
-unflatten_or_reinterpret_or_missing(psi::AbstractArray, h) = unflatten_or_reinterpret(psi, h.orbstruct)
-unflatten_or_reinterpret_or_missing(s::Subspace, h) = unflatten_or_reinterpret(s.basis, h.orbstruct)
+unflatten_orbitals_or_reinterpret_or_missing(psi::Missing, h) = missing
+unflatten_orbitals_or_reinterpret_or_missing(psi::AbstractArray, h) = unflatten_orbitals_or_reinterpret(psi, h.orbstruct)
+unflatten_orbitals_or_reinterpret_or_missing(s::Subspace, h) = unflatten_orbitals_or_reinterpret(s.basis, h.orbstruct)
 
 checkdims_psi(h, psi) = size(h, 2) == size(psi, 1) ||
     throw(ArgumentError("The eigenstate length $(size(psi,1)) must match the Hamiltonian dimension $(size(h, 2))"))
@@ -326,7 +326,7 @@ end
 function linkstable!(table, h, psi, cell = missing;
                      axes, digits, onlyonecell, plotsites, plotlinks,
                      sitesize, siteopacity, sitecolor, linksize, linkopacity, linkcolor) where {LA,L}
-    psi´ = unflatten_or_reinterpret_or_missing(psi, h)
+    psi´ = unflatten_orbitals_or_reinterpret_or_missing(psi, h)
     checkdims_psi(h, psi´)
     d = (; axes = axes, digits = digits,
         sitesize_shader    = site_shader(sitesize, h, psi´),

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -122,7 +122,7 @@ padtotype(s::Number, ::Type{S}) where {N,T,S<:SVector{N,T}} =
 padtotype(x::Number, ::Type{T}) where {T<:Number} = T(x)
 padtotype(u::UniformScaling, ::Type{T}) where {T<:Number} = T(u.λ)
 padtotype(u::UniformScaling, ::Type{S}) where {S<:SMatrix} = S(u)
-padtotype(a::AbstractVector, t::SVector) = padright(a, t)
+padtotype(a::AbstractArray, t::Type{<:SVector}) = padright(a, t)
 
 function padtotype(a::AbstractMatrix, ::Type{S}) where {N,M,T,S<:SMatrix{N,M,T}}
     t = ntuple(Val(N*M)) do i

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -106,22 +106,31 @@ padright(t::NTuple{N´,Any}, x, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 
 padright(t::NTuple{N´,Any}, ::Val{N}) where {N´,N} = ntuple(i -> i > N´ ? 0 : t[i], Val(N))
 
 padright(v, ::Type{<:Number}) = first(v)
-padright(v, ::Type{S}) where {E,T,S<:SVector{E,T}} = padright(v, zero(T), S)
+padright(v, ::Type{S}) where {T,S<:SVector{<:Any,T}} = padright(v, zero(T), S)
 padright(v, x::T, ::Type{S}) where {E,T,S<:SVector{E,T}} =
     SVector{E,T}(ntuple(i -> i > length(v) ? x : convert(T, v[i]), Val(E)))
 
 # Pad element type to a "larger" type
-@inline padtotype(s::SMatrix{E,L}, ::Type{S}) where {E,L,E2,L2,S<:SMatrix{E2,L2}} =
+padtotype(s::SMatrix{E,L}, ::Type{S}) where {E,L,E2,L2,T,S<:SMatrix{E2,L2,T}} =
     S(SMatrix{E2,E}(I) * s * SMatrix{L,L2}(I))
-@inline padtotype(s::StaticVector, ::Type{S}) where {N,T,S<:SVector{N,T}} =
+padtotype(s::StaticVector, ::Type{S}) where {N,T,S<:SVector{N,T}} =
     padright(T.(s), Val(N))
-@inline padtotype(x::Number, ::Type{S}) where {E,L,S<:SMatrix{E,L}} =
+padtotype(x::Number, ::Type{S}) where {E,L,S<:SMatrix{E,L}} =
     S(x * (SMatrix{E,1}(I) * SMatrix{1,L}(I)))
-@inline padtotype(s::Number, ::Type{S}) where {N,T,S<:SVector{N,T}} =
+padtotype(s::Number, ::Type{S}) where {N,T,S<:SVector{N,T}} =
     padright(SA[T(s)], Val(N))
-@inline padtotype(x::Number, ::Type{T}) where {T<:Number} = T(x)
-@inline padtotype(u::UniformScaling, ::Type{T}) where {T<:Number} = T(u.λ)
-@inline padtotype(u::UniformScaling, ::Type{S}) where {S<:SMatrix} = S(u)
+padtotype(x::Number, ::Type{T}) where {T<:Number} = T(x)
+padtotype(u::UniformScaling, ::Type{T}) where {T<:Number} = T(u.λ)
+padtotype(u::UniformScaling, ::Type{S}) where {S<:SMatrix} = S(u)
+padtotype(a::AbstractVector, t::SVector) = padright(a, t)
+
+function padtotype(a::AbstractMatrix, ::Type{S}) where {N,M,T,S<:SMatrix{N,M,T}}
+    t = ntuple(Val(N*M)) do i
+        n, m = mod1(i, N), fld1(i, N)
+        @inbounds n > size(a, 1) || m > size(a, 2) ? zero(T) : T(a[n,m])
+    end
+    return S(t)
+end
 
 ## Work around BUG: -SVector{0,Int}() isa SVector{0,Union{}}
 negative(s::SVector{L,<:Number}) where {L} = -s
@@ -187,8 +196,23 @@ function ispositive(ndist)
     return result
 end
 
-chop(x::T, x0 = one(T)) where {T<:Real} = ifelse(abs(x) < √eps(T(x0)), zero(T), x)
+chop(x::T, x0 = one(T)) where {T<:Real} = ifelse(abs2(x) < eps(T(x0)), zero(T), x)
 chop(x::C, x0 = one(R)) where {R<:Real,C<:Complex{R}} = chop(real(x), x0) + im*chop(imag(x), x0)
+
+# function chop!(A::AbstractArray{T}, atol = default_tol(T)) where {T}
+#     for (i, a) in enumerate(A)
+#         # if abs(a) < atol
+#         #     A[i] = zero(T)
+#         if !iszero(a) #&& (abs(real(a)) < atol || abs(imag(a)) < atol)
+#             A[i] = chop(a)
+#         elseif abs(a) > 1/atol || isnan(a)
+#             A[i] = T(Inf)
+#         end
+#     end
+#     return A
+# end
+
+default_tol(::Type{T}) where {T} = sqrt(eps(real(float(T))))
 
 function unique_sorted_approx!(v::AbstractVector{T}) where {T}
     i = 1
@@ -213,6 +237,10 @@ function normalize_columns!(kmat::AbstractMatrix, cols)
     end
     return kmat
 end
+
+normalize_columns(s::SMatrix{L,0}) where {L} = s
+normalize_columns(s::SMatrix{0,L}) where {L} = s
+normalize_columns(s) = mapslices(v -> v/norm(v), s, dims = 1)
 
 eltypevec(::AbstractMatrix{T}) where {T<:Number} = T
 eltypevec(::AbstractMatrix{S}) where {N,T<:Number,S<:SMatrix{N,N,T}} = SVector{N,T}
@@ -282,6 +310,14 @@ permutations!(p, ::Tuple{}, s2) = push!(p, s2)
 
 delete(t::NTuple{N,Any}, i) where {N} = ntuple(j -> j < i ? t[j] : t[j+1], Val(N-1))
 
+function one!(m::StridedMatrix{T}) where {T}
+    @inbounds for c in CartesianIndices(m)
+        m[c] = ifelse(c[1] == c[2], one(T), zero(T))
+    end
+    return m
+end
+
+
 ######################################################################
 # convert a matrix/number block to a matrix/inlinematrix string
 ######################################################################
@@ -350,3 +386,81 @@ rclamp(r1::UnitRange, r2::UnitRange) = isempty(r1) ? r1 : clamp(minimum(r1), ext
 
 iclamp(minmax, r::Missing) = minmax
 iclamp((x1, x2), (xmin, xmax)) = (max(x1, xmin), min(x2, xmax))
+
+############################################################################################
+# QR utils
+############################################################################################
+# Sparse QR from SparseSuite is also pivoted
+pqr(a::SparseMatrixCSC) = qr(a)
+pqr(a::Adjoint{T,<:SparseMatrixCSC}) where {T} = qr(copy(a))
+pqr(a::Transpose{T,<:SparseMatrixCSC}) where {T} = qr(copy(a))
+pqr(a) = qr!(copy(a), Val(true))
+
+getQ(qr::Factorization, cols = :) = qr.Q * Idense(size(qr, 1), cols)
+getQ(qr::SuiteSparse.SPQR.QRSparse, cols = :) =  Isparse(size(qr, 1), :, qr.prow) * sparse(qr.Q * Idense(size(qr, 1), cols))
+getQ_dense(qr::SuiteSparse.SPQR.QRSparse, cols = :) =  Isparse(size(qr, 1), :, qr.prow) * (qr.Q * Idense(size(qr, 1), cols))
+
+getQ´(qr::Factorization, cols = :) = qr.Q' * Idense(size(qr, 1), cols)
+getQ´(qr::SuiteSparse.SPQR.QRSparse, cols = :) = sparse((qr.Q * Idense(size(qr, 1), cols))') * Isparse(size(qr,1), qr.prow, :)
+
+getRP´(qr::Factorization) = qr.R * qr.P'
+getRP´(qr::SuiteSparse.SPQR.QRSparse) = qr.R * Isparse(size(qr, 2), qr.pcol, :)
+
+getPR´(qr::Factorization) = qr.P * qr.R'
+getPR´(qr::SuiteSparse.SPQR.QRSparse) = Isparse(size(qr, 2), :, qr.pcol) * qr.R'
+
+Idense(n, ::Colon) = Matrix(I, n, n)
+
+function Idense(n, cols)
+    m = zeros(Bool, n, length(cols))
+    for (j, col) in enumerate(cols)
+        m[col, j] = true
+    end
+    return m
+end
+
+# Equivalent to I(n)[rows, cols], but faster
+Isparse(n, rows, cols) = Isparse(inds(rows, n), inds(cols, n))
+
+function Isparse(rows, cols)
+    rowval = Int[]
+    nzval = Bool[]
+    colptr = Vector{Int}(undef, length(cols) + 1)
+    colptr[1] = 1
+    for (j, col) in enumerate(cols)
+        push_rows!(rowval, nzval, rows, col)
+        colptr[j+1] = length(rowval) + 1
+    end
+    return SparseMatrixCSC(length(rows), length(cols), colptr, rowval, nzval)
+end
+
+inds(::Colon, n) = 1:n
+inds(is, n) = is
+
+function push_rows!(rowval, nzval, rows::AbstractUnitRange, col)
+    if col in rows
+        push!(rowval, 1 + rows[1 + col - first(rows)] - first(rows))
+        push!(nzval, true)
+    end
+    return nothing
+end
+
+function push_rows!(rowval, nzval, rows, col)
+    for (j, row) in enumerate(rows)
+        if row == col
+            push!(rowval, j)
+            push!(nzval, true)
+        end
+    end
+    return nothing
+end
+
+function nonzero_rows(m::AbstractMatrix{T}, atol = default_tol(T)) where {T}
+    nrows = size(m, 1)
+    zerorows = 0
+    for j in 0:nrows-1
+        maximum(abs, view(m, nrows - j, :)) > atol && break
+        zerorows += 1
+    end
+    return nrows - zerorows
+end

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -112,7 +112,7 @@ end
 @testset "unflatten" begin
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = (Val(2), Val(1))) |> unitcell(2) |> unitcell
     sp = spectrum(h).states[:,1]
-    sp´ = Quantica.unflatten_or_reinterpret(sp, h.orbstruct)
+    sp´ = Quantica.unflatten_orbitals_or_reinterpret(sp, h.orbstruct)
     l = size(h, 1)
     @test length(sp) == 1.5 * l
     @test length(sp´) == l
@@ -131,7 +131,7 @@ end
 
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = Val(2)) |> unitcell(2) |> unitcell
     sp = spectrum(h).states[:,1]
-    sp´ = Quantica.unflatten_or_reinterpret(sp, h.orbstruct)
+    sp´ = Quantica.unflatten_orbitals_or_reinterpret(sp, h.orbstruct)
     l = size(h, 1)
     @test length(sp) == 2 * l
     @test length(sp´) == l
@@ -139,7 +139,7 @@ end
 
     h = LatticePresets.honeycomb() |> hamiltonian(onsite(2I) + hopping(I, range = 1), orbitals = Val(2)) |> unitcell(2) |> unitcell
     sp = spectrum(h).states[:,1]
-    sp´ = Quantica.unflatten_or_reinterpret(sp, h.orbstruct)
+    sp´ = Quantica.unflatten_orbitals_or_reinterpret(sp, h.orbstruct)
     @test sp === sp
 end
 

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -1,51 +1,62 @@
 using LinearAlgebra: tr
 
-# @testset "greens bandstructure" begin
-#     g = LatticePresets.square() |> hamiltonian(hopping(-1)) |> unitcell((2,0), (0,1)) |>
-#         greens(bandstructure(subticks = 17))
-#     @test g(0.2) ≈ transpose(g(0.2))
-#     @test imag(tr(g(1))) < 0
-#     @test Quantica.chop(imag(tr(g(5)))) == 0
-# end
+@testset "greens singleshot selfenergy" begin
+    h1 = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+    h2 = LP.honeycomb() |> hamiltonian(hopping(1) + onsite(0.02, sublats = :A) - onsite(0.02, sublats = :B)) |> unitcell((4,4), region = r -> -5 < r[1] < 5)
+    res(g, ω) = (s = g.solver; Σ = s(ω); sum(abs.(Σ - s.hm * (((ω * I - s.h0) - Σ) \ Matrix(s.hp)))))
+    for h in (h1, h2)
+        g = greens(h, Schur1D(), boundaries = (0,))
+        residual = maximum(res(g, ω) for ω in range(-3.2, 3.2, length = 101))
+        g = greens(h, Schur1D(deflation = nothing), boundaries = (0,))
+        residual0 = maximum(res(g, ω) for ω in range(-3.2, 3.2, length = 101))
+        @test residual < 2*residual0
+    end
+end
+
+@testset "greens multiorbital" begin
+    h = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0], range = 2), orbitals = Val(2)) |> unitcell((2,-1), region = r->abs(r[2])<3)
+    g = greens(h, Schur1D(), boundaries = (0,))
+    g0 = greens(flatten(h), Schur1D(), boundaries = (0,))
+    @test tr(tr(g(0.2))) ≈ tr(g0(0.2))
+end
 
 @testset "greens singleshot spectra" begin
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
-    # h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
-    # g = greens(h, SingleShot1D())
-    # @test_throws ArgumentError g(0)
-    # dos = [-imag(tr(g(w + 1.0e-6im))) for w in range(-3.2, 3.2, length = 1001)]
-    # @test all(x -> Quantica.chop(x) >= 0, dos)
+    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+    g = greens(h, Schur1D())
+    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
 
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
-    # h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
-    # g = greens(h, SingleShot1D())
-    # dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 1001)]
-    # @test all(x -> Quantica.chop(x) >= 0, dos)
+    h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+    g = greens(h, Schur1D())
+    dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 101)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
 
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
-    # h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
-    # g = greens(h, SingleShot1D())
-    # dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 1001)]
-    # @test all(x -> Quantica.chop(x) >= 0, dos)
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
+    g = greens(h, Schur1D())
+    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
 
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
-    # h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/(dr'*dr), range = 1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
-    # g = greens(h, SingleShot1D())
-    # dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 1001)]
-    # @test all(x -> Quantica.chop(x) >= 0, dos)
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/(dr'*dr), range = 1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
+    g = greens(h, Schur1D())
+    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+    @test all(x -> Quantica.chop(x) >= 0, dos)
 
     h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((2,-2),(3,3)) |> unitcell(1, 1, indices = not(1)) |> wrap(2)
-    g = greens(h, SingleShot1D(direct = true))
+    g = greens(h, Schur1D())
     # @test_broken Quantica.chop(imag(tr(g(0.2)))) <= 0
-    g = greens(h, SingleShot1D())
+    g = greens(h, Schur1D())
     @test Quantica.chop(imag(tr(g(0.2)))) <= 0
-    dos = [-imag(tr(g(w + 1.0e-6im))) for w in range(-3.2, 3.2, length = 1001)]
+    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
     @test all(x -> Quantica.chop(x) >= 0, dos)
 end
 
 @testset "greens singleshot spatial" begin
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(3,3)) |> unitcell((1,0))
-    g = greens(h, SingleShot1D(), boundaries = (0,))
+    g = greens(h, Schur1D(), boundaries = (0,))
     g0 = g(0.01, missing)
     ldos = [-imag(tr(g0(n=>n))) for n in 1:200]
     @test all(x -> Quantica.chop(x) >= 0, ldos)

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -21,33 +21,31 @@ end
 end
 
 @testset "greens singleshot spectra" begin
-    # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
     h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
     g = greens(h, Schur1D())
     dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
     @test all(x -> Quantica.chop(x) >= 0, dos)
 
-    # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
     h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
     g = greens(h, Schur1D())
     dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 101)]
     @test all(x -> Quantica.chop(x) >= 0, dos)
 
-    # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
     g = greens(h, Schur1D())
     dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
     @test all(x -> Quantica.chop(x) >= 0, dos)
 
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/(dr'*dr), range = 1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
-    g = greens(h, Schur1D())
-    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
-    @test all(x -> Quantica.chop(x) >= 0, dos)
+    if VERSION >= v"1.7.0-DEV"
+        h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/(dr'*dr), range = 1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
+        g = greens(h, Schur1D())
+        dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+        @test all(x -> Quantica.chop(x) >= 0, dos)
+    end
 
     h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((2,-2),(3,3)) |> unitcell(1, 1, indices = not(1)) |> wrap(2)
     g = greens(h, Schur1D())
-    # @test_broken Quantica.chop(imag(tr(g(0.2)))) <= 0
     g = greens(h, Schur1D())
     @test Quantica.chop(imag(tr(g(0.2)))) <= 0
     dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -21,23 +21,23 @@ end
 end
 
 @testset "greens singleshot spectra" begin
-    h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
-    g = greens(h, Schur1D())
-    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
-    @test all(x -> Quantica.chop(x) >= 0, dos)
-
-    h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
-    g = greens(h, Schur1D())
-    dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 101)]
-    @test all(x -> Quantica.chop(x) >= 0, dos)
-
-    h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
-    g = greens(h, Schur1D())
-    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
-    @test all(x -> Quantica.chop(x) >= 0, dos)
-
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
     if VERSION >= v"1.7.0-DEV"
+        h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+        g = greens(h, Schur1D())
+        dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+        @test all(x -> Quantica.chop(x) >= 0, dos)
+
+        h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
+        g = greens(h, Schur1D())
+        dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 101)]
+        @test all(x -> Quantica.chop(x) >= 0, dos)
+
+        h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
+        g = greens(h, Schur1D())
+        dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+        @test all(x -> Quantica.chop(x) >= 0, dos)
+
         h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/(dr'*dr), range = 1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
         g = greens(h, Schur1D())
         dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]


### PR DESCRIPTION
Closes #154 

This implements a deflating Schur algorithm that is far more precise, performant and stable than the one in master. It is developed in detail in a paper to be submitted, will post here when available. I just post a plot from the paper here

<img width="915" alt="Screen Shot 2021-05-14 at 18 27 49" src="https://user-images.githubusercontent.com/4310809/118300353-1e5dbb80-b4e2-11eb-892d-98572207d69c.png">

I leave some branches open for a while with alternative algorithms that were explored in developing this.

When writing tests for this I realized that the fact that `unitcell` sometimes changes the shape of the unit cell (probably because of #117) and the algorithm enlarges the unit cell using `unticell` when there are next-nearest-cell hoppings, the result can be wrong. Must fix `unitcell` in a future PR to always preserve cell shape, at least in 1D.