### PR TITLE
Inverse-free Green's functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         version:
           - '1.5'
           - '1.6'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -15,7 +15,7 @@ using StaticArrays, NearestNeighbors, SparseArrays, LinearAlgebra, OffsetArrays,
 
 using ExprTools
 
-using SparseArrays: getcolptr, AbstractSparseMatrix
+using SparseArrays: getcolptr, AbstractSparseMatrix, AbstractSparseMatrixCSC
 
 using Statistics: mean
 
@@ -57,6 +57,7 @@ include("mesh.jl")
 include("diagonalizer.jl")
 include("bandstructure.jl")
 include("KPM.jl")
+include("effective.jl")
 include("greens.jl")
 include("convert.jl")
 

--- a/src/effective.jl
+++ b/src/effective.jl
@@ -1,0 +1,66 @@
+#######################################################################
+# EffectiveMatrix
+#######################################################################
+"""
+    EffectiveMatrix
+
+A dense matrix of the form `matrix = [ZaL(ω) L' 0; L*ZaR(ω) I*ω-H R*ZrL(ω); 0 R' ZrR(ω)]`,
+where H, L and R are given at construction, while ω, φL, φR are given at runtime.
+"""
+struct EffectiveMatrix{T}
+    matrix::Matrix{T}
+    L::Matrix{T}
+    R::Matrix{T}
+    n::Int
+    r::Int
+end
+
+function EffectiveMatrix(H, L, R)
+    size(L) == size(R) || throw("L and R in Effective matrix should have same `size`, but are $(size(L)) and $(size(R))")
+    Hd = Matrix(H)
+    Ld = Matrix(L)
+    Rd = Matrix(R)
+    matrix = [0I Ld' 0I; 0Ld -Hd 0Rd; 0I Rd' 0I]
+    n, r = size(R)
+    return EffectiveMatrix(matrix, L, R, n, r)
+end
+
+function effective_matrix!(mat, e::EffectiveMatrix, ω, (ZrL, ZrR, ZaL, ZaR))
+    copy!(mat, e.matrix)
+    for n in axes(mat, 1)
+        mat[n, n] += ω
+    end
+    r, n = e.r, e.n
+    i1, i2, i3 = 1:r, r+1:r+n, r+n+1:n+2r
+    copy!(view(mat, i1, i1), ZaL)
+    copy!(view(mat, i3, i3), ZrR)
+    mul!(view(mat, i2, i1), e.L, ZaR)
+    mul!(view(mat, i2, i3), e.R, ZrL)
+    return mat
+end
+
+pad_effective(m::StridedMatrix{T}, e::EffectiveMatrix, ::Val{:L}) where {T} =
+    [zeros(T, e.r, size(m, 2)); m]
+pad_effective(m::StridedMatrix{T}, e::EffectiveMatrix, ::Val{:R}) where {T} =
+    [m; zeros(T, e.r, size(m, 2))]
+pad_effective(m::StridedMatrix{T}, e::EffectiveMatrix, ::Val{:LR}) where {T} =
+    [zeros(T, e.r, size(m, 2)); m; zeros(T, e.r, size(m, 2))]
+
+unpad_effective(m::StridedMatrix, e::EffectiveMatrix, ::Val{:L}) = view(m, e.r+1:e.r+e.n, :)
+unpad_effective(m::StridedMatrix, e::EffectiveMatrix, ::Val{:R}) = view(m, 1:e.n, :)
+unpad_effective(m::StridedMatrix, e::EffectiveMatrix, ::Val{:LR}) = view(m, e.r+1:e.r+e.n, :)
+
+padded_lu!(invmat, e::EffectiveMatrix, ::Val{:L}) = lu!(view(invmat, 1:e.r+e.n, 1:e.r+e.n))
+padded_lu!(invmat, e::EffectiveMatrix, ::Val{:R}) = lu!(view(invmat, e.r+1:2e.r+e.n, e.r+1:2e.r+e.n))
+padded_lu!(invmat, e::EffectiveMatrix, ::Val{:LR}) = lu!(invmat)
+
+padded_ldiv(invmat::AbstractMatrix, mat::AbstractMatrix, e::EffectiveMatrix, side) =
+    padded_ldiv(padded_lu!(invmat, e, side), mat, e, side)
+padded_ldiv(fact::Factorization, mat, e::EffectiveMatrix, side) =
+    unpad_effective(ldiv!(fact, pad_effective(mat, e, side)), e, side)
+
+Base.eltype(::EffectiveMatrix{T}) where {T} = T
+
+#######################################################################
+# EffectiveHamiltonian
+#######################################################################

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -213,6 +213,7 @@ chop(x::C, x0 = one(R)) where {R<:Real,C<:Complex{R}} = chop(real(x), x0) + im*c
 # end
 
 default_tol(::Type{T}) where {T} = sqrt(eps(real(float(T))))
+default_tol(::T) where {T<:Number} = default_tol(T)
 
 function unique_sorted_approx!(v::AbstractVector{T}) where {T}
     i = 1

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -388,7 +388,7 @@ iclamp(minmax, r::Missing) = minmax
 iclamp((x1, x2), (xmin, xmax)) = (max(x1, xmin), min(x2, xmax))
 
 ############################################################################################
-# QR utils
+# QR/SVD utils
 ############################################################################################
 # Sparse QR from SparseSuite is also pivoted
 pqr(a::SparseMatrixCSC) = qr(a)
@@ -404,7 +404,10 @@ getQ´(qr::Factorization, cols = :) = qr.Q' * Idense(size(qr, 1), cols)
 getQ´(qr::SuiteSparse.SPQR.QRSparse, cols = :) = sparse((qr.Q * Idense(size(qr, 1), cols))') * Isparse(size(qr,1), qr.prow, :)
 
 getRP´(qr::Factorization) = qr.R * qr.P'
+getRP´(qr::Factorization, rows) = qr.R[rows, :] * qr.P'
 getRP´(qr::SuiteSparse.SPQR.QRSparse) = qr.R * Isparse(size(qr, 2), qr.pcol, :)
+getRP´(qr::SuiteSparse.SPQR.QRSparse, rows) = Isparse(size(qr, 1), rows, :) * qr.R * Isparse(size(qr, 2), qr.pcol, :)
+getRP´thin(qr::Factorization) = getRP´(qr, 1:nonzero_rows(qr.R))
 
 getPR´(qr::Factorization) = qr.P * qr.R'
 getPR´(qr::SuiteSparse.SPQR.QRSparse) = Isparse(size(qr, 2), :, qr.pcol) * qr.R'
@@ -463,4 +466,23 @@ function nonzero_rows(m::AbstractMatrix{T}, atol = default_tol(T)) where {T}
         zerorows += 1
     end
     return nrows - zerorows
+end
+
+nonzero_rows(m::AbstractSparseMatrix{T}, atol = default_tol(T)) where {T} =
+    isempty(rowvals(m)) ? 0 : maximum(rowvals(m))
+
+function svd_sparse(s::AbstractSparseMatrix{T}, atol = default_tol(T)) where {T}
+    iszero(s) && return spzeros(T, size(s, 1), 0), spzeros(T, size(s, 1), 0)
+    q = qr(s)
+    RP´ = getRP´thin(q)
+    r = size(RP´, 1)
+    U = getQ(q, 1:r)
+    q´ = qr(copy(RP´'))
+    RP´´ = getRP´(q´)
+    r = size(RP´´, 1)
+    V = getQ(q´, 1:r)
+    U´, S´, V´ = svd(Matrix(RP´´'))
+    US = sparse(U´ .* sqrt.(S´)')
+    VS = sparse(V´ .* sqrt.(S´)')
+    return U * US, V * VS
 end

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -1,62 +1,82 @@
 using LinearAlgebra: tr
 
-@testset "greens singleshot selfenergy" begin
+@testset "greens schur1D selfenergy accuracy" begin
     h1 = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
     h2 = LP.honeycomb() |> hamiltonian(hopping(1) + onsite(0.02, sublats = :A) - onsite(0.02, sublats = :B)) |> unitcell((4,4), region = r -> -5 < r[1] < 5)
-    res(g, ω) = (s = g.solver; Σ = s(ω); sum(abs.(Σ - s.hm * (((ω * I - s.h0) - Σ) \ Matrix(s.hp)))))
+    function res(g, ω)
+        s = g.solver
+        g0 = g(ω)
+        L, R, GRL, GLR= g0.L, g0.R, g0.GRL, g0.GLR
+        Σ = R * L' * GRL * R'
+        resR = sum(abs, Σ - s.hm * ((ω*I - s.h0 - Σ) \ Matrix(s.hp)))
+        Σ = L * R' * GLR * L'
+        resL = sum(abs, Σ - s.hp * ((ω*I - s.h0 - Σ) \ Matrix(s.hm)))
+        return resR + resL
+    end
+    g = greens(h1, Schur1D(), boundaries = (0,))
     for h in (h1, h2)
         g = greens(h, Schur1D(), boundaries = (0,))
-        residual = maximum(res(g, ω) for ω in range(-3.2, 3.2, length = 101))
-        g = greens(h, Schur1D(deflation = nothing), boundaries = (0,))
-        residual0 = maximum(res(g, ω) for ω in range(-3.2, 3.2, length = 101))
-        @test residual < 2*residual0
+        residual = maximum(res(g, ω + 1E-8im) for ω in range(-3.2, 3.2, length = 101))
+        @test residual < 1e-10
     end
 end
 
 @testset "greens multiorbital" begin
-    h = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0], range = 2), orbitals = Val(2)) |> unitcell((2,-1), region = r->abs(r[2])<3)
+    h = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0], range = 4), orbitals = Val(2)) |> unitcell((2,-1), region = r->abs(r[2])<3) |> unitcell(2)
     g = greens(h, Schur1D(), boundaries = (0,))
     g0 = greens(flatten(h), Schur1D(), boundaries = (0,))
-    @test tr(tr(g(0.2))) ≈ tr(g0(0.2))
+    o = orbitalstructure(h)
+    # for n in -3:3, m in -3:3
+    for n in 1:1, m in 1:1
+        @test flatten(g(0.2, n=>m), o) ≈ g0(0.2, n=>m)
+    end
 end
 
-@testset "greens singleshot spectra" begin
+@testset "greens schur1D positivity" begin
     # Broken until https://github.com/Reference-LAPACK/lapack/issues/477 comes to julia
     if VERSION >= v"1.7.0-DEV"
         h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1), region = r->abs(r[2])<3)
         g = greens(h, Schur1D())
-        dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+        dos = [-imag(tr(g(w, 1=>1))) for w in range(-3.2, 3.2, length = 101)]
         @test all(x -> Quantica.chop(x) >= 0, dos)
 
         h = LP.honeycomb() |> hamiltonian(hopping(1, range = 2)) |> unitcell((1,-1), region = r->abs(r[2])<3)
-        g = greens(h, Schur1D())
-        dos = [-imag(tr(g(w))) for w in range(-6, 6, length = 101)]
-        @test all(x -> Quantica.chop(x) >= 0, dos)
+        @test_throws ArgumentError greens(h, Schur1D())
 
         h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
         g = greens(h, Schur1D())
-        dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+        dos = [-imag(tr(g(w, 1=>1))) for w in range(-3.2, 3.2, length = 101)]
         @test all(x -> Quantica.chop(x) >= 0, dos)
 
         h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/(dr'*dr), range = 1)) |> unitcell((1,-1),(2,2)) |> wrap(2)
         g = greens(h, Schur1D())
-        dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+        dos = [-imag(tr(g(w, 1=>1))) for w in range(-3.2, 3.2, length = 101)]
         @test all(x -> Quantica.chop(x) >= 0, dos)
     end
 
     h = LP.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((2,-2),(3,3)) |> unitcell(1, 1, indices = not(1)) |> wrap(2)
     g = greens(h, Schur1D())
     g = greens(h, Schur1D())
-    @test Quantica.chop(imag(tr(g(0.2)))) <= 0
-    dos = [-imag(tr(g(w))) for w in range(-3.2, 3.2, length = 101)]
+    @test Quantica.chop(imag(tr(g(0.2, 1=>1)))) <= 0
+    dos = [-imag(tr(g(w, 1=>1))) for w in range(-3.2, 3.2, length = 101)]
     @test all(x -> Quantica.chop(x) >= 0, dos)
 end
 
-@testset "greens singleshot spatial" begin
+@testset "greens schur1D spatial positivity" begin
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1)) |> unitcell((1,-1),(3,3)) |> unitcell((1,0))
     g = greens(h, Schur1D(), boundaries = (0,))
-    g0 = g(0.01, missing)
-    ldos = [-imag(tr(g0(n=>n))) for n in 1:200]
+    g0 = g(0.01)
+    ldos = [-imag(tr(g0[n=>n])) for n in 1:200]
     @test all(x -> Quantica.chop(x) >= 0, ldos)
 end
 
+@testset "greens fastpath equivalence" begin
+    h1 = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0], range = 1), orbitals = Val(2)) |> unitcell((1,-1), region = r->abs(r[2])<2)
+    h2 = LP.honeycomb() |> hamiltonian(hopping(1) + onsite(r->randn())) |> unitcell((2,-3), region = r->abs(r[2])<3)
+    for h in (h1, h2)
+        g = greens(h, Schur1D(), boundaries = (0,))
+        ldos_1 = [sum(g(ω)[n=>m]) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
+        ldos_2 = [sum(g(ω, n=>m)) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
+        @test isapprox(ldos_1, ldos_2, atol = 1E-7)
+    end
+end

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -17,7 +17,7 @@ using LinearAlgebra: tr
     for h in (h1, h2)
         g = greens(h, Schur1D(), boundaries = (0,))
         residual = maximum(res(g, ω + 1E-8im) for ω in range(-3.2, 3.2, length = 101))
-        @test residual < 1e-10
+        @test residual < Quantica.default_tol(residual)
     end
 end
 
@@ -75,8 +75,8 @@ end
     h2 = LP.honeycomb() |> hamiltonian(hopping(1) + onsite(r->randn())) |> unitcell((2,-3), region = r->abs(r[2])<3)
     for h in (h1, h2)
         g = greens(h, Schur1D(), boundaries = (0,))
-        ldos_1 = [sum(g(ω)[n=>m]) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
-        ldos_2 = [sum(g(ω, n=>m)) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
-        @test isapprox(ldos_1, ldos_2, atol = 1E-7)
+        ldos_1 = [g(ω)[n=>m] for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
+        ldos_2 = [g(ω, n=>m) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
+        @test isapprox(ldos_1, ldos_2, atol = Quantica.default_tol(Quantica.blockeltype(h)))
     end
 end

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -71,12 +71,14 @@ end
 end
 
 @testset "greens fastpath equivalence" begin
-    h1 = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0], range = 1), orbitals = Val(2)) |> unitcell((1,-1), region = r->abs(r[2])<2)
-    h2 = LP.honeycomb() |> hamiltonian(hopping(1) + onsite(r->randn())) |> unitcell((2,-3), region = r->abs(r[2])<3)
-    for h in (h1, h2)
-        g = greens(h, Schur1D(), boundaries = (0,))
-        ldos_1 = [g(ω)[n=>m] for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
-        ldos_2 = [g(ω, n=>m) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
-        @test isapprox(ldos_1, ldos_2, atol = Quantica.default_tol(Quantica.blockeltype(h)))
+    if VERSION >= v"1.7.0-DEV"
+        h1 = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0], range = 1), orbitals = Val(2)) |> unitcell((1,-1), region = r->abs(r[2])<2)
+        h2 = LP.honeycomb() |> hamiltonian(hopping(1) + onsite(r->randn())) |> unitcell((2,-3), region = r->abs(r[2])<3)
+        for h in (h1, h2)
+            g = greens(h, Schur1D(), boundaries = (0,))
+            ldos_1 = [g(ω)[n=>m] for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
+            ldos_2 = [g(ω, n=>m) for ω in range(-0.1, 0.1, length = 5), n in -3:3, m in -3:3]
+            @test isapprox(ldos_1, ldos_2, atol = Quantica.default_tol(Quantica.blockeltype(h)))
+        end
     end
 end


### PR DESCRIPTION
This builds on top of #161
- We replace the QR deflation algorithm with a similar deflation algorithm developed by M. Wimmer, A. Akhmerov et al. that has a similar performance but is more transparent IMO. It also provides the physical retarded/advanced eigenmodes or their invariant subspaces, but does so through an LU inversion instead of a QR factorization. The numerical precision is slightly better, squeezing out one or two more significant digits of the self energy in my tests.
- We introduce a new way to build the Green's function that does not require the computation of the self-energy explicitly, which requires an inverse. This has profound consequences for the case of defective eigenmode matrices, i.e. when there is a bound state or a singularity of any other type. The idea is to replace the self energy by an auxiliary subspace, whose "hamiltonian" and coupling to the unit cell h0 is expressed in terms of the eigenmode invariant subspaces, no inverse needed.
- This "inverse-free" approach is also interesting for future problems involving hybrid systems, such as multiterminal scattering systems and other combination of coupled Hamiltonians, since *any* reservoir, regardless of its dimensionality, could be coupled to another system through the same mechanism.

The user-facing consequences of this PR are
- No undeflated method exists anymore, so `Schur1D()` takes no keyword arguments.
- Numerical precision and speed should be improved
- In #161, doing `g(ω, 1=>n)` used a fastpath that was twice faster than a general `g(ω, m=>n)`. Not anymore. Through careful reuse of Schur factorizations, now everything is faster than the original `g(ω, 1=>n)`, and there is no penalty for the general case.
- A new breaking syntax is introduced: `g0 = g(ω)` with `g::GreensFunction{Schur1DGreensSolver}` generates a `Schur1DGreensSolution` object, instead of defaulting to `g(ω, 1=>1)`. It is the equivalent of #161's `g(ω, missing)`. Then `g0[n=>m]` computes the actual Greens function matrix. Fastpaths still exist that save a little bit of time when only a specific `n,m` is needed. The syntax for the fastpath computation is just as before, `g(ω, n=>m)`, with the guarantee that `g(ω, n=>m) ≈ g(ω)[n=>m]`
- Hamiltonians with intercell couplings beyond nearest neighbors cannot be used to build Green's functions. An error is thrown instructing to enlarge the unit cell with `unitcell`. This is done to avoid nasty bugs (unitcell is not a block-wise cell expansion, but shuffles sites/sublattices)

Example
```julia
julia> using LinearAlgebra, VegaLite, BenchmarkTools, Quantica

julia> h = LatticePresets.square() |>
           hamiltonian(hopping(1)) |>
           unitcell((20, 0), region = r -> -10 <= r[2] <= 10 && norm(r-SA[10,0]) > 5)
Hamiltonian{<:Lattice} : Hamiltonian on a 1D Lattice in 2D space
  Bloch harmonics  : 3 (SparseMatrixCSC, sparse)
  Harmonic size    : 339 × 339
  Orbitals         : ((:a,),)
  Element type     : scalar (ComplexF64)
  Onsites          : 0
  Hoppings         : 1272
  Coordination     : 3.752212389380531

julia> g = greens(h, Schur1D(), boundaries = (0,))
GreensFunction{Schur1DGreensSolver}: Green's function using the Schur1D method
  Flat matrix size      : 339 × 339
  Flat deflated size    : 21 × 21
  Original element type : scalar (ComplexF64)
  Boundaries            : (0,)

julia> g0 = @btime g(0.2)
  22.541 ms (76 allocations: 9.93 MiB)
Schur1DGreensSolution : Schur1D solution of a GreensFunction at fixed ω
  ω             : 0.2 + 1.4901161193847656e-8im
  Matrix size   : 339 × 339
  Deflated size : 21 × 21
  Element type  : ComplexF64
  Boundary      : 0

julia> ldos = @time [(n,) => -imag.(diag(g0[n=>n])) for n in 1:5];
  0.073697 seconds (66.91 k allocations: 12.890 MiB, 64.73% compilation time)

julia> vlplot(h, ldos, sitesize = DensityShader(), maxthickness = 0.02)
```
<img width="859" alt="Screen Shot 2021-05-26 at 21 59 33" src="https://user-images.githubusercontent.com/4310809/119723424-b7d78680-be6d-11eb-9355-4c3b64ef55fb.png">
