### PR TITLE
Bandstructure extrema and gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
         version:
           - '1.5'
           - '1.6'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Pablo San-Jose"]
 version = "0.4.0"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 - `flatten`, `unflatten`, `orbitalstructure`: operate with multiorbital Hamiltonian, Kets or Subspaces
 - `cuboid`: build a bandstructure discretization mesh
 - `bandstructure`, `spectrum`, `diagonalizer`: compute the generalized bandstructure of a Hamiltonian or a ParametricHamiltonian
-- `bands`, `energies`, `states`: inspect spectrum and bandstructure objects
+- `bands`, `energies`, `states`, `minima`, `maxima`, `gapedges`, `gap`, `isinband`: inspect spectrum and bandstructure objects
 - `momentaKPM`, `dosKPM`, `averageKPM`, `densityKPM`, `bandrangeKPM`: Kernel Polynomial Method (KPM)
 - `greens`, `greensolver`: build Green's functions of a Hamiltonian
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 - `flatten`, `unflatten`, `orbitalstructure`: operate with multiorbital Hamiltonian, Kets or Subspaces
 - `cuboid`: build a bandstructure discretization mesh
 - `bandstructure`, `spectrum`, `diagonalizer`: compute the generalized bandstructure of a Hamiltonian or a ParametricHamiltonian
-- `bands`, `energies`, `states`, `minima`, `maxima`, `gapedges`, `gap`, `isinband`: inspect spectrum and bandstructure objects
+- `bands`, `energies`, `states`, `minima`, `maxima`, `gapedge`, `gap`, `isinband`: inspect spectrum and bandstructure objects
 - `momentaKPM`, `dosKPM`, `averageKPM`, `densityKPM`, `bandrangeKPM`: Kernel Polynomial Method (KPM)
 - `greens`, `greensolver`: build Green's functions of a Hamiltonian
 

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -26,7 +26,7 @@ export sublat, bravais, lattice, dims, supercell, unitcell,
        hamiltonian, parametric, bloch, bloch!, similarmatrix,
        flatten, unflatten, orbitalstructure, wrap, transform!, combine,
        spectrum, bandstructure, diagonalizer, cuboid, isometric, splitbands,
-       bands, vertices, minima, maxima, gapedges, gap, isinband,
+       bands, vertices, minima, maxima, gapedge, gap, isinband,
        energies, states, degeneracy,
        momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM,
        greens, greensolver, Schur1D

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -19,6 +19,8 @@ using SparseArrays: getcolptr, AbstractSparseMatrix, AbstractSparseMatrixCSC
 
 using Statistics: mean
 
+using Compat # for use of findmin/findmax in bandstructure.jl
+
 export sublat, bravais, lattice, dims, supercell, unitcell,
        hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector, nrange,
        sitepositions, siteindices, not,

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -26,7 +26,7 @@ export sublat, bravais, lattice, dims, supercell, unitcell,
        hamiltonian, parametric, bloch, bloch!, similarmatrix,
        flatten, unflatten, orbitalstructure, wrap, transform!, combine,
        spectrum, bandstructure, diagonalizer, cuboid, isometric, splitbands,
-       bands, vertices,
+       bands, vertices, minima, maxima, gapedges, gap, isinband,
        energies, states, degeneracy,
        momentaKPM, dosKPM, averageKPM, densityKPM, bandrangeKPM,
        greens, greensolver, Schur1D

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -942,7 +942,7 @@ end
 filter_around!(ss::Vector{<:Subspace}, ε0, which) = partialsort!(ss, which; by = s -> abs(s.energy - ε0))
 
 #######################################################################
-# Bandstructure minima, maxima, gap, gapedges
+# Bandstructure minima, maxima, gap, gapedge
 #######################################################################
 """
     minima(b::Bandstructure{1}; refinesteps = 0)
@@ -954,7 +954,7 @@ Only band vertices with one neighbors on each side will be considered as potenti
 minimum.
 
 # See also:
-    `maxima`, `gapedges`, `gap`
+    `maxima`, `gapedge`, `gap`
 """
 minima(b::Bandstructure{1,<:Any,T}; kw...) where {T} =
     Vector{Tuple{T,T}}[band_extrema(band, minimum_criterion, b.diag; kw...) for band in b.bands]
@@ -971,7 +971,7 @@ Only band vertices with one neighbors on each side will be considered as potenti
 maximum.
 
 # See also:
-    `minima`, `gapedges`, `gap`
+    `minima`, `gapedge`, `gap`
 """
 maxima(b::Bandstructure{1,<:Any,T}; kw...) where {T} =
     Vector{Tuple{T,T}}[band_extrema(band, maximum_criterion, b.diag; kw...) for band in b.bands]
@@ -1055,9 +1055,9 @@ Compute only `(φ₊, ε₊)` or `(φ₋, ε₋)`, respectively.
 # See also:
     `gap`, `minima`, `maxima`
 """
-gapedges(b::Bandstructure{1}, ε0; kw...) = gapedges(b, ε0, +; kw...), gapedges(b, ε0, -; kw...)
+gapedge(b::Bandstructure{1}, ε0; kw...) = gapedge(b, ε0, +; kw...), gapedge(b, ε0, -; kw...)
 
-function gapedges(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(+); kw...) where {T}
+function gapedge(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(+); kw...) where {T}
     isinband(b, ε0) && return (missing, zero(T))
     minbands = Iterators.flatten(filter!.(φε -> last(φε) > ε0, minima(b; kw...)))
     isempty(minbands) && return (missing, T(Inf))
@@ -1065,7 +1065,7 @@ function gapedges(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(+); kw...) where {T
     return (φ₊, ε₊)
 end
 
-function gapedges(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(-); kw...) where {T}
+function gapedge(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(-); kw...) where {T}
     isinband(b, ε0) && return (missing, zero(T))
     maxbands = Iterators.flatten(filter!.(φε -> last(φε) < ε0, maxima(b; kw...)))
     isempty(maxbands) && return (missing, T(-Inf))
@@ -1091,9 +1091,9 @@ isinband(b::Band, ε) = maximum(last, b.verts) > ε > minimum(last, b.verts)
 Compute the gap if a 1D bandstructure `b` around ε₀, if any.
 
 # See also:
-    `gapedges`, `minima`, `maxima`
+    `gapedge`, `minima`, `maxima`
 """
 function gap(b::Bandstructure{1}, ε0; kw...)
-    (_, ε₊), (_, ε₋) = gapedges(b, ε0; kw...)
+    (_, ε₊), (_, ε₋) = gapedge(b, ε0; kw...)
     return ε₊ - ε₋
 end

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -188,3 +188,23 @@ end
     @test first(d(())) ≈ [-3,3]
     @test all(d() .≈ Tuple(spectrum(h)))
 end
+
+@testset "bandstructure extrema" begin
+    h = LP.honeycomb() |>
+        hamiltonian(hopping(I) + onsite(0.1, sublats = :A) - onsite(0.1, sublats = :B)) |>
+        unitcell(3) |>
+        Quantica.wrap(1)
+    b = bandstructure(h, subticks = 20)
+    @test !isapprox(gap(b, 0; refinesteps = 0), 0.2)
+    @test isapprox(gap(b, 0; refinesteps = 1), 0.2)
+    @test isapprox(gap(b, 0.3; refinesteps = 1), 0)
+    @test isapprox(gap(b, 4; refinesteps = 1), Inf)
+    @test all(gapedges(b, 0, +; refinesteps = 1) .≈ (0, 0.1))
+    @test all(gapedges(b, 0, -; refinesteps = 1) .≈ (0, -0.1))
+    h = LP.honeycomb() |> hamiltonian(hopping(I)) |> Quantica.wrap(1)
+    b = bandstructure(h, subticks = 20)
+    length.(minima(b, refinesteps = 0)) == [2, 0]
+    length.(maxima(b, refinesteps = 0)) == [0, 2]
+    length.(minima(b, refinesteps = 1)) == [1, 0]
+    length.(maxima(b, refinesteps = 1)) == [0, 1]
+end

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -199,8 +199,8 @@ end
     @test isapprox(gap(b, 0; refinesteps = 1), 0.2)
     @test isapprox(gap(b, 0.3; refinesteps = 1), 0)
     @test isapprox(gap(b, 4; refinesteps = 1), Inf)
-    @test all(gapedges(b, 0, +; refinesteps = 1) .≈ (0, 0.1))
-    @test all(gapedges(b, 0, -; refinesteps = 1) .≈ (0, -0.1))
+    @test all(gapedge(b, 0, +; refinesteps = 1) .≈ (0, 0.1))
+    @test all(gapedge(b, 0, -; refinesteps = 1) .≈ (0, -0.1))
     h = LP.honeycomb() |> hamiltonian(hopping(I)) |> Quantica.wrap(1)
     b = bandstructure(h, subticks = 20)
     length.(minima(b, refinesteps = 0)) == [2, 0]


### PR DESCRIPTION
This introduces the following convenience functions for Bandstructure introspection, most defined for the moment only for 1D bandstructures for simplicity

- `minima(b::Bandstructure{1}; refinesteps = 0)`  and `maxima(b::Bandstructure; refinesteps = 0)`: finds all local minima and maxima of each band of `b`. A `refinesteps > 0` indicates the number of Newton-bisections to perform in search of the actual extremum. In this search, the Hamiltonian will be actually diagonalized in the bisection points using the same method that was used to compute `b` (through `b.diag::Diagonalizer`). Only band vertices that are local extrema without refinement will be considered as candidates for actual extrema, so that if a small gap is not resolved by the sampling of `b` it will not be found.
- `gapedge(b, ϵ0; kw...)`: computes two tuples `(φ₊, ε₊)` and `(φ₋, ε₋)` for gap edges immediately above and below energy ϵ0. `gapedge(b, ϵ0, +; kw...)` and `gapedge(b, ϵ0, -; kw...)` computes only the upper and lower edge, respectively. If ϵ0 is not inside a gap, `φ₊₋` will be `missing`. `kw...` are again `refinesteps`
- `gap(b, ϵ0; kw...)`: computes `ε₊-ε₋` from the above
- `isinband(b, ϵ0)`: determines if `ϵ0` is inside any of the bands in `b`. This one works for any dimension of `b::Bandstructure`, and also for `b::Band`.

Example: graphene with a gap. Note that the Dirac point is not sampled in the bandstructure, but it is located by refinement.
```
julia> h = LP.honeycomb() |>
               hamiltonian(hopping(I) + onsite(0.1, sublats = :A) - onsite(0.1, sublats = :B)) |>
               unitcell(3) |>
               wrap(1);

julia> b = bandstructure(h, subticks = 20);

julia> vlplot(b)

julia> gapedge(b, 0.0; refinesteps = 1)
((0.0, 0.10000000000000094), (0.0, -0.09999999999999987))

julia> gapedge(b, 1.0; refinesteps = 1)
((missing, 0.0), (missing, 0.0))

julia> gap(b, 0; refinesteps = 1)
0.2000000000000008
```
<img width="442" alt="Screen Shot 2021-06-01 at 19 21 21" src="https://user-images.githubusercontent.com/4310809/120365315-91eb2f80-c30e-11eb-9c42-fff632bf429b.png">
