### PR TITLE
`source` and `dest` for scalar greens functions

### DIFF
--- a/src/greens.jl
+++ b/src/greens.jl
@@ -25,14 +25,19 @@ origin.
 
 Curried form equivalent to the above, giving `greens(h, solveobject(h), args...)`.
 
-    g(ω, cells::Pair)
-    g(ω)[cells::Pair]
+    g(ω, cells::Pair; source = I, dest = I)
+    g(ω; source = I, dest = I)[cells::Pair]
 
 From a constructed `g::GreensFunction`, obtain the retarded Green's function matrix at
 frequency `ω` between unit cells `src` and `dst`, where `src, dst` are `::NTuple{L,Int}` or
 `SVector{L,Int}`. If allowed by the used `solveobject`, `g0=g(ω)` builds an solution object
 that can efficiently produce the Greens function between different cells at fixed `ω` with
 `g0[cells]` without repeating cell-independent parts of the computation.
+
+Keywords `source` and `dest` are matrices, possibly non-square, that act as projectors, so
+that `g(ω, ...; source = S, dest = D) = D'*g(ω,...)*S`, which avoinds building the full-cell
+intermediate `g(ω,...)` for efficiency. If `source` and/or `dest` are not `AbstractMatrix`,
+but an iterable of sites, `S` and `D` will be constructed as projectors onto said sites.
 
 # Examples
 

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -85,5 +85,7 @@ end
 
 @testset "greens partial solutions" begin
     g = LatticePresets.honeycomb() |> hamiltonian(hopping(-I)) |> unitcell((3,0), region = r->0<r[2]<5) |> greens(Schur1D())
-    @test g(0.2, 1=>1; source = (1,6), dest = (1,6)) ≈ g(0.2, 1=>1)[[1,6],[1,6]]
+    @test g(0.2, 2=>3; source = (1,6), dest = (1,6)) ≈ g(0.2, 2=>3)[[1,6],[1,6]]
+    g = LatticePresets.honeycomb() |> hamiltonian(hopping(-I), orbitals = Val(2)) |> unitcell((3,0), region = r->0<r[2]<5) |> greens(Schur1D())
+    @test_throws ArgumentError g(0.2, 1=>1; source = (1,6), dest = (1,6))
 end

--- a/test/test_greens.jl
+++ b/test/test_greens.jl
@@ -82,3 +82,8 @@ end
         end
     end
 end
+
+@testset "greens partial solutions" begin
+    g = LatticePresets.honeycomb() |> hamiltonian(hopping(-I)) |> unitcell((3,0), region = r->0<r[2]<5) |> greens(Schur1D())
+    @test g(0.2, 1=>1; source = (1,6), dest = (1,6)) ≈ g(0.2, 1=>1)[[1,6],[1,6]]
+end


### PR DESCRIPTION
This allows partial evaluation of Greens functions, specifying source and a destination sites for the propagator. The Green function matrix is computed only within the specified subspace for efficiency.
```
julia> g = LatticePresets.honeycomb() |> hamiltonian(hopping(-I)) |> unitcell((3,0), region = r->0<r[2]<5) |> greens(Schur1D())
GreensFunction{Schur1DGreensSolver}: Green's function using the Schur1D method
  Flat matrix size      : 36 × 36
  Flat deflated size    : 3 × 3
  Original element type : scalar (ComplexF64)
  Boundaries            : (missing,)

julia> @test g(0.2, 1=>1; source = (1,6), dest = (1,6)) ≈ g(0.2, 1=>1)[[1,6],[1,6]]
Test Passed
```

An important limitation of the current PR is that it does not support `source` and `dest` for multiorbital Hamiltonians. The reason is that supporting that case requires generalizing the `flatten`/`unflatten` machinery, which was designed with `Hamiltonian`s and `Ket`s in mind. It becomes quite tricky to flatten and unflatten reliably on a subset of sites. It also requires generalizing the API for `flatten`/`unflatten`, which should then admit things like `flatten(matrix, orbstruct; source = ..., dest = ...)`. In the mono-orbital case, the internal calls to flatten and unflatten the Green's function matrices are no-ops, so this problem does not arise.