### PR TITLE
New `basiskets` ket model, and `singlesitekets` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Quantica.jl package provides an expressive API to build arbitrary quantum sy
 - `parametric`, `@onsite!`, `@hopping!`, `parameters`: build a parametric Hamiltonian
 - `dims`, `sitepositions`, `siteindices`, `bravais`: inspect lattices and Hamiltonians
 - `supercell`, `unitcell`, `wrap`, `transform!`, `combine`: build derived lattices or Hamiltonians
-- `ket`, `randomkets`: define ket models for use in e.g. KPM routines
+- `ket`, `ketmodel`, `randomkets`, `basiskets`: define kets and ket models for use in e.g. KPM routines
 - `flatten`, `unflatten`, `orbitalstructure`: operate with multiorbital Hamiltonian, Kets or Subspaces
 - `cuboid`: build a bandstructure discretization mesh
 - `bandstructure`, `spectrum`, `diagonalizer`: compute the generalized bandstructure of a Hamiltonian or a ParametricHamiltonian

--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -28,6 +28,23 @@ randomkets(n::Int, a = r -> cis(2pi*rand()); kw...) =
     Iterators.repeated(ketmodel(a; normalization = 1/√n, kw...), n)
 
 #######################################################################
+# basiskets
+#######################################################################
+"""
+    basiskets(a = I; kw...)
+
+Create a multicolumn ket model that represents a basis for sites selected by
+`siteselctor(kw...)`, with amplitude `a` on each site. For hamiltonians with `N` orbitals
+per site, `a` will need to be either `I` or a matrix with `N` columns. 
+
+`basiskets(a; kw...)` is equivalent to `ketmodel(a; singlesitekets = true, kw...)`.
+
+# See also
+    `ket`
+"""
+basiskets(a = I; kw...) = ketmodel(a; singlesitekets = true, kw...)
+
+#######################################################################
 # Kernel Polynomial Method : momenta
 #######################################################################
 using Base.Threads

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -24,7 +24,7 @@ using Compat # for use of findmin/findmax in bandstructure.jl
 export sublat, bravais, lattice, dims, supercell, unitcell,
        hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector, nrange,
        sitepositions, siteindices, not,
-       ket, ketmodel, randomkets,
+       ket, ketmodel, randomkets, basiskets,
        hamiltonian, parametric, bloch, bloch!, similarmatrix,
        flatten, unflatten, orbitalstructure, wrap, transform!, combine,
        spectrum, bandstructure, diagonalizer, cuboid, isometric, splitbands,

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -828,7 +828,8 @@ sitepositions(h::Hamiltonian; kw...) = sitepositions(h.lattice, siteselector(;kw
 
 """
     siteindices(lat::AbstractLattice; kw...)
-    siteindices(lat::Hamiltonian; kw...)
+    siteindices(h::Hamiltonian; kw...)
+    siteindices(lat_or_h, s::SiteSelector)
 
 Build a generator of the unique indices of sites in the lattice unitcell. Only sites
 specified by `siteselector(kw...)` are selected, see `siteselector` for details.
@@ -836,6 +837,7 @@ specified by `siteselector(kw...)` are selected, see `siteselector` for details.
 """
 siteindices(lat::AbstractLattice; kw...) = siteindices(lat, siteselector(;kw...))
 siteindices(h::Hamiltonian; kw...) = siteindices(h.lattice, siteselector(;kw...))
+siteindices(h::Hamiltonian, s::SiteSelector) = siteindices(h.lattice, s)
 
 """
     transform!(f::Function, h::Hamiltonian)

--- a/test/test_ket.jl
+++ b/test/test_ket.jl
@@ -75,3 +75,28 @@ end
     Quantica.ket!(kf, ketmodel(SA[1 1]; maporbitals = true), h)
     @test unflatten(kf, orbitalstructure(k)) == k
 end
+
+@testset "ket algebra" begin
+    h = LatticePresets.honeycomb() |> hamiltonian(hopping(I), orbitals = (Val(1), Val(3))) |> unitcell(2)
+    km = 2*ketmodel(SA[1 1], sublats = :A) + ketmodel(SA[1 1; 0 0; 1 1], sublats = :B)
+    k = ket(km, h)
+    @test size(k) == (8,2)
+    @test all(k[1:4, 1:2] .== Ref(k[1,1]))
+    @test all(k[5:8, 1:2] .== Ref(k[5,1]))
+    km = ketmodel(SA[1 1], sublats = :A) - 2*ketmodel(SA[1; 0; 1], sublats = :B)
+    @test_throws ArgumentError ket(km, h)
+    km = ketmodel(1, sublats = :A) - 2*ketmodel(SA[1 2; 0 1; 1 1], sublats = :B, singlesitekets = true)
+    k = ket(km, h)
+    @test size(k) == (8, 12)
+    km = ketmodel(I, sublats = :A) + 2*ketmodel(I, sublats = :B, singlesitekets = true)
+    k = ket(km, h)
+    @test size(k) == (8, 16)
+    @test parent(flatten(k)) == I
+    km = basiskets()
+    k´ = ket(km, h)
+    @test k == k´
+    km = ketmodel(I, sublats = :A) + ketmodel(SA[1 0 0; 0 1 0; 0 0 -1], sublats = :B, singlesitekets = true)
+    k = ket(km, h)
+    @test size(k) == (8, 16)
+    @test parent(flatten(k)) != I && abs.(parent(flatten(k))) == I
+end

--- a/test/test_ket.jl
+++ b/test/test_ket.jl
@@ -96,6 +96,7 @@ end
     k´ = ket(km, h)
     @test k == k´
     km = ketmodel(I, sublats = :A) + ketmodel(SA[1 0 0; 0 1 0; 0 0 -1], sublats = :B, singlesitekets = true)
+    @test km.singlesitekets == true
     k = ket(km, h)
     @test size(k) == (8, 16)
     @test parent(flatten(k)) != I && abs.(parent(flatten(k))) == I


### PR DESCRIPTION
The current ket model functionality `km = ketmodel(a; kw...)` builds a single or multicolumn ket model that, when applied to hamiltonian `h` with `ket(km, h)` produces a ket with amplitude `a` on *all* sites selected by `siteselector(;kw...)`. 

This is great e.g. for KPM with stochastic traces, where you want all sites in a region of interest to have independent random amplitudes. You could then just do `ketmodel(r->randn(); region = myregion)` for a single realization, or `randomkets(n, r ->randn(); region = myregion)` for `n` realizations. 

But imagine you don't want to use stochastic traces. You want the local DOS with KPM using a ket basis for all sites and orbitals in `myregion` containing `N` single-orbital sites. You want to build an N-column ket with amplitude `1` on each site, and zero on the rest. In other words, you don't want `a` applied to all sites in `myregion`, but rather `a` on a single site per column. There is currently no easy way to do that.

This PR adds a new `singlesitekets` keyword to `ketmodel` that enables this. It ensures that each site gets its own column of the resulting ket, with amplitude `a`. If the model has several terms (e.g. when you sum two `KetModel`s) each term will produce its own set of columns. Summing two terms where either is `singlesitekets = true` will have `singlesitekets = true`. We also enable `a=I` with `singlesitekets = true`, which then expands `I` to have the proper dimension for each sublattice.

So, to build a basis for a generic ket basis over `myregion` (single or multiorbital, homogeneous or heterogeneous) we now just do `ketmodel(I; region = myregion, singlesitekets = true)`. This PR also adds a convenience function for this kind of model, that complements `randomkets`, called `basiskets(a = I; kw...)`.