### PR TITLE
New `@block!`: a block-wise `ParametricHamiltonian` modifier

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -22,7 +22,7 @@ using Statistics: mean
 using Compat # for use of findmin/findmax in bandstructure.jl
 
 export sublat, bravais, lattice, dims, supercell, unitcell,
-       hopping, onsite, @onsite!, @hopping!, parameters, siteselector, hopselector, nrange,
+       hopping, onsite, @onsite!, @hopping!, @block!, parameters, siteselector, hopselector, nrange,
        sitepositions, siteindices, not,
        ket, ketmodel, randomkets, basiskets,
        hamiltonian, parametric, bloch, bloch!, similarmatrix,

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -170,9 +170,9 @@ end
 issquare(a::AbstractMatrix) = size(a, 1) == size(a, 2)
 
 # normalize_axis_directions(q::SMatrix{M,N}) where {M,N} = hcat(ntuple(i->q[:,i]*sign(q[i,i]), Val(N))...)
-
-padprojector(::Type{S}, ::Val{N}) where {M,N,S<:SMatrix{M,M}} = S(Diagonal(SVector(padright(filltuple(1, Val(N)), Val(M)))))
-padprojector(::Type{S}, ::NTuple{N,Any}) where {S,N} = padprojector(S, Val(N))
+padprojector(::Type{S}, ::NTuple{N,Any}) where {S,N} = padprojector(S, N)
+padprojector(::Type{S}, n::Integer) where {M,T,S<:SMatrix{M,M,T}} =
+    S(Diagonal(SVector(ntuple(i -> ifelse(i > n, zero(T), one(T)), Val(M)))))
 
 _blockdiag(s1::SMatrix{E1,L1,T1}, s2::SMatrix{E2,L2,T2}) where {E1,L1,T1,E2,L2,T2} = hcat(
     ntuple(j->vcat(s1[:,j], zero(SVector{E2,T2})), Val(L1))...,

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -415,7 +415,7 @@ end
     ph = h |> parametric(@onsite!((o; λ=0) -> o - λ*I), @block!((b; λ=0) -> b + λ*I, sites))
     @test_throws ArgumentError ph(λ = 1)
     ph = h |> parametric(@onsite!((o; λ=0) -> o - λ*I), @block!((b; λ=0) -> b + λ*I, sites); check = false)
-    @test ph(λ = 1) isa Quantica.Hamiltonian
+    @test ph(λ = 1) isa Hamiltonian
     sites = siteindices(h, region = r->r[1]<0, sublats = :B);
     ph = h |> parametric(@onsite!((o; λ=0) -> o - λ*I; sublats = :B), @block!((b; λ=0) -> b + λ*I, sites))
     h3 = ph(λ = 3)


### PR DESCRIPTION
Our `@onsite!` and `@hopping!` create `ElementModifier <: AbstractModifier` that are great to build parametric Hamiltonians defined though modification of individual matrix elements. However they don't easily lend themselves to tasks involving the modification of whole blocks of a Hamiltonian, for example when needing to add a self-energy from a lead to a certain subset of contact sites. In that case you need a way to evaluate the self-energy block once (for a given parameter like the frequency or the contact transparency), and then apply it to a subset of sites, instead of evaluating the modification (the self energy) once per site or hopping to be modified (as `@onsite!` and `@hopping!` do).

This PR provides a new `BlockModifier <: AbstractModifier`, created with `@block!((block; params...) -> modified_block, rows, cols; dn = missing)`, to be applied to `block = h[dn][rows, cols]` of a Hamiltonian `h`. The default `dn = missing` represents `dn = (0...)`, but can be one or several `dn`s. A convenience `@block!(... -> ..., sites; kw...)` equivalent to `@block(... -> ..., sites, sites; kw...)` is also provided for blocks in the diagonal.

As a usage example, 
```julia
sites = siteindices(h, region = contactregion)
ph = h |> parametric((b; ω=0) -> b + Σ(ω), sites)
```
This would build a parametric Hamiltonian `ph(; ω)` with a self energy `Σ(ω)::AbstractMatrix` in `contactregion::Function`.

Simultaneously, we introduce a new `check` kwarg in `parametric(...; check = true)` that in the inhomogeneous multiorbital case, performs a check to see if the modifiers provided by the user preserves the correct internal structure of matrix elements, consistent with the orbitals in each site. We didn't have this check until now, which could easily lead to subtle bugs whereby the Hamiltonian ended up internally inconsistent. 

Since this is an easy footgun to run into when writing modifiers in the most general case, `check = true` is the default. The downside is that, since the check needs to run on each call `ph(; params...)`, it can have a significant performance impact. So the user might want to switch to `check = false` after ensuring his/her modifiers are correct. If all sublattices have the same number of orbitals, however, the check is unnecessary and is skipped, and the performance cost of the default is completely negligible.