### PR TITLE
Fix compatibility issues with v1.7+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         version:
           - '1.5'
           - '1.6'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.5'
+          - '1'
           - '1.6'
           - 'nightly'
         os:

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -1,6 +1,7 @@
 module Quantica
 
 # Use README as the docstring of the module:
+using Base.Threads: Iterators
 @doc read(joinpath(dirname(@__DIR__), "README.md"), String) Quantica
 
 using Requires
@@ -19,7 +20,7 @@ using SparseArrays: getcolptr, AbstractSparseMatrix, AbstractSparseMatrixCSC
 
 using Statistics: mean
 
-using Compat # for use of findmin/findmax in bandstructure.jl
+using Compat # for use of argmin/argmax in bandstructure.jl
 
 export sublat, bravais, lattice, dims, supercell, unitcell,
        hopping, onsite, @onsite!, @hopping!, @block!, parameters, siteselector, hopselector, nrange,

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -1033,7 +1033,7 @@ function refine_bisection(found, neighs, steps, criterion, diag)
 end
 
 select_closest(εs, criterion, ε0, εi...) =
-    last(findmin(ε -> ifelse(criterion(ε, ε0, εi...), abs(ε - ε0), Inf), εs))
+    argmin(ε -> ifelse(criterion(ε, ε0, εi...), abs(ε - ε0), Inf), εs)
 
 """
     gapedge(b::Bandstructure{1}, ε₀; refinesteps = 0)
@@ -1057,7 +1057,7 @@ function gapedge(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(+); kw...) where {T}
     isinband(b, ε0) && return (missing, zero(T))
     minbands = Iterators.flatten(filter!.(φε -> last(φε) > ε0, minima(b; kw...)))
     isempty(minbands) && return (missing, T(Inf))
-    (φ₊, ε₊) = findmin(last, minbands) |> last
+    (φ₊, ε₊) = argmin(last, minbands)
     return (φ₊, ε₊)
 end
 
@@ -1065,7 +1065,7 @@ function gapedge(b::Bandstructure{1,<:Any,T}, ε0, ::typeof(-); kw...) where {T}
     isinband(b, ε0) && return (missing, zero(T))
     maxbands = Iterators.flatten(filter!.(φε -> last(φε) < ε0, maxima(b; kw...)))
     isempty(maxbands) && return (missing, T(-Inf))
-    (φ₋, ε₋) = findmax(last, maxbands) |> last
+    (φ₋, ε₋) = argmax(last, maxbands)
     return (φ₋, ε₋)
 end
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -163,7 +163,11 @@ end
 pinverse(::SMatrix{E,0,T}) where {E,T} = SMatrix{0,E,T}() # BUG: workaround StaticArrays bug SMatrix{E,0,T}()'
 
 function pinverse(m::SMatrix)
-    qrm = qr(m)
+    @static if VERSION >= v"1.7.0-beta2"
+        qrm = qr(m, NoPivot())
+    else
+        qrm = qr(m)
+    end
     return inv(qrm.R) * qrm.Q'
 end
 


### PR DESCRIPTION
@Max-Borovkov encountered an ambiguity issue with `qr(::SMatrix)` that arose after https://github.com/JuliaLang/julia/pull/40623. Until StaticArrays.jl catches up and/or Julialang fixes the ambiguity, this PR creates a special codepath for v1.7-beta2+ that employs the updated `qr(::SMatrix, NoPivot())` explicit syntax. Also added nightly to CI, let's see what it says.