### PR TITLE
Ensure sorted dosKPM

### DIFF
--- a/src/KPM.jl
+++ b/src/KPM.jl
@@ -350,6 +350,8 @@ function densityKPM(momenta::MomentaKPM{T}; resolution = 2) where {T}
     xk = [cos(π * (k + 0.5) / numpoints) for k in 0:numpoints - 1]
     @. ρlist = center + halfwidth * ρlist / (π * sqrt(1.0 - xk^2))
     @. xk = center + halfwidth * xk
+    reverse!(xk)
+    reverse!(ρlist)
     return xk, ρlist
 end
 

--- a/test/test_KPM.jl
+++ b/test/test_KPM.jl
@@ -10,6 +10,8 @@ using ArnoldiMethod, Random, FFTW
     @test abs(m1.mulist[1]) ≈ abs(m2.mulist[1])
     dos1 = dosKPM(h, order = 10, bandrange = (-3,3), ket = randomkets(1, maporbitals = true))
     dos2 = dosKPM(h, order = 10, bandrange = (-3,3), ket = randomkets(1, r -> randn(), maporbitals = true))
+    @test issorted(first(dos1))
+    @test issorted(first(dos2))
     @test all(>(0), last(dos1))
     @test all(>(0), last(dos2))
     dos = dosKPM(h, order = 10, bandrange = (-3,3), ket = randomkets(2, r -> randn() * SA[1 0; 0 -1], sublats = :B))


### PR DESCRIPTION
Previously, `densityKPM`, and `dosKPM` in particular, returned a tuple `(energies, dos)` with `energies` and `dos` in reverse order (decreasing energies).