### PR TITLE
Implement spectrum(h, phi)

### DIFF
--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -92,10 +92,10 @@ $i  Subspaces    : $(length(s.subs))")
 end
 
 """
-    spectrum(h; method = LinearAlgebraPackage(), transform = missing)
+    spectrum(h, φs; method = LinearAlgebraPackage(), transform = missing)
 
-Compute the spectrum of a 0D Hamiltonian `h` (or alternatively of the bounded unit cell of a
-finite dimensional `h`) using one of the following `method`s
+Compute the spectrum of a Hamiltonian `h` at Bloch phases φs (or at zero if φs is not given)
+using one of the following `method`s
 
     method                    diagonalization function
     --------------------------------------------------------------
@@ -127,9 +127,10 @@ independent copy.
 # See also
     `bandstructure`, `diagonalizer`
 """
-function spectrum(h; method = LinearAlgebraPackage(), transform = missing)
+
+function spectrum(h, φs = zerocell(h); method = LinearAlgebraPackage(), transform = missing)
     diag = diagonalizer(h; method = method)
-    (ϵk, ψk) = diag((), NoUnflatten())
+    (ϵk, ψk) = diag(φs, NoUnflatten())
     s = Spectrum(ϵk, ψk, diag)
     transform === missing || transform!(transform, s)
     return s

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -869,6 +869,8 @@ latdim(h::Hamiltonian) = last(dims(h.lattice))
 
 matrixtype(::Hamiltonian{LA,L,M,A}) where {LA,L,M,A} = A
 
+zerocell(h::Hamiltonian) = zerocell(h.lattice)
+
 blockeltype(::Hamiltonian{<:Any,<:Any,M}) where {M} = eltype(M)
 
 # find SMatrix type that can hold all matrix elements between lattice sites

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -280,6 +280,8 @@ function lattice(lat::Lattice; bravais = bravais(lat), kw...)
 end
 lattice(; kw...) = lat -> lattice(lat; kw...)
 
+zerocell(::Lattice{<:Any,L}) where {L} = zero(SVector{L,Int})
+
 #######################################################################
 # Supercell
 #######################################################################


### PR DESCRIPTION
Implements `spectrum(h, phi; kw...)` for unbounded Hamiltonians, where `phi` is a bloch phase