### PR TITLE
Fix adding eps shift to integer omega

### DIFF
--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -50,7 +50,7 @@ call!(g::GreenSlice, ω; params...) =
     call!(greenfunction(g), ω; params...)[slicerows(g), slicecols(g)]
 
 retarded_omega(ω::T, s::AppliedGreenSolver) where {T<:Real} =
-    ω + im * sqrt(eps(T)) * needs_omega_shift(s)
+    ω + im * sqrt(eps(float(T))) * needs_omega_shift(s)
 
 # fallback, may be overridden
 needs_omega_shift(s::AppliedGreenSolver) = true

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -6,6 +6,7 @@ function testgreen(h, s; kw...)
     @test g isa GreenFunction
     gω = g(ω; kw...)
     @test gω isa GreenSolution
+    @test g(0) isa GreenSolution # promote Int to AbstractFloat to add eps
     L = Quantica.latdim(lattice(h))
     z = zero(SVector{L,Int})
     o = Quantica.unitvector(1, SVector{L,Int})


### PR DESCRIPTION
For `g::GreenFunction`, `g(0)` would fail because `eps(Int)` is not defined.