### PR TITLE
Fix missing flat_sync!

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1219,6 +1219,14 @@ bloch(h::Hamiltonian) = h.bloch
 minimal_callsafe_copy(h::Hamiltonian) = Hamiltonian(
     lattice(h), blockstructure(h), copy.(harmonics(h)), copy_matrices(bloch(h)))
 
+function flat_sync!(h::Hamiltonian)
+    for har in harmonics(h)
+        harmat = matrix(har)
+        needs_flat_sync(harmat) && flat_sync!(harmat)
+    end
+    return h
+end
+
 Base.size(h::Hamiltonian, i...) = size(bloch(h), i...)
 Base.axes(h::Hamiltonian, i...) = axes(bloch(h), i...)
 

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -31,6 +31,9 @@ end
     for (h, s) in zip((h0, h1, h1), (s0, s1, s1´))
         testgreen(h, s; o = 2)
     end
+    # This ensures that flat_sync! is called with multiorbitals when call!-ing ph upon calling g
+    g = LP.square() |> hamiltonian(@onsite(()->I), orbitals = 2) |> supercell |> greenfunction
+    @test g[](0.0 + 0im) ≈ SA[-1 0; 0 -1]
 end
 
 @testset "greenfunction with contacts" begin


### PR DESCRIPTION
In multiorbital systems, calling a `g(ω; params...)` of a GreenFunction of a parametric Hamiltonian performed a `call!(ph; params...)`, which updated the unflat portion of its harmonics, but not the flat portion, yielding a wrong result. This ensures that `call!(ph; params...)` does a `flat_sync!` after applying modifiers if required.