### PR TITLE
Optimization: don't apply mask block for scalar eltypes

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -112,13 +112,13 @@ end
 function apply(o::OnsiteTerm, (lat, os)::Tuple{Lattice{T,E,L},OrbitalBlockStructure{B}}) where {T,E,L,B}
     f = (r, orbs) -> mask_block(B, o(r), (orbs, orbs))
     asel = apply(selector(o), lat)
-    return AppliedOnsiteTerm{T,E,L,B}(f, asel)   # f gets wrapped in a FunctionWrapper
+    return AppliedOnsiteTerm{T,E,L,B}(f, asel)         # f gets wrapped in a FunctionWrapper
 end
 
 function apply(t::HoppingTerm, (lat, os)::Tuple{Lattice{T,E,L},OrbitalBlockStructure{B}}) where {T,E,L,B}
     f = (r, dr, orbs) -> mask_block(B, t(r, dr), orbs)
     asel = apply(selector(t), lat)
-    return AppliedHoppingTerm{T,E,L,B}(f, asel)  # f gets wrapped in a FunctionWrapper
+    return AppliedHoppingTerm{T,E,L,B}(f, asel)        # f gets wrapped in a FunctionWrapper
 end
 
 apply(m::TightbindingModel, latos) = TightbindingModel(apply.(terms(m), Ref(latos)))

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -540,4 +540,3 @@ end
 
 #endregion
 #endregion
-

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -184,7 +184,7 @@ end
         h = LatticePresets.honeycomb() |> hamiltonian(hopping((r, dr) -> 1/norm(dr) * I, range = 10), orbitals = o)
         @test_throws ArgumentError wrap(h, (1,2,3))
         @test_throws ArgumentError wrap(h, 1)
-        wh = wrap(h, (1,2))
+        wh = h |> wrap((1,2))
         @test wh(()) ≈ h(SA[1,2])
         wh = wrap(h, (1,:))
         @test wh(SA[2]) ≈ h(SA[1,2])
@@ -230,6 +230,11 @@ end
         @test unflat(Quantica.HybridSparseMatrix(bs, hunflat)) == hunflat
         @test Quantica.flat(Quantica.HybridSparseMatrix(bs, hunflat)) == hflat
         @test unflat(Quantica.HybridSparseMatrix(bs, hflat)) == hunflat
+        # Tampering protection
+        h[(1,0)][1,1] = 1
+        @test_throws ArgumentError h[(1,0)]
+        @test h[unflat(0,0)] isa Quantica.SparseMatrixCSC
+        @test_throws ArgumentError h((0,0))
     end
 end
 


### PR DESCRIPTION
We were relying on the compiler to elide the `mask_block` of Modifiers and ModelTerms when the eltype is a number, but it is not quite able to do so. Here we special case scalar eltypes so that `mask_block` is not even called. Gains of around 30% in runtime observed for ParametricHamiltonian calls of size 20000

CC: @BacAmorim