### PR TITLE
More logical behavior of wrap and supercell of ParametricHamiltonian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.9'
-          - 'nightly'
+          - '1'
+          # - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -431,7 +431,7 @@ end
 
 # For E < 2 Hamiltonians, promote to 2D
 function Makie.plot!(plot::PlotLattice{Tuple{H}}) where {T,H<:Hamiltonian{T,1}}
-    h = Hamiltonian{T,2}(to_value(plot[1]))
+    h = Hamiltonian{2}(to_value(plot[1]))
     return plotlattice!(plot, h; plot.attributes...)
 end
 

--- a/ext/QuanticaMakieExt/tools.jl
+++ b/ext/QuanticaMakieExt/tools.jl
@@ -34,6 +34,7 @@ safeextrema(v) = isempty(v) ? (Float32(0), Float32(1)) : extrema(v)
 function empty_fig_axis_2D(default_figure, default_axis2D; axis = (;), figure = (;), kw...)
     fig = Figure(; default_figure..., figure...)
     ax = Axis(fig[1,1]; default_axis2D..., axis...)
+    tight_ticklabel_spacing!(ax) # Workaround for Makie issue #3009
     return fig, ax
 end
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -22,18 +22,18 @@ Sublat{T,E}(s::Sublat, name = s.name) where {T<:AbstractFloat,E} =
 CellSites{L,V}(c::CellSites) where {L,V} =
     CellSites{L,V}(convert(SVector{L,Int}, cell(c)), convert(V, siteindices(c)))
 
-function Hamiltonian{T,E}(h::Hamiltonian) where {T,E}
+function Hamiltonian{E}(h::Hamiltonian) where {E}
     lat = lattice(h)
-    lat´ = lattice(lat, dim = Val(E), type = T)
+    lat´ = lattice(lat, dim = Val(E))
     bs = blockstructure(h)
     hs = harmonics(h)
     b = bloch(h)
     return Hamiltonian(lat´, bs, hs, b)
 end
 
-function ParametricHamiltonian{T,E}(ph::ParametricHamiltonian) where {T,E}
-    hparent = Hamiltonian{T,E}(parent(ph))
-    h = Hamiltonian{T,E}(hamiltonian(ph))
+function ParametricHamiltonian{E}(ph::ParametricHamiltonian) where {E}
+    hparent = Hamiltonian{E}(parent(ph))
+    h = Hamiltonian{E}(hamiltonian(ph))
     ms = modifiers(ph)
     ptrs = pointers(ph)
     pars = parameters(ph)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -137,7 +137,8 @@ hamiltonian(lat::Lattice, m0::ParametricModel, ms::Modifier...; kw...) =
 hamiltonian(lat::Lattice, m::Modifier, ms::Modifier...; kw...) =
     parametric(hamiltonian(lat; kw...), m, ms...)
 
-hamiltonian(h::AbstractHamiltonian, m::Modifier, ms::Modifier...) = parametric(h, m, ms...)
+hamiltonian(h::AbstractHamiltonian, m::AbstractModifier, ms::AbstractModifier...) =
+    parametric(h, m, ms...)
 
 hamiltonian(lat::Lattice, m::AbstractBlockModel{<:TightbindingModel}; kw...) =
     hamiltonian(lat, parent(m), block(m); kw...)
@@ -226,17 +227,17 @@ function parametric(hparent::Hamiltonian)
 end
 
 parametric(h::Hamiltonian, m::AbstractModifier, ms::AbstractModifier...) =
-    _parametric!(parametric(h), m, ms...)
+    parametric!(parametric(h), m, ms...)
 parametric(p::ParametricHamiltonian, ms::AbstractModifier...) =
-    _parametric!(copy(p), ms...)
+    parametric!(copy(p), ms...)
 
 # This should not be exported, because it doesn't modify p in place (because of modifiers)
-function _parametric!(p::ParametricHamiltonian, ms::Modifier...)
+function parametric!(p::ParametricHamiltonian, ms::Modifier...)
     ams = apply.(ms, Ref(parent(p)))
-    return _parametric!(p, ams...)
+    return parametric!(p, ams...)
 end
 
-function _parametric!(p::ParametricHamiltonian, ms::AppliedModifier...)
+function parametric!(p::ParametricHamiltonian, ms::AppliedModifier...)
     hparent = parent(p)
     h = hamiltonian(p)
     allmodifiers = (modifiers(p)..., ms...)
@@ -361,7 +362,7 @@ function reset_to_parent!(ph)
         nz = nonzeros(needs_initialization(m) ? unflat(m) : unflat_unsafe(m))
         nz´ = nonzeros(unflat(m´))
         if length(ptrs) < length(nz) * nnzfraction
-            @simd for ptr in ptrs
+            for ptr in ptrs
                 nz[ptr] = nz´[ptr]
             end
         else
@@ -378,7 +379,7 @@ applymodifiers!(h, m::Modifier; kw...) = applymodifiers!(h, apply(m, h); kw...)
 
 function applymodifiers!(h, m::AppliedOnsiteModifier; kw...)
     nz = nonzeros(unflat(first(harmonics(h))))
-    @simd for p in pointers(m)
+    for p in pointers(m)
         (ptr, r, norbs) = p
         @inbounds nz[ptr] = m(nz[ptr], r, norbs; kw...)   # @inbounds too risky?
     end
@@ -387,7 +388,7 @@ end
 
 function applymodifiers!(h, m::AppliedOnsiteModifier{B}; kw...) where {B<:SMatrixView}
     nz = nonzeros(unflat(first(harmonics(h))))
-    @simd for p in pointers(m)
+    for p in pointers(m)
         (ptr, r, norbs) = p
         val = view(nz[ptr], 1:norbs, 1:norbs)  # this might be suboptimal - do we need view?
         @inbounds nz[ptr] = m(val, r, norbs; kw...)      # this allocates, currently unavoidable
@@ -398,7 +399,7 @@ end
 function applymodifiers!(h, m::AppliedHoppingModifier; kw...)
     for (har, ptrs) in zip(harmonics(h), pointers(m))
         nz = nonzeros(unflat(har))
-        @simd for p in ptrs
+        for p in ptrs
             (ptr, r, dr, orborb) = p
             @inbounds nz[ptr] = m(nz[ptr], r, dr, orborb; kw...)
         end
@@ -409,7 +410,7 @@ end
 function applymodifiers!(h, m::AppliedHoppingModifier{B}; kw...) where {B<:SMatrixView}
     for (har, ptrs) in zip(harmonics(h), pointers(m))
         nz = nonzeros(unflat(har))
-        @simd for p in ptrs
+        for p in ptrs
             (ptr, r, dr, (norbs, norbs´)) = p
             val = view(nz[ptr], 1:norbs, 1:norbs´)    # this might be suboptimal - do we need view?
             @inbounds nz[ptr] = m(val, r, dr, (norbs, norbs´); kw...) # this allocates, unavoidable
@@ -517,7 +518,7 @@ end
 #endregion
 
 ############################################################################################
-# wrap
+# wrap(::Hamiltonian, phases)
 #region
 
 wrap(phases) = h -> wrap(h, phases)
@@ -571,11 +572,63 @@ function summed_harmonic(inds, hars::Vector{<:Harmonic{<:Any,<:Any,B}}, phases_w
     return Harmonic(dn_u, HybridSparseMatrix(bs, mat))
 end
 
+#endregion
+
+############################################################################################
+# wrap(::ParametricHamiltonian, phases)
+#region
+
 function wrap(p::ParametricHamiltonian, phases)
-    h´ = wrap(parent(p), phases)
-    ms = parent.(modifiers(p))
-    p´ = hamiltonian(h´, ms...)
+    wa, ua = split_axes(phases)  # indices for wrapped and unwrapped axes
+    iszero(length(wa)) && return minimal_callsafe_copy(p)
+    h = parent(p)
+    h´ = wrap(h, phases)
+    ams = modifiers(p)
+    L = latdim(lattice(h))
+    S = SMatrix{L,L,Int}(I)[SVector(ua), :] # dnnew = S * dnold
+    ptrmap = pointer_map(h, h´, S)    # [[(ptr´ of har´[S*dn]) for ptr in har] for har in h]
+    harmap = harmonics_map(h, h´, S)  # [(index of har´[S*dn]) for har in h]
+    ams´ = wrap_modifier.(ams, Ref(ptrmap), Ref(harmap))
+    p´ = hamiltonian(h´, ams´...)
     return p´
+end
+
+pointer_map(h, h´, S) =
+    [pointer_map(har, first(harmonic_index(h´, S*dcell(har)))) for har in harmonics(h)]
+
+function pointer_map(har, har´)
+    ptrs´ = Int[]
+    mat, mat´ = unflat(matrix(har)), unflat(matrix(har´))
+    rows, rows´ = rowvals(mat), rowvals(mat´)
+    for col in axes(mat, 2), ptr in nzrange(mat, col)
+        row = rows[ptr]
+        for ptr´ in nzrange(mat´, col)
+            if row == rows´[ptr´]
+                push!(ptrs´, ptr´)
+                break
+            end
+        end
+    end
+    return ptrs´
+end
+
+harmonics_map(h, h´, S) = [last(harmonic_index(h´, S*dcell(har))) for har in harmonics(h)]
+
+function wrap_modifier(m::AppliedOnsiteModifier, ptrmap, harmap)
+    ptrs´ = first(ptrmap)
+    p´ = [(ptrs´[ptr], r, orbs) for (ptr, r, orbs) in pointers(m)]
+    return AppliedOnsiteModifier(m, p´)
+end
+
+function wrap_modifier(m::AppliedHoppingModifier, ptrmap, harmap)
+    ps = pointers(m)
+    ps´ = similar.(ps, 0)
+    for (i, p) in enumerate(ps), (ptr, r, dr, orborbs) in p
+        i´ = harmap[i]
+        ptrs´ = ptrmap[i]
+        push!(ps´[i´], (ptrs´[ptr], r, dr, orborbs))
+    end
+    return AppliedHoppingModifier(m, ps´)
 end
 
 

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -49,7 +49,7 @@ end
 # end
 
 function Base.in(((sj, si), (r, dr), dcell)::Tuple{Pair,Tuple,SVector}, sel::AppliedHopSelector)
-    return !isonsite((sj, si), dcell) &&
+    return !isonsite(dr) &&
             indcells(dcell, sel) &&
             insublats(sj => si, sel) &&
             iswithinrange(dr, sel) &&
@@ -57,6 +57,7 @@ function Base.in(((sj, si), (r, dr), dcell)::Tuple{Pair,Tuple,SVector}, sel::App
 end
 
 isonsite((j, i), dn) = ifelse(i == j && iszero(dn), true, false)
+isonsite(dr) = iszero(dr)
 
 #endregion
 

--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -179,28 +179,6 @@ function supercell(h::Hamiltonian, data::SupercellData; mincoordination = 0)
     return Hamiltonian(lat´, blk´, har´)
 end
 
-function supercell(h::Hamiltonian, v...; mincoordination = 0, kw...)
-    data = supercell_data(lattice(h), v...; kw...)
-    # data.sitelist === sites(lat´), so any change to data will reflect in lat´ too
-    lat´ = lattice(data)
-    B = blocktype(h)
-    blk´ = OrbitalBlockStructure{B}(norbitals(h), sublatlengths(lat´))
-    builder = CSCBuilder(lat´, blk´)
-    har´ = supercell_harmonics(h, data, builder, mincoordination)
-    return Hamiltonian(lat´, blk´, har´)
-end
-
-function supercell(h::Hamiltonian, v...; mincoordination = 0, kw...)
-    data = supercell_data(lattice(h), v...; kw...)
-    # data.sitelist === sites(lat´), so any change to data will reflect in lat´ too
-    lat´ = lattice(data)
-    B = blocktype(h)
-    blk´ = OrbitalBlockStructure{B}(norbitals(h), sublatlengths(lat´))
-    builder = CSCBuilder(lat´, blk´)
-    har´ = supercell_harmonics(h, data, builder, mincoordination)
-    return Hamiltonian(lat´, blk´, har´)
-end
-
 function supercell_harmonics(h, data, builder, mincoordination)
     indexlist, offset = supercell_indexlist(data)
     if mincoordination > 0

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -105,6 +105,30 @@ lengths_to_offsets(v) = prepend!(cumsum(v), 0)
 #     return x
 # end
 
+# # split runs of consecutive elements of itr such that by(itr[i]) == by(itr[i+1]),
+# # applying post to each. Assume no type widening. Each run is reduced with reduce(by, run)
+# splitruns(itr; kw...) = splitruns(identity, itr; kw...)
+
+# function splitruns(post, itr; by = identity, reduce = missing)
+#     i0, itr´ = Iterators.peel(itr)
+#     run = [post(i0)]
+#     rrun = reduce === missing ? run : reduce(by(i0), run)
+#     runs = [rrun]
+#     for i in itr´
+#         p = post(i)
+#         byi, byi0 = by(i), by(i0)
+#         if byi == byi0
+#             push!(run, p)
+#         else
+#             run = [p]
+#             rrun = reduce === missing ? run : reduce(byi, run)
+#             push!(runs, rrun)
+#         end
+#         i0 = i
+#     end
+#     return runs
+# end
+
 #endregion
 
 ############################################################################################

--- a/src/types.jl
+++ b/src/types.jl
@@ -602,6 +602,16 @@ end
 const Modifier = Union{OnsiteModifier,HoppingModifier}
 const AppliedModifier = Union{AppliedOnsiteModifier,AppliedHoppingModifier}
 
+#region ## Constructors ##
+
+AppliedOnsiteModifier(m::AppliedOnsiteModifier, ptrs) =
+    AppliedOnsiteModifier(m.parentselector, m.blocktype, m.f, ptrs)
+
+AppliedHoppingModifier(m::AppliedHoppingModifier, ptrs) =
+    AppliedHoppingModifier(m.parentselector, m.blocktype, m.f, ptrs)
+
+#enregion
+
 #region ## API ##
 
 selector(m::Modifier) = m.selector
@@ -1205,6 +1215,14 @@ flatrange(h::AbstractHamiltonian, name::Symbol) =
 
 zerocell(h::AbstractHamiltonian) = zerocell(lattice(h))
 zerocellsites(h::AbstractHamiltonian, i) = zerocellsites(lattice(h), i)
+
+function harmonic_index(h::AbstractHamiltonian, dn)
+    for (i, har) in enumerate(harmonics(h))
+        dcell(har) == dn && return har, i
+    end
+    boundserror(harmonics(h), dn)
+    return first(harmonics(h)), 1  # unreachable
+end
 
 ## Hamiltonian
 

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -137,8 +137,8 @@ function testjosephson(g0)
 end
 
 @testset "greenfunction observables" begin
-    g1 = LP.square() |> hamiltonian(@hopping((r, dr; B = 0.1) -> I * cis(B * dr' * SA[r[2],-r[1]])), orbitals = 1) |> supercell((1,0), region = r->-2<r[2]<2) |> greenfunction(GS.Schur(boundary = 0));
-    g2 = LP.square() |> hamiltonian(@hopping((r, dr; B = 0.1) -> I * cis(B * dr' * SA[r[2],-r[1]])), orbitals = 2) |> supercell((1,0), region = r->-2<r[2]<2) |> greenfunction(GS.Schur(boundary = 0));
+    g1 = LP.square() |> supercell((1,0), region = r->-2<r[2]<2) |> hamiltonian(@hopping((r, dr; B = 0.1) -> I * cis(B * dr' * SA[r[2],-r[1]])), orbitals = 1) |> greenfunction(GS.Schur(boundary = 0));
+    g2 = LP.square() |> supercell((1,0), region = r->-2<r[2]<2) |> hamiltonian(@hopping((r, dr; B = 0.1) -> I * cis(B * dr' * SA[r[2],-r[1]])), orbitals = 2) |> greenfunction(GS.Schur(boundary = 0));
     J1 = current(g1[cells = SA[1]])
     J2 = current(g2[cells = SA[1]])
     @test size(J1(0.2)) == size(J2(0.2)) == (3, 3)
@@ -161,4 +161,3 @@ end
     testcond(g0; nambu = true)
     testjosephson(g0)
 end
-

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -318,9 +318,12 @@ end
     h = LP.linear() |> hopping(1) |> supercell(3) |> @onsite!((o,r; E = 1)-> E*r[1]) |> @hopping!((t, r,dr; A = SA[1])->t*cis(dot(A,dr[1])))
     @test supercell(h(), 4)((1,)) ≈ supercell(h, 4)((1,))
     @test wrap(h, (2,))(()) ≈ wrap(h(), (2,))(()) ≈ h((2,))
-    h = LP.linear() |> supercell(3) |> @hopping((r,dr; ϕ = 1) -> cis(ϕ*dr[1]))
+    h = LP.linear() |> supercell(3) |> @hopping((r,dr; ϕ = 1) -> cis(ϕ * dr[1]))
     @test supercell(h(), 4)((1,)) ≈ supercell(h, 4)((1,))
     @test wrap(h(), (2,))(()) ≈ h((2,))
+    h0 = LP.square() |> hopping(1) |> supercell(3) |> @hopping!((t, r, dr; A = SA[1,2]) -> t*cis(A'dr))
+    h = wrap(h0, (0.2,:))
+    @test h0((0.2, 0.3)) ≈ h((0.3,))
 end
 
 @testset "hamiltonian nrange" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -47,6 +47,7 @@ using Quantica: Hamiltonian, ParametricHamiltonian, sites, nsites, nonsites, nho
     @test Quantica.Quantica.nhoppings(h) == 12
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(1, range = (10, 10.1)))
     @test Quantica.Quantica.nhoppings(h) == 48
+    @test Hamiltonian{3}(h) isa Hamiltonian{<:Any,3}
 end
 
 @testset "hamiltonian orbitals" begin
@@ -311,6 +312,7 @@ end
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(2I), orbitals = (Val(2), Val(1)), @hopping!((t; α, β = 0) -> α * t .+ β))
     b = h((0, 0); α = 2)
     @test b == [0 0 12; 0 0 0; 12 0 0]
+    @test ParametricHamiltonian{3}(h) isa ParametricHamiltonian{<:Any,3}
     # Old bug in apply
     h = LP.honeycomb() |> supercell(2) |> onsite(1) |> @onsite!(o -> 0; sublats = :A)
     @test tr(h((0,0))) == 4

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -320,7 +320,7 @@ end
     @test wrap(h, (2,))(()) == wrap(h(), (2,))(()) == h((2,))
     h = LP.linear() |> supercell(3) |> @hopping((r,dr; A = SA[1])->cis(dot(A,dr[1])))
     @test supercell(h(), 4)((1,)) == supercell(h, 4)((1,))
-    @test_broken wrap(h, (2,))(()) == wrap(h(), (2,))(()) == h((2,))
+    @test wrap(h(), (2,))(()) == h((2,))
 end
 
 @testset "hamiltonian nrange" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -316,11 +316,11 @@ end
     @test tr(h((0,0))) == 4
     # wrap and supercell commutativity with modifier application
     h = LP.linear() |> hopping(1) |> supercell(3) |> @onsite!((o,r; E = 1)-> E*r[1]) |> @hopping!((t, r,dr; A = SA[1])->t*cis(dot(A,dr[1])))
-    @test supercell(h(), 4)((1,)) == supercell(h, 4)((1,))
-    @test wrap(h, (2,))(()) == wrap(h(), (2,))(()) == h((2,))
-    h = LP.linear() |> supercell(3) |> @hopping((r,dr; A = SA[1])->cis(dot(A,dr[1])))
-    @test supercell(h(), 4)((1,)) == supercell(h, 4)((1,))
-    @test wrap(h(), (2,))(()) == h((2,))
+    @test supercell(h(), 4)((1,)) ≈ supercell(h, 4)((1,))
+    @test wrap(h, (2,))(()) ≈ wrap(h(), (2,))(()) ≈ h((2,))
+    h = LP.linear() |> supercell(3) |> @hopping((r,dr; ϕ = 1) -> cis(ϕ*dr[1]))
+    @test supercell(h(), 4)((1,)) ≈ supercell(h, 4)((1,))
+    @test wrap(h(), (2,))(()) ≈ h((2,))
 end
 
 @testset "hamiltonian nrange" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -311,6 +311,16 @@ end
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(2I), orbitals = (Val(2), Val(1)), @hopping!((t; α, β = 0) -> α * t .+ β))
     b = h((0, 0); α = 2)
     @test b == [0 0 12; 0 0 0; 12 0 0]
+    # Old bug in apply
+    h = LP.honeycomb() |> supercell(2) |> onsite(1) |> @onsite!(o -> 0; sublats = :A)
+    @test tr(h((0,0))) == 4
+    # wrap and supercell commutativity with modifier application
+    h = LP.linear() |> hopping(1) |> supercell(3) |> @onsite!((o,r; E = 1)-> E*r[1]) |> @hopping!((t, r,dr; A = SA[1])->t*cis(dot(A,dr[1])))
+    @test supercell(h(), 4)((1,)) == supercell(h, 4)((1,))
+    @test wrap(h, (2,))(()) == wrap(h(), (2,))(()) == h((2,))
+    h = LP.linear() |> supercell(3) |> @hopping((r,dr; A = SA[1])->cis(dot(A,dr[1])))
+    @test supercell(h(), 4)((1,)) == supercell(h, 4)((1,))
+    @test_broken wrap(h, (2,))(()) == wrap(h(), (2,))(()) == h((2,))
 end
 
 @testset "hamiltonian nrange" begin

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -30,7 +30,7 @@ end
 
 @testset "plot bands" begin
     SOC(dr) = ifelse(iseven(round(Int, atan(dr[2], dr[1])/(pi/3))), im, -im)
-    model = hopping(1, range = 1/√3) + @hopping((r, dr; α = 0) -> α * SOC(dr); sublats = :A => :A, range = 1) - @hopping((r, dr; α = 0) -> α * SOC(dr); sublats = :B => :B, range = 1)
+    model = hopping(1) + @hopping((r, dr; α = 0) -> α * SOC(dr); sublats = :A => :A, range = 1) - @hopping((r, dr; α = 0) -> α * SOC(dr); sublats = :B => :B, range = 1)
     h = LatticePresets.honeycomb(a0 = 1) |> hamiltonian(model)
     b = bands(h(α = 0.05), range(0, 2pi, length=60), range(0, 2pi, length = 60))
     @test qplot(b, color = (psi, e, k) -> angle(psi[1] / psi[2]), colormap = :cyclic_mrybm_35_75_c68_n256, inspector = true) isa Figure


### PR DESCRIPTION
Fixes #205 

We fix supercell by extending `applymodifier` to reapply modifiers to the supercell hamiltonian with an extra parameter that shifts (r, dr)'s to the ones of the original lattice

We fix wrap by rewriting already applied modifiers, essentially transforming the pointers of the old modifiers to new pointers to the merged (wrapped) harmonics