### PR TITLE
Make `transform(h::ParametricHamiltonian, f)` act on `hamiltonian(h)`, not `parent(h)`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1318,7 +1318,7 @@ blockstructure(h::ParametricHamiltonian) = blockstructure(parent(h))
 
 blocktype(h::ParametricHamiltonian) = blocktype(parent(h))
 
-lattice(h::ParametricHamiltonian) = lattice(parent(h))
+lattice(h::ParametricHamiltonian) = lattice(hamiltonian(h))
 
 minimal_callsafe_copy(p::ParametricHamiltonian) = ParametricHamiltonian(
     p.hparent, minimal_callsafe_copy(p.h), p.modifiers, p.allptrs, p.allparams)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -351,6 +351,10 @@ end
     @test h1 === h2 === h3
     @test all(r->r[3] == 2.0, sites(lattice(h3)))
     @test h((1,2)) == h3((1,2))
+    h = LP.square() |> @hopping((; t=1) -> t) |> supercell((2,0), (0, 1))
+    h´ = h |> transform(r -> SA[r[2], r[1]])
+    @test sites(lattice(h´)) == sites(h´.h.lattice) != sites(lattice(parent(h´)))
+    @test sites(lattice(h´)) == [SA[0,0], SA[0,1]]
 end
 
 @testset "hamiltonians combine" begin


### PR DESCRIPTION
As the title says. This is achieved by changing `lattice(h) = lattice(parent(h))` to `lattice(h) = lattice(hamiltonian(h))`. The previous behavior did not make sense: the reference Hamiltonian of `h` is `hamiltonian(h)`, since it is the object that is produced. `parent(h)` is only there for reference, to reset `hamiltonian(h)` when needed.