### PR TITLE
Reverse for `Lattice` and `AbstractHamiltonian`

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -223,7 +223,7 @@ Selectors are very expressive and powerful. Do check `siteselector` and `hopsele
 
 ### Transforming lattices
 
-We can transform lattices using `supercell`, `transform` and `translate`.
+We can transform lattices using `supercell`, `reverse`, `transform`, `translate`.
 
 As a periodic structure, the choice of the unitcell in an unbounded lattice is, to an extent, arbitrary. Given a lattice `lat` we can obtain another with a unit cell 3 times larger with `supercell(lat, 3)`
 
@@ -270,6 +270,16 @@ julia> qplot(lat[cells = -7:7])
 
 !!! tip "No need to build selectors explicitly"
     Note that we we didn't build a `siteselector(region = ...)` object to pass it to `supercell`. Instead, as shown above, we passed the corresponding keywords directly to `supercell`, which then takes care to build the selector internally.
+
+To simply reverse the direction of the Bravais vectors of a lattice, while leaving the site positions unchanged, use `reverse` (or `reverse!` to do it in-place)
+```jldoctest
+julia> reverse(LP.square())
+Lattice{Float64,2,2} : 2D lattice in 2D space
+  Bravais vectors : [[-1.0, -0.0], [-0.0, -1.0]]
+  Sublattices     : 1
+    Names         : (:A,)
+    Sites         : (1,) --> 1 total per unit cell
+```
 
 To transform a lattice, so that site positions `r` become `f(r)` use `transform`
 ```jldoctest
@@ -665,7 +675,7 @@ Note that unspecified parameters take their default values when using the call s
 
 ### Transforming Hamiltonians
 
-Like with lattices, we can transform an `h::AbstractHamiltonians` using `transform`, `translate` and `supercell`. Both `transform` and `translate` operate only on the underlying `lattice(h)` of `h`, leaving the hoppings and onsite elements unchanged, while `supercell` acts on `lattice(h)` and copies the hoppings and onsites of `h` onto the new sites, preserving the periodicity of the original `h`.
+Like with lattices, we can transform an `h::AbstractHamiltonians` using `supercell`, `reverse`, `transform` and `translate`. All these except `supercell` operate only on the underlying `lattice(h)` of `h`, leaving the hoppings and onsite elements unchanged. Meanwhile, `supercell` acts on `lattice(h)` but also copies the hoppings and onsites of `h` onto the new sites, preserving the periodicity of the original `h`.
 
 Additionally, we can also use `wrap`, which makes `h` periodic along a number of its Bravais vectors, while leaving the rest unbounded.
 ```jldoctest

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -647,30 +647,20 @@ function selfenergy_plottable(solver::Quantica.SelfEnergyModelSolver, ph; kw...)
 end
 
 function selfenergy_plottable(s::Quantica.SelfEnergySchurSolver,
-    hlead, reverse; numcells = 1, kw...)
-    p1, k2 = _selfenergy_plottable_hlead(hlead, reverse, numcells)
-    return ((p1, k2),)
-end
-
-function selfenergy_plottable(s::Quantica.SelfEnergyCouplingSchurSolver,
-    hcoupling;  kw...)
-    p1 = hcoupling
-    k1 = (; selector = siteselector())
+    hlead; kw...)
+    p1, k1 = hlead, (; selector = siteselector())
     return ((p1, k1),)
 end
 
-function _selfenergy_plottable_hlead(hlead, reverse, numcells)
-    # hlead[0] is first unit cell of semi-infinite lead
-    n = max(1, numcells)
-    cellrng = reverse ? (-n+1:0) : (0:n-1)
-    p = hlead
-    k = (; selector = siteselector(; cells = cellrng))
-    return (p, k)
+function selfenergy_plottable(s::Quantica.SelfEnergyCouplingSchurSolver,
+    hcoupling, hlead;  kw...)
+    p1, k1 = hlead, (; selector = siteselector())
+    p2, k2 = hcoupling, (; siteoutline = 7)
+    return ((p1, k1), (p2, k2))
 end
 
 function selfenergy_plottable(s::Quantica.SelfEnergyGenericSolver, hcoupling; kw...)
-    p1 = hcoupling
-    k1 = (; selector = siteselector())
+    p1, k1 = hcoupling, (; siteoutline = 7)
     return ((p1, k1),)
 end
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -288,6 +288,26 @@ Lattice{Float64,2,2} : 2D lattice in 2D space
 supercell
 
 """
+    reverse(lat_or_h::Union{Lattice,AbstractHamiltonian})
+
+Build a new lattice or hamiltonian with the orientation of all Bravais vectors reversed.
+
+# See also
+    `reverse!`, `transform`
+"""
+Base.reverse
+
+"""
+    reverse!(lat_or_h::Union{Lattice,AbstractHamiltonian})
+
+In-place version of `reverse`, inverts all Bravais vectors of `lat_or_h`.
+
+# See also
+    `reverse`, `transform`
+"""
+Base.reverse!
+
+"""
     transform(lat_or_h::Union{Lattice,AbstractHamiltonian}, f::Function)
 
 Build a new lattice or hamiltonian transforming each site positions `r` into `f(r)`.
@@ -312,7 +332,7 @@ Lattice{Float64,2,2} : 2D lattice in 2D space
 ```
 
 # See also
-    `translate`
+    `translate`, `reverse`, `reverse!`
 """
 transform
 
@@ -340,7 +360,7 @@ julia> LatticePresets.square() |> translate((3,3)) |> sites
 ```
 
 # See also
-    `transform`
+    `transform`, `reverse`, `reverse!`
 
 """
 translate

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -63,7 +63,9 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurEmpty
     transform === missing || Quantica.transform!(hlead, transform)
     translate!(hlead, displacement)
     solver´ = SelfEnergySchurSolver(fsolver, hlead, reverse, leadorbs)
-    plottables = (hlead, reverse)
+
+    reverse && Base.reverse!(hlead)
+    plottables = (hlead,)
     return SelfEnergy(solver´, lsparent, plottables)
 end
 
@@ -193,7 +195,10 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead,
     gslice = glead[cells = SA[xunit]]
     Σs = selfenergies(contacts(glead))
     solver´ = extended_or_regular_solver(Σs, gslice, gunit, hcoupling, nparent)
-    plottables = (hcoupling,)
+
+    reverse && Base.reverse!(hlead)
+    plottables = (hcoupling, hlead)
+
     return SelfEnergy(solver´, lsparent, plottables)
 end
 
@@ -257,7 +262,10 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead;
     V  = SparseMatrixView(view(h₊₁, :, leadorbs))
     V´ = SparseMatrixView(view(h₋₁, leadorbs, :))
     solver´ = SelfEnergyGenericSolver(gslice, hlead, V´, V)
+
+    reverse && Base.reverse!(hlead)
     plottables = (hlead,)
+
     return SelfEnergy(solver´, lsparent, plottables)
 end
 

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -42,6 +42,20 @@ translate(l::Lattice, δr) = translate!(copy(l), δr)
 #endregion
 
 ############################################################################################
+# Lattice reverse - flip all Bravais vectors
+#region
+
+Base.reverse!(lat::Lattice) = (matrix(bravais(lat)) .*= -1; lat)
+
+Base.reverse(lat::Lattice) = reverse!(copy(lat))
+
+Base.reverse!(h::AbstractHamiltonian) = (reverse!(lattice(h)); h)
+
+Base.reverse(h::AbstractHamiltonian) = reverse!(copy(h))
+
+#end
+
+############################################################################################
 # Hamiltonian transform/translate
 #region
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -355,6 +355,10 @@ end
     h´ = h |> transform(r -> SA[r[2], r[1]])
     @test sites(lattice(h´)) == sites(h´.h.lattice) != sites(lattice(parent(h´)))
     @test sites(lattice(h´)) == [SA[0,0], SA[0,1]]
+    h´´ = reverse(h´)
+    @test bravais_matrix(lattice(h´´)) == - bravais_matrix(lattice(h´))
+    @test reverse!(h´´) === h´´
+    @test bravais_matrix(lattice(h´´)) == bravais_matrix(lattice(h´))
 end
 
 @testset "hamiltonians combine" begin


### PR DESCRIPTION
Add methods to `Base.reverse` and `Base.reverse!` as a fast way to switch the orientation of all Bravais vectors, which was not too straightforward with current constructors, while simplifying the code for the reverse of 1D leads