### PR TITLE
Allow empty sublats

### DIFF
--- a/docs/src/tutorial/observables.md
+++ b/docs/src/tutorial/observables.md
@@ -93,9 +93,10 @@ julia> f = Figure(); a = Axis(f[1,1], xlabel = "ω/t", ylabel = "T(ω)"); lines!
 ```@raw html
 <img src="../../assets/four_terminal_T.png" alt="Total transmission from right contact" width="400" class="center"/>
 ```
+So we indeed find that the 90-degree transmission `T₃₁` is indeed larger than the forward transmission `T₂₁` for all energies. The rapid oscillations are due to mesoscopic fluctuations.
 
 !!! note "Total transmission vs transmission probability"
-    Note that `transmission` gives the total transmission, which is the sum of the transmission probability from each orbital in the source contact to any other orbital in the drain contact. As such it is not normalized to 1, but to the number of source orbitals. It also gives the local conductance from a given contact in units of $$e^2/h$$ according to the Landauer formula, $$G\_j = e^2/h \sum_i T_{ij}(eV)$$.
+    Note that `transmission` gives the total transmission, which is the sum of the transmission probability from each orbital in the source contact to any other orbital in the drain contact. As such it is not normalized to 1, but to the number of source orbitals. It also gives the local conductance from a given contact in units of $$e^2/h$$ according to the Landauer formula, $$G_j = e^2/h \sum_i T_{ij}(eV)$$.
 
 ## Conductance
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1726,6 +1726,7 @@ dω ∑ⱼ [fᵢ(ω) - fⱼ(ω)] Gᵢⱼ(ω)``, where ``fᵢ(ω)`` is the Fermi 
 
 Compute the conductance at the specified contacts.
 
+# Examples
 ```jldoctest
 julia> # A central system g0 with two 1D leads and transparent contacts
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,10 +5,6 @@
 struct Sublat{T<:AbstractFloat,E}
     sites::Vector{SVector{E,T}}
     name::Symbol
-    function Sublat{T,E}(sites, name) where {T<:AbstractFloat,E}
-        isempty(sites) && argerror("Sublattices cannot be empty")
-        return new(sites, name)
-    end
 end
 
 struct Unitcell{T<:AbstractFloat,E}
@@ -40,8 +36,6 @@ struct Lattice{T<:AbstractFloat,E,L}
 end
 
 #region ## Constructors ##
-
-Sublat(sites::Vector{SVector{E,T}}, name::Symbol) where {T,E} = Sublat{T,E}(sites, name)
 
 Bravais(::Type{T}, E, m) where {T} = Bravais(T, Val(E), m)
 Bravais(::Type{T}, ::Val{E}, m::Tuple{}) where {T,E} =

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -22,7 +22,7 @@ function testgreen(h, s; kw...)
     return nothing
 end
 
-@testset "bare greenfunctions" begin
+@testset "basic greenfunctions" begin
     h0 = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0]), orbitals = 2) |> supercell(region = RP.circle(10))
     s0 = GS.SparseLU()
     h1 = LP.square() |> hamiltonian(@onsite((; o = 1) -> o*I) + hopping(SA[0 1; 1 0]), orbitals = 2) |> supercell((1,0), region = r -> abs(r[2]) < 2)
@@ -66,6 +66,9 @@ end
             testgreen(oh, s)
         end
     end
+    # contacts that don't include all sublattices
+    h = lattice(sublat(0, name = :L), sublat(1, name = :R)) |> hamiltonian
+    @test h |> attach(onsite(ω->1), sublats = :L) |> greenfunction isa GreenFunction
 end
 
 @testset "greenfunction KPM" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -31,7 +31,7 @@ end
     end
     @test sublat((3,)) isa Sublat{Float64,1}
     @test sublat(()) isa Sublat{Float64,0}
-    @test_throws ArgumentError sublat(SVector{3,Float64}[])
+    @test sublat(SVector{3,Float64}[]) isa Sublat{Float64,3}
 end
 
 @testset "lattice construction" begin

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -1,3 +1,5 @@
+@test_throws ArgumentError qplot(LP.linear())  # no backend loaded
+
 using CairoMakie
 
 @testset "plot lattice" begin


### PR DESCRIPTION
We were not allowing empty sublattices, which led to an error if a contact was added that didn't have at least one site in each sublattice.

Since there seems to be no issue with allowing such a situation, we have relaxed the condition. Let's see if all tests pass.