### PR TITLE
`markersize` fastpath in qplot

### DIFF
--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -531,12 +531,19 @@ function plotsites_flat!(plot::PlotLattice, sp::SitePrimitives, transparency)
     inspector_label = (self, i, r) -> sp.tooltips[i]
     scalefactor = plot[:pixelscalesites][]
     markersize = scalefactor ≈ 1 ? sp.radii : scalefactor * sp.radii
-    scatter!(plot, sp.centers; color = sp.colors, markersize,
-            markerspace = :data,
-            strokewidth = plot[:siteoutline][],
-            strokecolor = darken.(sp.colors, Ref(plot[:siteoutlinedarken][])),
-            transparency,
-            inspector_label)
+    opts = (
+        color = sp.colors,
+        markerspace = :data,
+        strokewidth = plot[:siteoutline][],
+        strokecolor = darken.(sp.colors, Ref(plot[:siteoutlinedarken][])),
+        transparency,
+        inspector_label)
+    ## performance BUG in markersize: currently required in Makie for performance
+    if allequal(sp.radii)
+        scatter!(plot, sp.centers; markersize = first(scalefactor*sp.radii), opts...)
+    else
+        scatter!(plot, sp.centers; markersize, opts...)
+    end
     return plot
 end
 


### PR DESCRIPTION
It seems that `Makie.scatter!` is quite slow if `markersize = vector`. This is most certainly a missed optimization on their part. Until that is resolved, we add a fastpath for the common case where markersize is constant.