### PR TITLE
Configurable qplot defaults

### DIFF
--- a/docs/src/tutorial/lattices.md
+++ b/docs/src/tutorial/lattices.md
@@ -112,6 +112,9 @@ julia> qplot(lat, hide = nothing)
 !!! tip "GLMakie.jl vs CairoMakie.jl"
     GLMakie.jl is optimized for interactive GPU-accelerated, rasterized plots. If you need to export to PDF for publications or display plots inside a Jupyter notebook, use CairoMakie.jl instead, which in general renders non-interactive, but vector-based plots.
 
+!!! tip "User-defined defaults for `qplot`"
+    The command `qplotdefaults(; axis, figure)` can be used to define the default value of `figure` and `axis` keyword arguments of `qplot`. Example: to fix the resolution of all subsequent plots, do `qplotdefaults(; figure = (resolution = (1000, 1000),))`.
+
 ## [SiteSelectors](@id siteselectors)
 
 A central concept in Quantica.jl is that of a "selector". There are two types of selectors, `SiteSelector`s and `HopSelectors`. `SiteSelector`s are a set of directives or rules that define a subset of its sites. `SiteSelector` rules are defined through three keywords:

--- a/ext/QuanticaMakieExt/QuanticaMakieExt.jl
+++ b/ext/QuanticaMakieExt/QuanticaMakieExt.jl
@@ -9,7 +9,7 @@ using Quantica: Lattice, LatticeSlice, AbstractHamiltonian, Hamiltonian,
       argerror, harmonics, sublats, siterange, site, norm,
       normalize, nsites, nzrange, rowvals, nonzeros, sanitize_SVector
 
-import Quantica: plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!
+import Quantica: plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults
 
 # Currying fallback
 Quantica.qplot(; kw...) = x -> Quantica.qplot(x; kw...)
@@ -18,6 +18,7 @@ Quantica.qplot!(; kw...) = x -> Quantica.qplot!(x; kw...)
 include("plotlattice.jl")
 include("plotbands.jl")
 include("tools.jl")
+include("defaults.jl")
 include("docstrings.jl")
 
 end # module

--- a/ext/QuanticaMakieExt/defaults.jl
+++ b/ext/QuanticaMakieExt/defaults.jl
@@ -1,0 +1,35 @@
+############################################################################################
+# qplot defaults
+#region
+
+function qplotdefaults(; figure = (;), axis = (;))
+    global default_figure_user = figure
+    global default_axis_user = axis
+    return (; default_figure_user, default_axis_user)
+end
+
+default_figure_user = (;)
+default_axis_user = (;)
+
+const plotlat_default_figure = (; resolution = (1200, 1200), fontsize = 40)
+
+const plotlat_default_axis3D = (;
+    xlabel = "x", ylabel = "y", zlabel = "z",
+    xticklabelcolor = :gray, yticklabelcolor = :gray, zticklabelcolor = :gray,
+    xspinewidth = 0.2, yspinewidth = 0.2, zspinewidth = 0.2,
+    xlabelrotation = 0, ylabelrotation = 0, zlabelrotation = 0,
+    xticklabelsize = 30, yticklabelsize = 30, zticklabelsize = 30,
+    xlabelsize = 40, ylabelsize = 40, zlabelsize = 40,
+    xlabelfont = :italic, ylabelfont = :italic, zlabelfont = :italic,
+    perspectiveness = 0.0, aspect = :data)
+
+const plotlat_default_axis2D = (; autolimitaspect = 1)
+
+const plotlat_default_lscene = (;)
+
+const plotlat_default_2D =
+    (plotlat_default_figure, plotlat_default_axis2D)
+const plotlat_default_3D =
+    (plotlat_default_figure, plotlat_default_axis3D, plotlat_default_lscene)
+
+#endregion

--- a/ext/QuanticaMakieExt/defaults.jl
+++ b/ext/QuanticaMakieExt/defaults.jl
@@ -3,13 +3,13 @@
 #region
 
 function qplotdefaults(; figure = (;), axis = (;))
-    global default_figure_user = figure
-    global default_axis_user = axis
-    return (; default_figure_user, default_axis_user)
+    global default_figure_kwarg = figure
+    global default_axis_kwarg = axis
+    return (; default_figure_kwarg, default_axis_kwarg)
 end
 
-default_figure_user = (;)
-default_axis_user = (;)
+default_figure_kwarg = (;)
+default_axis_kwarg = (;)
 
 const plotlat_default_figure = (; resolution = (1200, 1200), fontsize = 40)
 

--- a/ext/QuanticaMakieExt/defaults.jl
+++ b/ext/QuanticaMakieExt/defaults.jl
@@ -2,6 +2,8 @@
 # qplot defaults
 #region
 
+## qplot defaults
+
 function qplotdefaults(; figure = (;), axis = (;))
     global default_figure_kwarg = figure
     global default_axis_kwarg = axis
@@ -10,6 +12,8 @@ end
 
 default_figure_kwarg = (;)
 default_axis_kwarg = (;)
+
+## plotlattice defaults
 
 const plotlat_default_figure = (; resolution = (1200, 1200), fontsize = 40)
 
@@ -31,5 +35,27 @@ const plotlat_default_2D =
     (plotlat_default_figure, plotlat_default_axis2D)
 const plotlat_default_3D =
     (plotlat_default_figure, plotlat_default_axis3D, plotlat_default_lscene)
+
+## plotbands defaults
+
+const plotbands_default_figure = (; resolution = (1200, 1200), fontsize = 40)
+
+const plotbands_default_axis3D = (;
+    xticklabelcolor = :gray, yticklabelcolor = :gray, zticklabelcolor = :gray,
+    xspinewidth = 0.2, yspinewidth = 0.2, zspinewidth = 0.2,
+    xlabelrotation = 0, ylabelrotation = 0, zlabelrotation = 0,
+    xticklabelsize = 30, yticklabelsize = 30, zticklabelsize = 30,
+    xlabelsize = 40, ylabelsize = 40, zlabelsize = 40,
+    xlabelfont = :italic, ylabelfont = :italic, zlabelfont = :italic,
+    perspectiveness = 0.0, aspect = :data)
+
+const plotbands_default_axis2D = (; autolimitaspect = nothing)
+
+const plotbands_default_lscene = (;)
+
+const plotbands_default_2D =
+    (plotbands_default_figure, plotbands_default_axis2D)
+const plotbands_default_3D =
+    (plotbands_default_figure, plotbands_default_axis3D, plotbands_default_lscene)
 
 #endregion

--- a/ext/QuanticaMakieExt/docstrings.jl
+++ b/ext/QuanticaMakieExt/docstrings.jl
@@ -27,6 +27,8 @@ cycling over them if necessary.
 - `inspector::Bool`: whether to enable interactive tooltips of plot elements
 - `plotkw`: additional keywords to pass on to `plotlattice` or `plotbands`, see their docstring for details.
 
+# See also
+    `plotlattice`, `plotbands`, `qplotdefaults`
 """
 qplot
 
@@ -137,3 +139,19 @@ Render bands-based `object` on currently active scene. See `plotbands` for possi
 
 """
 plotbands!
+
+"""
+    qplotdefaults(; figure = (;), axis = (;))
+
+Define default values for the `figure` and `axis` keyword arguments of `qplot`.
+
+# Examples
+```jldoctest
+julia> qplotdefaults(figure = (resolution = (1000, 1000),))
+(default_figure_kwarg = (resolution = (1000, 1000),), default_axis_kwarg = NamedTuple())
+
+julia> qplotdefaults()
+(default_figure_kwarg = NamedTuple(), default_axis_kwarg = NamedTuple())
+```
+"""
+qplotdefaults

--- a/ext/QuanticaMakieExt/plotbands.jl
+++ b/ext/QuanticaMakieExt/plotbands.jl
@@ -26,7 +26,7 @@ end
 const PlotBandsArgumentType =
     Union{Quantica.Bandstructure,Quantica.Subband,AbstractVector{<:Quantica.Subband},AbstractVector{<:Quantica.Mesh},Quantica.Mesh}
 
-function Quantica.qplot(b::PlotBandsArgumentType; fancyaxis = true, axis = default_axis_user, figure = default_figure_user, inspector = false, plotkw...)
+function Quantica.qplot(b::PlotBandsArgumentType; fancyaxis = true, axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, plotkw...)
     meshes = collect(Quantica.meshes(b))
     E = Quantica.embdim(first(meshes))
     fig, ax = if E < 3

--- a/ext/QuanticaMakieExt/plotbands.jl
+++ b/ext/QuanticaMakieExt/plotbands.jl
@@ -26,7 +26,7 @@ end
 const PlotBandsArgumentType =
     Union{Quantica.Bandstructure,Quantica.Subband,AbstractVector{<:Quantica.Subband},AbstractVector{<:Quantica.Mesh},Quantica.Mesh}
 
-function Quantica.qplot(b::PlotBandsArgumentType; fancyaxis = true, axis = (;), figure = (;), inspector = false, plotkw...)
+function Quantica.qplot(b::PlotBandsArgumentType; fancyaxis = true, axis = default_axis_user, figure = default_figure_user, inspector = false, plotkw...)
     meshes = collect(Quantica.meshes(b))
     E = Quantica.embdim(first(meshes))
     fig, ax = if E < 3
@@ -42,26 +42,6 @@ function Quantica.qplot(b::PlotBandsArgumentType; fancyaxis = true, axis = (;), 
 end
 
 Quantica.qplot!(b::PlotBandsArgumentType; kw...) = plotbands!(b; kw...)
-
-const plotbands_default_figure = (; resolution = (1200, 1200), fontsize = 40)
-
-const plotbands_default_axis3D = (;
-    xticklabelcolor = :gray, yticklabelcolor = :gray, zticklabelcolor = :gray,
-    xspinewidth = 0.2, yspinewidth = 0.2, zspinewidth = 0.2,
-    xlabelrotation = 0, ylabelrotation = 0, zlabelrotation = 0,
-    xticklabelsize = 30, yticklabelsize = 30, zticklabelsize = 30,
-    xlabelsize = 40, ylabelsize = 40, zlabelsize = 40,
-    xlabelfont = :italic, ylabelfont = :italic, zlabelfont = :italic,
-    perspectiveness = 0.0, aspect = :data)
-
-const plotbands_default_axis2D = (; autolimitaspect = nothing)
-
-const plotbands_default_lscene = (;)
-
-const plotbands_default_2D =
-    (plotbands_default_figure, plotbands_default_axis2D)
-const plotbands_default_3D =
-    (plotbands_default_figure, plotbands_default_axis3D, plotbands_default_lscene)
 
 #endregion
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -38,21 +38,21 @@ end
 
 const PlotLatticeArgumentType{E} = Union{Lattice{<:Any,E},LatticeSlice{<:Any,E},AbstractHamiltonian{<:Any,E}}
 
-function Quantica.qplot(h::PlotLatticeArgumentType{3}; fancyaxis = true, axis = default_axis_user, figure = default_figure_user, inspector = false, plotkw...)
+function Quantica.qplot(h::PlotLatticeArgumentType{3}; fancyaxis = true, axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, plotkw...)
     fig, ax = empty_fig_axis_3D(plotlat_default_3D...; fancyaxis, axis, figure)
     plotlattice!(ax, h; plotkw...)
     inspector && DataInspector()
     return fig
 end
 
-function Quantica.qplot(h::PlotLatticeArgumentType; axis = default_axis_user, figure = default_figure_user, inspector = false, plotkw...)
+function Quantica.qplot(h::PlotLatticeArgumentType; axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, plotkw...)
     fig, ax = empty_fig_axis_2D(plotlat_default_2D...; axis, figure)
     plotlattice!(ax, h; plotkw...)
     inspector && DataInspector()
     return fig
 end
 
-function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = default_axis_user, figure = default_figure_user, inspector = false, children = missing, plotkw...)
+function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, children = missing, plotkw...)
     fig, ax = empty_fig_axis(g; fancyaxis, axis, figure)
     Σkws = Iterators.cycle(parse_children(children))
     Σs = Quantica.selfenergies(Quantica.contacts(g))

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -38,21 +38,21 @@ end
 
 const PlotLatticeArgumentType{E} = Union{Lattice{<:Any,E},LatticeSlice{<:Any,E},AbstractHamiltonian{<:Any,E}}
 
-function Quantica.qplot(h::PlotLatticeArgumentType{3}; fancyaxis = true, axis = (;), figure = (;), inspector = false, plotkw...)
+function Quantica.qplot(h::PlotLatticeArgumentType{3}; fancyaxis = true, axis = default_axis_user, figure = default_figure_user, inspector = false, plotkw...)
     fig, ax = empty_fig_axis_3D(plotlat_default_3D...; fancyaxis, axis, figure)
     plotlattice!(ax, h; plotkw...)
     inspector && DataInspector()
     return fig
 end
 
-function Quantica.qplot(h::PlotLatticeArgumentType; axis = (;), figure = (;), inspector = false, plotkw...)
+function Quantica.qplot(h::PlotLatticeArgumentType; axis = default_axis_user, figure = default_figure_user, inspector = false, plotkw...)
     fig, ax = empty_fig_axis_2D(plotlat_default_2D...; axis, figure)
     plotlattice!(ax, h; plotkw...)
     inspector && DataInspector()
     return fig
 end
 
-function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = (;), figure = (;), inspector = false, children = missing, plotkw...)
+function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = default_axis_user, figure = default_figure_user, inspector = false, children = missing, plotkw...)
     fig, ax = empty_fig_axis(g; fancyaxis, axis, figure)
     Σkws = Iterators.cycle(parse_children(children))
     Σs = Quantica.selfenergies(Quantica.contacts(g))
@@ -80,27 +80,6 @@ empty_fig_axis(::GreenFunction{<:Any,3}; kw...) =
     empty_fig_axis_3D(plotlat_default_3D...; kw...)
 empty_fig_axis(::GreenFunction; kw...) =
     empty_fig_axis_2D(plotlat_default_2D...; kw...)
-
-const plotlat_default_figure = (; resolution = (1200, 1200), fontsize = 40)
-
-const plotlat_default_axis3D = (;
-    xlabel = "x", ylabel = "y", zlabel = "z",
-    xticklabelcolor = :gray, yticklabelcolor = :gray, zticklabelcolor = :gray,
-    xspinewidth = 0.2, yspinewidth = 0.2, zspinewidth = 0.2,
-    xlabelrotation = 0, ylabelrotation = 0, zlabelrotation = 0,
-    xticklabelsize = 30, yticklabelsize = 30, zticklabelsize = 30,
-    xlabelsize = 40, ylabelsize = 40, zlabelsize = 40,
-    xlabelfont = :italic, ylabelfont = :italic, zlabelfont = :italic,
-    perspectiveness = 0.0, aspect = :data)
-
-const plotlat_default_axis2D = (; autolimitaspect = 1)
-
-const plotlat_default_lscene = (;)
-
-const plotlat_default_2D =
-    (plotlat_default_figure, plotlat_default_axis2D)
-const plotlat_default_3D =
-    (plotlat_default_figure, plotlat_default_axis3D, plotlat_default_lscene)
 
 #endregion
 

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -27,7 +27,7 @@ export sublat, bravais_matrix, lattice, sites, supercell,
        unflat, wrap, transform, translate, combine,
        spectrum, energies, states, bands, subdiv,
        greenfunction, selfenergy, attach, contact, cellsites,
-       plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!,
+       plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults,
        conductance, josephson, ldos, current, transmission
 
 export LatticePresets, LP, RegionPresets, RP, HamiltonianPresets, HP
@@ -84,6 +84,7 @@ function plotbands end
 function plotbands! end
 function qplot end
 function qplot! end
+function qplotdefaults end
 
 qplot(args...; kw...) =
     argerror("No plotting backend found or unexpected argument. Forgot to do e.g. `using GLMakie`?")


### PR DESCRIPTION
The new exported function `plotdefaults(; figure = (;), axis = (;))` can be used to define the default values of the `figure` and `axis` kwargs in qplot. Typical uses: fix the resolution of all subsequent plots, or the labels of their axes.