### PR TITLE
Matrix site shader should sum cols not rows

### DIFF
--- a/docs/src/tutorial/observables.md
+++ b/docs/src/tutorial/observables.md
@@ -71,13 +71,16 @@ julia> g = hcentral |>
            attach(glead, region = r -> r[2] == -101, reverse = true, transform = Rot) |>
            greenfunction;
 
-julia> gx1 = sum(abs2, g(-3.96)[siteselector(), 1], dims = 2);
+julia> gx1 = abs2.(g(-3.96)[siteselector(), 1]);
 
-julia> qplot(hcentral, hide = :hops, siteoutline = 1, sitecolor = (i, r) -> gx1[i], siteradius = (i, r) -> gx1[i], minmaxsiteradius = (0, 2), sitecolormap = :balance)
+julia> qplot(hcentral, hide = :hops, siteoutline = 1, sitecolor = gx1, siteradius = gx1, minmaxsiteradius = (0, 2), sitecolormap = :balance)
 ```
 ```@raw html
 <img src="../../assets/four_terminal_g_big.png" alt="Green function from right lead" width="400" class="center"/>
 ```
+
+!!! tip "Matrix and vector shaders"
+    In the above example `gx1` is a matrix with one row per orbital in `hcentral`. The color and radii of each site is obtained from the sum of each row. If `gx1` were a vector, the color/radius of site `i` would be taken as `gx1[i]`. See `plotlattice` for more details and other shader types.
 
 It's apparent from the plot that the transmission from right to left (`T₂₁` here) at this energy of `0.04` is larger than from right to top (`T₃₁`). Is this true in general? Let us compute the two transmissions as a function of energy. To show the progress of the calculation we can use a monitor package, such as `ProgressMeter`
 ```julia

--- a/ext/QuanticaMakieExt/docstrings.jl
+++ b/ext/QuanticaMakieExt/docstrings.jl
@@ -85,11 +85,15 @@ inter-site links.
 
 The element properties in the list above that accept site shaders may take either of these options
 - `(i, r) -> Real`: a real function of site index `i::Int` and site position `r::SVector`.
+- `AbstractVector`: a real vector representing the shading for each plotted site
+- `AbstractMatrix`: a real matrix whose summed rows represent the shading for each plotted site
 - `LocalSpectralDensitySolution`: a generator of local density of states at a fixed energy (see `ldos`). It is evaluated at the site position.
 - `CurrentDensitySolution`: a generator of local current density at a fixed energy (see `current`). It is taken as the sum of currents along all hops connected to the site.
 
 Element properties marked as accepting hop shaders may take either of these options
 - `((src, dst), (r, dr)) -> Real`: a real function of site indices `(src, dst)` and hop coordinates `(r, dr)` (see `hopselector` for definition of hop coordinates)
+- `AbstractVector`: a real vector `v` such that `(v[i]+v[j])/2` represents the shading for each hopping `j => i`
+- `AbstractMatrix`: a real matrix `m` such that `m[i,j]` represents the shading for each hopping `j => i`
 - `LocalSpectralDensitySolution`: a generator of local density of states at a fixed energy (see `ldos`). It is evaluated as the average between connected sites.
 - `CurrentDensitySolution`: a generator of local current density at a fixed energy (see `current`). It is taken as the current along the hop.
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -180,7 +180,7 @@ maybe_evaluate_observable(o::Quantica.IndexableObservable, ls) = o[ls]
 maybe_evaluate_observable(x, ls) = x
 
 maybe_getindex(v::AbstractVector, i) = v[i]
-maybe_getindex(m::AbstractMatrix, i) = sum(view(m, :, i))
+maybe_getindex(m::AbstractMatrix, i) = sum(view(m, i, :))
 maybe_getindex(m::Quantica.AbstractSparseMatrixCSC, i) = sum(view(nonzeros(m), nzrange(m, i)))
 maybe_getindex(v, i) = v
 maybe_getindex(v::AbstractVector, i, j) = 0.5*(v[i] + v[j])

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -28,6 +28,12 @@ end
     @test qplot(g) isa Figure
     g = LP.linear() |> hamiltonian(hopping(I), orbitals = 2) |> attach(@onsite(ω->im*I), cells = 1) |> attach(@onsite(ω->im*I), cells = 4) |> greenfunction
     @test qplot(g, cells = -10:10) isa Figure
+    # matrix shader
+    gx1 = abs2.(g(0.01)[siteselector(cells = 1:10), 1])
+    @test qplot(g, selector = siteselector(cells = 1:10), sitecolor = gx1) isa Figure
+    # vector shader
+    gx1´ = vec(sum(gx1, dims = 2))
+    @test qplot(g, selector = siteselector(cells = 1:10), sitecolor = gx1´) isa Figure
 end
 
 @testset "plot bands" begin


### PR DESCRIPTION
There was a bug whereby a shader of type `AbstractMatrix` would be summed over rows instead of cols. 

Added missing docs also.