### PR TITLE
`foreach_cell` iteration should continue until at least one site is found

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -92,13 +92,19 @@ function recursive_push!(v::Vector{Pair{T,T}}, (xs, ys)::Pair) where {T}
     return v
 end
 
-# for cells = function
+# for cells::Function
 function recursive_push!(v::Vector{SVector{L,Int}}, fcell::Function) where {L}
     iter = BoxIterator(zero(SVector{L,Int}))
+    keepgoing = true
     for cell in iter
-        fcell(cell) || continue
-        acceptcell!(iter, cell)
-        push!(v, cell)
+        found = fcell(cell)
+        if found || keepgoing
+            acceptcell!(iter, cell)
+            if found
+                push!(v, cell)
+                keepgoing = false
+            end
+        end
     end
     return v
 end

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -70,11 +70,15 @@ isonsite(dr) = iszero(dr)
 function foreach_cell(f, sel::AppliedSiteSelector)
     lat = lattice(sel)
     cells_list = cells(sel)
-    if isempty(cells_list) # no cells specified
+    if isempty(cells_list)      # no cells specified
         iter = BoxIterator(zerocell(lat))
+        keepgoing = true        # will search until we find at least one
         for cell in iter
             found = f(cell)
-            found && acceptcell!(iter, cell)
+            if found || keepgoing
+                acceptcell!(iter, cell)
+                found && (keepgoing = false)
+            end
         end
     else
         for cell in cells_list

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -168,6 +168,9 @@ end
     @test ls2[2] isa Tuple{SVector{2, Int}, Int}
     ls = ls1[sublats = :B]
     @test isempty(ls)
-    ls = lat[cells = n -> norm(n) < 4]
-    @test all(n -> norm(n) < 4, Quantica.cells(ls))
+    ls = lat[cells = n -> 5 < norm(n) < 10]
+    @test !isempty(Quantica.cells(ls)) && all(n -> 5 < norm(n) < 10, Quantica.cells(ls))
+    ls = lat[region = r -> 5 < norm(r) < 10]
+    @test !isempty(Quantica.cells(ls)) && all(r -> 5 < norm(r) < 10, Quantica.sites(ls))
+
 end


### PR DESCRIPTION
In supercell searches without a specific list of cells, we ensure BoxIterator keeps going until we find at least one site (or we exceed the maximum iterations). However `foreach_cell` did not have this check, and would stop as soon as a closed shell without hits was formed. This led to lattice slicing (using a region such as a ring around the origing) where we could fail to form a slice. Note also that `siteselector` has no `seed` option currently (unlike `supercell`), so this problem could not be worked around.

Perhaps a future refactor could employ `foreach_cell` and `foreach_site` in supercell, to be more DRY.