### PR TITLE
Composable and sticky `qplot` defaults

### DIFF
--- a/ext/QuanticaMakieExt/QuanticaMakieExt.jl
+++ b/ext/QuanticaMakieExt/QuanticaMakieExt.jl
@@ -11,7 +11,24 @@ using Quantica: Lattice, LatticeSlice, AbstractHamiltonian, Hamiltonian,
 
 import Quantica: plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults
 
-# Currying fallback
+## PlotArgumentTypes
+
+const PlotLatticeArgumentType{E} = Union{
+    Lattice{<:Any,E},
+    LatticeSlice{<:Any,E},
+    AbstractHamiltonian{<:Any,E},
+    GreenFunction{<:Any,E}}
+
+const PlotBandsArgumentType{E} =
+    Union{Quantica.Bandstructure{<:Any,E},
+          Quantica.Subband{<:Any,E},
+          AbstractVector{<:Quantica.Subband{<:Any,E}},
+          Quantica.Mesh{<:Quantica.BandVertex{<:Any,E}},
+          AbstractVector{<:Quantica.Mesh{<:Quantica.BandVertex{<:Any,E}}}}
+
+const PlotArgumentType{E} = Union{PlotLatticeArgumentType{E},PlotBandsArgumentType{E}}
+
+## Currying fallbacks
 Quantica.qplot(; kw...) = x -> Quantica.qplot(x; kw...)
 Quantica.qplot!(; kw...) = x -> Quantica.qplot!(x; kw...)
 

--- a/ext/QuanticaMakieExt/defaults.jl
+++ b/ext/QuanticaMakieExt/defaults.jl
@@ -4,14 +4,59 @@
 
 ## qplot defaults
 
-function qplotdefaults(; figure::NamedTuple = (;), axis::NamedTuple = (;))
-    global default_figure_kwarg = figure
-    global default_axis_kwarg = axis
-    return (; default_figure_kwarg, default_axis_kwarg)
+function qplotdefaults(;
+    figure::Union{Missing,NamedTuple} = missing,
+    axis2D::Union{Missing,NamedTuple} = missing,
+    axis3D::Union{Missing,NamedTuple} = missing,
+    lscene::Union{Missing,NamedTuple} = missing)
+    ismissing(figure) || (global user_default_figure = figure)
+    ismissing(axis2D) || (global user_default_axis2D = axis2D)
+    ismissing(axis3D) || (global user_default_axis3D = axis3D)
+    ismissing(lscene) || (global user_default_lscene = lscene)
+    return (; user_default_figure, user_default_axis2D, user_default_axis3D, user_default_lscene)
 end
 
-default_figure_kwarg = (;)
-default_axis_kwarg = (;)
+qplotdefaults(defaults::NamedTuple) = qplotdefaults(; defaults...)
+
+user_default_figure = (;)
+user_default_axis2D = (;)
+user_default_axis3D = (;)
+user_default_lscene = (;)
+
+# Choose used_default_axis for each given type of plotted object
+axis_defaults(::PlotArgumentType{3}, fancyaxis) = axis_defaults(fancyaxis)
+axis_defaults(::PlotArgumentType, fancyaxis) = user_default_axis2D
+axis_defaults(fancyaxis::Bool) = ifelse(fancyaxis, user_default_lscene, user_default_axis3D)
+
+empty_fig_axis(b::PlotArgumentType; kw...) = (checkplotdim(b); _empty_fig_axis(b; kw...))
+
+_empty_fig_axis(::PlotLatticeArgumentType{3}; kw...) = empty_fig_axis_3D(plotlat_default_3D...; kw...)
+_empty_fig_axis(b::PlotLatticeArgumentType; kw...) = empty_fig_axis_2D(plotlat_default_2D...; kw...)
+_empty_fig_axis(::PlotBandsArgumentType{3}; kw...) = empty_fig_axis_3D(plotbands_default_3D...; kw...)
+_empty_fig_axis(b::PlotBandsArgumentType; kw...) = empty_fig_axis_2D(plotbands_default_2D...; kw...)
+
+function empty_fig_axis_2D(default_figure, default_axis2D; axis = user_default_axis2D, figure = user_default_figure, kw...)
+    axis´ = merge(user_default_axis2D, axis)
+    fig = Figure(; default_figure..., figure...)
+    ax = Axis(fig[1,1]; default_axis2D..., axis´...)
+    tight_ticklabel_spacing!(ax)  # Workaround for Makie issue #3009
+    return fig, ax
+end
+
+function empty_fig_axis_3D(default_figure, default_axis3D, default_lscene;
+    fancyaxis = true,
+    axis = axis_defaults(fancyaxis),
+    figure = user_default_figure, kw...)
+    fig = Figure(; default_figure..., figure...)
+    axis´ = merge(axis_defaults(fancyaxis), axis)
+    ax = fancyaxis ?
+        LScene(fig[1,1]; default_lscene..., axis´...) :
+        Axis3(fig[1,1]; default_axis3D..., axis´...)
+    return fig, ax
+end
+
+checkplotdim(::PlotArgumentType{E}) where {E} =
+    E > 3 && argerror("Cannot represent a mesh in an $E-dimensional embedding space")
 
 ## plotlattice defaults
 
@@ -41,13 +86,14 @@ const plotlat_default_3D =
 const plotbands_default_figure = (; resolution = (1200, 1200), fontsize = 40)
 
 const plotbands_default_axis3D = (;
+    xlabel = "ϕ₁", ylabel = "ϕ₂", zlabel = "ϕ₃",
     xticklabelcolor = :gray, yticklabelcolor = :gray, zticklabelcolor = :gray,
     xspinewidth = 0.2, yspinewidth = 0.2, zspinewidth = 0.2,
     xlabelrotation = 0, ylabelrotation = 0, zlabelrotation = 0,
     xticklabelsize = 30, yticklabelsize = 30, zticklabelsize = 30,
-    xlabelsize = 40, ylabelsize = 40, zlabelsize = 40,
+    xlabelsize = 35, ylabelsize = 35, zlabelsize = 35,
     xlabelfont = :italic, ylabelfont = :italic, zlabelfont = :italic,
-    perspectiveness = 0.0, aspect = :data)
+    perspectiveness = 0.4, aspect = :data)
 
 const plotbands_default_axis2D = (; autolimitaspect = nothing)
 

--- a/ext/QuanticaMakieExt/defaults.jl
+++ b/ext/QuanticaMakieExt/defaults.jl
@@ -8,12 +8,14 @@ function qplotdefaults(;
     figure::Union{Missing,NamedTuple} = missing,
     axis2D::Union{Missing,NamedTuple} = missing,
     axis3D::Union{Missing,NamedTuple} = missing,
-    lscene::Union{Missing,NamedTuple} = missing)
+    lscene::Union{Missing,NamedTuple} = missing,
+    inspector::Union{Missing,NamedTuple} = missing)
     ismissing(figure) || (global user_default_figure = figure)
     ismissing(axis2D) || (global user_default_axis2D = axis2D)
     ismissing(axis3D) || (global user_default_axis3D = axis3D)
     ismissing(lscene) || (global user_default_lscene = lscene)
-    return (; user_default_figure, user_default_axis2D, user_default_axis3D, user_default_lscene)
+    ismissing(inspector) || (global user_default_inspector = inspector)
+    return (; user_default_figure, user_default_axis2D, user_default_axis3D, user_default_lscene, user_default_inspector)
 end
 
 qplotdefaults(defaults::NamedTuple) = qplotdefaults(; defaults...)
@@ -22,6 +24,7 @@ user_default_figure = (;)
 user_default_axis2D = (;)
 user_default_axis3D = (;)
 user_default_lscene = (;)
+user_default_inspector = (;)
 
 # Choose used_default_axis for each given type of plotted object
 axis_defaults(::PlotArgumentType{3}, fancyaxis) = axis_defaults(fancyaxis)
@@ -103,5 +106,9 @@ const plotbands_default_2D =
     (plotbands_default_figure, plotbands_default_axis2D)
 const plotbands_default_3D =
     (plotbands_default_figure, plotbands_default_axis3D, plotbands_default_lscene)
+
+## inspector defaults
+
+const default_inspector = (; fontsize = 20)
 
 #endregion

--- a/ext/QuanticaMakieExt/docstrings.jl
+++ b/ext/QuanticaMakieExt/docstrings.jl
@@ -145,9 +145,12 @@ Render bands-based `object` on currently active scene. See `plotbands` for possi
 plotbands!
 
 """
-    qplotdefaults(; figure = missing, axis2D = missing, axis3D = missing, lscene = missing)
+    qplotdefaults(; figure = missing, axis2D = missing, axis3D = missing, lscene = missing, inspector = missing)
 
-Define default values for the `figure` and `axis` keyword arguments of `qplot`.
+Define default values for the `figure` and `axis` keyword arguments of `qplot`. The `axis2D`
+defaults are applied to `axis` for 2D plots, while `lscene` or `axis3D` are applied to
+`axis` if `fancyaxis` is `true` or `false`, respectively. Similarly, the `inspector`
+defaults are passed to `DataInspector` if tooltips are activated.
 
     qplotdefaults(defaults::NamedTuple)
 
@@ -156,11 +159,10 @@ Equivalent to `qplotdefaults(; defaults...)`
 # Examples
 ```jldoctest
 julia> qplotdefaults(figure = (resolution = (1000, 1000),))
-(user_default_figure = (resolution = (1000, 1000),), user_default_axis2D = NamedTuple(), user_default_axis3D = NamedTuple(), user_default_lscene = NamedTuple())
+(user_default_figure = (resolution = (1000, 1000),), user_default_axis2D = NamedTuple(), user_default_axis3D = NamedTuple(), user_default_lscene = NamedTuple(), user_default_inspector = NamedTuple())
 
-julia> qplotdefaults(axis2D = (xlabel = "X",))
-(user_default_figure = (resolution = (1000, 1000),), user_default_axis2D = (xlabel = "X",), user_default_axis3D = NamedTuple(), user_default_lscene = NamedTuple())
-
+julia> qplotdefaults(axis2D = (xlabel = "X",), inspector = (fontsize = 30,))
+(user_default_figure = (resolution = (1000, 1000),), user_default_axis2D = (xlabel = "X",), user_default_axis3D = NamedTuple(), user_default_lscene = NamedTuple(), user_default_inspector = (fontsize = 30,))
 ```
 """
 qplotdefaults

--- a/ext/QuanticaMakieExt/docstrings.jl
+++ b/ext/QuanticaMakieExt/docstrings.jl
@@ -145,17 +145,22 @@ Render bands-based `object` on currently active scene. See `plotbands` for possi
 plotbands!
 
 """
-    qplotdefaults(; figure = (;), axis = (;))
+    qplotdefaults(; figure = missing, axis2D = missing, axis3D = missing, lscene = missing)
 
 Define default values for the `figure` and `axis` keyword arguments of `qplot`.
+
+    qplotdefaults(defaults::NamedTuple)
+
+Equivalent to `qplotdefaults(; defaults...)`
 
 # Examples
 ```jldoctest
 julia> qplotdefaults(figure = (resolution = (1000, 1000),))
-(default_figure_kwarg = (resolution = (1000, 1000),), default_axis_kwarg = NamedTuple())
+(user_default_figure = (resolution = (1000, 1000),), user_default_axis2D = NamedTuple(), user_default_axis3D = NamedTuple(), user_default_lscene = NamedTuple())
 
-julia> qplotdefaults()
-(default_figure_kwarg = NamedTuple(), default_axis_kwarg = NamedTuple())
+julia> qplotdefaults(axis2D = (xlabel = "X",))
+(user_default_figure = (resolution = (1000, 1000),), user_default_axis2D = (xlabel = "X",), user_default_axis3D = NamedTuple(), user_default_lscene = NamedTuple())
+
 ```
 """
 qplotdefaults

--- a/ext/QuanticaMakieExt/plotbands.jl
+++ b/ext/QuanticaMakieExt/plotbands.jl
@@ -23,19 +23,9 @@ end
 #   slice(b, ...)::Vector{Mesh}
 #region
 
-const PlotBandsArgumentType =
-    Union{Quantica.Bandstructure,Quantica.Subband,AbstractVector{<:Quantica.Subband},AbstractVector{<:Quantica.Mesh},Quantica.Mesh}
-
-function Quantica.qplot(b::PlotBandsArgumentType; fancyaxis = true, axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, plotkw...)
-    meshes = collect(Quantica.meshes(b))
-    E = Quantica.embdim(first(meshes))
-    fig, ax = if E < 3
-        empty_fig_axis_2D(plotbands_default_2D...; axis, figure)
-    elseif E == 3
-        empty_fig_axis_3D(plotbands_default_3D...; fancyaxis, axis, figure)
-    else
-        argerror("Cannot represent a mesh in an $E-dimensional embedding space")
-    end
+function Quantica.qplot(b::PlotBandsArgumentType;
+    fancyaxis = true, axis = axis_defaults(b, fancyaxis), figure = user_default_figure, inspector = false, plotkw...)
+    fig, ax = empty_fig_axis(b; fancyaxis, axis, figure)
     plotbands!(ax, b; plotkw...)
     inspector && DataInspector()
     return fig

--- a/ext/QuanticaMakieExt/plotbands.jl
+++ b/ext/QuanticaMakieExt/plotbands.jl
@@ -27,7 +27,7 @@ function Quantica.qplot(b::PlotBandsArgumentType;
     fancyaxis = true, axis = axis_defaults(b, fancyaxis), figure = user_default_figure, inspector = false, plotkw...)
     fig, ax = empty_fig_axis(b; fancyaxis, axis, figure)
     plotbands!(ax, b; plotkw...)
-    inspector && DataInspector()
+    inspector && DataInspector(; default_inspector..., user_default_inspector...)
     return fig
 end
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -39,7 +39,7 @@ function Quantica.qplot(h::PlotLatticeArgumentType;
     fancyaxis = true, axis = axis_defaults(h, fancyaxis), figure = user_default_figure, inspector = false, plotkw...)
     fig, ax = empty_fig_axis(h; fancyaxis, axis, figure)
     plotlattice!(ax, h; plotkw...)
-    inspector && DataInspector()
+    inspector && DataInspector(; default_inspector..., user_default_inspector...)
     return fig
 end
 
@@ -56,7 +56,7 @@ function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = axis_defaults
     # Makie BUG: To allow inspector to show topmost tooltip, it should be transparent
     # if other layers (here the leads) are transparent
     plotlattice!(ax, parent(g); plotkw..., force_transparency = inspector && !isempty(Σs))
-    inspector && DataInspector()
+    inspector && DataInspector(; default_inspector..., user_default_inspector...)
     return fig
 end
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -1,4 +1,3 @@
-
 ############################################################################################
 # plotlattice recipe
 #region
@@ -36,23 +35,15 @@ end
 # qplot
 #region
 
-const PlotLatticeArgumentType{E} = Union{Lattice{<:Any,E},LatticeSlice{<:Any,E},AbstractHamiltonian{<:Any,E}}
-
-function Quantica.qplot(h::PlotLatticeArgumentType{3}; fancyaxis = true, axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, plotkw...)
-    fig, ax = empty_fig_axis_3D(plotlat_default_3D...; fancyaxis, axis, figure)
+function Quantica.qplot(h::PlotLatticeArgumentType;
+    fancyaxis = true, axis = axis_defaults(h, fancyaxis), figure = user_default_figure, inspector = false, plotkw...)
+    fig, ax = empty_fig_axis(h; fancyaxis, axis, figure)
     plotlattice!(ax, h; plotkw...)
     inspector && DataInspector()
     return fig
 end
 
-function Quantica.qplot(h::PlotLatticeArgumentType; axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, plotkw...)
-    fig, ax = empty_fig_axis_2D(plotlat_default_2D...; axis, figure)
-    plotlattice!(ax, h; plotkw...)
-    inspector && DataInspector()
-    return fig
-end
-
-function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = default_axis_kwarg, figure = default_figure_kwarg, inspector = false, children = missing, plotkw...)
+function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = axis_defaults(g, fancyaxis), figure = user_default_figure, inspector = false, children = missing, plotkw...)
     fig, ax = empty_fig_axis(g; fancyaxis, axis, figure)
     Σkws = Iterators.cycle(parse_children(children))
     Σs = Quantica.selfenergies(Quantica.contacts(g))
@@ -69,17 +60,11 @@ function Quantica.qplot(g::GreenFunction; fancyaxis = true, axis = default_axis_
     return fig
 end
 
-Quantica.qplot!(x::Union{PlotLatticeArgumentType,GreenFunction}; kw...) =
-    plotlattice!(x; kw...)
+Quantica.qplot!(x::PlotLatticeArgumentType; kw...) = plotlattice!(x; kw...)
 
 parse_children(::Missing) = (NamedTuple(),)
 parse_children(p::Tuple) = p
 parse_children(p::NamedTuple) = (p,)
-
-empty_fig_axis(::GreenFunction{<:Any,3}; kw...) =
-    empty_fig_axis_3D(plotlat_default_3D...; kw...)
-empty_fig_axis(::GreenFunction; kw...) =
-    empty_fig_axis_2D(plotlat_default_2D...; kw...)
 
 #endregion
 

--- a/ext/QuanticaMakieExt/tools.jl
+++ b/ext/QuanticaMakieExt/tools.jl
@@ -31,21 +31,6 @@ jointextrema(v, v´) = min(minimum(v; init = 0f0), minimum(v´; init = 0f0)), ma
 safeextrema(v::Missing) = (Float32(0), Float32(1))
 safeextrema(v) = isempty(v) ? (Float32(0), Float32(1)) : extrema(v)
 
-function empty_fig_axis_2D(default_figure, default_axis2D; axis = (;), figure = (;), kw...)
-    fig = Figure(; default_figure..., figure...)
-    ax = Axis(fig[1,1]; default_axis2D..., axis...)
-    tight_ticklabel_spacing!(ax)  # Workaround for Makie issue #3009
-    return fig, ax
-end
-
-function empty_fig_axis_3D(default_figure, default_axis3D, default_lscene; fancyaxis = true, axis = (;), figure = (;), kw...)
-    fig = Figure(; default_figure..., figure...)
-    ax = fancyaxis ?
-        LScene(fig[1,1]; default_lscene..., axis...) :
-        Axis3(fig[1,1]; default_axis3D..., axis...)
-    return fig, ax
-end
-
 has_transparencies(x::Real) = !(x ≈ 1)
 has_transparencies(::Missing) = false
 has_transparencies(x) = true


### PR DESCRIPTION
This build on top of #220 by splitting the defaults into four categories, for `Figure`, `Axis`, `Axis3D` and `LScene`. It also makes defaults sticky and composable: they are not overwritten by new defaults in a different category and they are merged with the explicit options passed to `qplot`. 