### PR TITLE
Faster `bands`: do `set_blas_threads(1)` before diagonalization, then restore

### DIFF
--- a/src/bands.jl
+++ b/src/bands.jl
@@ -137,7 +137,10 @@ function subbands_precompilable(hf::FunctionWrapper, solvers::Vector{A}, basemes
     # Uses multiple SpectrumSolvers (one per Julia thread) to diagonalize h at each
     # vertex of basemesh. Then, it collects each of the produced Spectrum (aka "columns")
     # into a bandverts::Vector{BandVertex}, recording the coloffsets for each column
+    blasthreads = BLAS.get_num_threads()
+    BLAS.set_num_threads(1)
     subbands_diagonalize!(data)
+    BLAS.set_num_threads(blasthreads)
 
     # Step 2 - Knit seams:
     # Each base vertex holds a column of subspaces. Each subspace s of degeneracy d will


### PR DESCRIPTION
The diagonalization step in `bands` is multithreaded over momenta. BLAS is also multithreaded by default. But actual diagonalization of matrices is more difficult to multithread than the loop over momenta, so it is much faster to switch to 1 single BLAS thread for the diagonalization step in `bands`, and then return to whatever it was before. The difference is specially dramatic using `EigenSolvers.LinearAlgebra`, to the point in which it is the fastest method (with multithreading) up to pretty large unit cells (like here, with 200 orbitals, 8 threads)

Master:
```julia
➜  ~ julia -t 8 -e "using Quantica, LinearAlgebra; h = HP.graphene() |> supercell(10); s=subdiv(0,2pi,50); @time bands(h, s, s);"
Step 1 - Diagonalizing: 100%|██████████████████████████████████| Time: 0:01:55
Step 2 - Knitting: 100%|███████████████████████████████████████| Time: 0:00:06
126.732104 seconds (26.83 M allocations: 11.157 GiB, 0.36% gc time, 4.15% compilation time)
```

This PR:
```julia
➜  ~ julia -t 8 -e "using Quantica, LinearAlgebra; h = HP.graphene() |> supercell(10); s=subdiv(0,2pi,50); @time bands(h, s, s);"
Step 1 - Diagonalizing: 100%|██████████████████████████████████| Time: 0:00:04
Step 2 - Knitting: 100%|███████████████████████████████████████| Time: 0:00:05
 15.468912 seconds (26.88 M allocations: 11.161 GiB, 3.01% gc time, 39.75% compilation time)
```
