### PR TITLE
Add 32bit support for GreenFunctions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  actions: write
+  contents: read
 jobs:
   test:
     if: github.event_name == 'push' && contains(toJson(github.event.commits), '[skip test]') == false && contains(toJson(github.event.commits), '[skip tests]') == false
@@ -14,23 +17,24 @@ jobs:
       matrix:
         version:
           - '1'
-          # - 'nightly'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
-          - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
+          # - x86   ## Currently broken on nightly due to OutOfMemoryError()
+        # exclude:
+        #   - os: macOS-latest
+        #     arch: x86
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@latest

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -15,6 +15,9 @@ Base.convert(::Type{T}, l::CellSites) where T<:CellSites = T(l)
 Base.convert(::Type{T}, l::T) where T<:AbstractHamiltonian = l
 Base.convert(::Type{T}, l::AbstractHamiltonian) where T<:AbstractHamiltonian = T(l)
 
+Base.convert(::Type{T}, l::T) where T<:Mesh = l
+Base.convert(::Type{T}, l::Mesh) where T<:Mesh = T(l)
+
 # Constructors for conversion
 Sublat{T,E}(s::Sublat, name = s.name) where {T<:AbstractFloat,E} =
     Sublat{T,E}([sanitize_SVector(SVector{E,T}, site) for site in sites(s)], name)
@@ -39,6 +42,9 @@ function ParametricHamiltonian{E}(ph::ParametricHamiltonian) where {E}
     pars = parameters(ph)
     return ParametricHamiltonian(hparent, h, ms, ptrs, pars)
 end
+
+Mesh{S}(m::Mesh) where {S} =
+    Mesh(convert(Vector{S}, vertices(m)), neighbors(m), simplices(m))
 
 # We need this to promote different sublats into common dimensionality and type to combine
 # into a lattice

--- a/src/presets/hamiltonians.jl
+++ b/src/presets/hamiltonians.jl
@@ -6,16 +6,16 @@ module HamiltonianPresets
 
 using Quantica, LinearAlgebra
 
-function graphene(; a0 = 0.246, range = a0/sqrt(3), t0 = 2.7, β = 3, dim = 2, type = Float64, names = (:A, :B), kw...)
+function graphene(; a0 = 0.246, range = neighbors(1), t0 = 2.7, β = 3, dim = 2, type = Float64, names = (:A, :B), kw...)
     lat = LatticePresets.honeycomb(; a0, dim, type, names)
     h = hamiltonian(lat,
-        hopping((r, dr) -> t0 * exp(-β*(sqrt(3) * norm(dr)/a0 - 1)) * I,range = range); kw...)
+        hopping((r, dr) -> t0 * exp(-β*(sqrt(3) * norm(dr)/a0 - 1)) * I, range = range); kw...)
     return h
 end
 
 function twisted_bilayer_graphene(;
     twistindex = 1, twistindices = (twistindex, 1), a0 = 0.246,
-    interlayerdistance = 1.36a0, rangeintralayer = a0/sqrt(3), rangeinterlayer = 4a0/sqrt(3),
+    interlayerdistance = 1.36a0, rangeintralayer = neighbors(1), rangeinterlayer = 4a0/sqrt(3),
     hopintra = 2.70 * I, hopinter = 0.48, modelintra = hopping(hopintra, range = rangeintralayer),
     type = Float64, names = (:Ab, :Bb, :At, :Bt),
     kw...)

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -157,7 +157,7 @@ combine_subcells(c::C, cs::C...) where {C<:CellOrbitals} =
 function combine_subcells(c::C, cs::C...) where {C<:CellOrbitalsGrouped}
     groups´ = merge(orbgroups(c), orbgroups.(cs)...)
     indices´ = union(orbindices(c), orbindices.(cs)...)
-    return CellIndices(cell(c), indices´, OrbitalLikeGrouped(groups´))
+    return CellOrbitalsGrouped(cell(c), indices´, groups´)
 end
 
 #endregion
@@ -299,7 +299,7 @@ sites_to_orbs(c::AnyCellOrbitalsDict, _) = c
 sites_to_orbs(c::AnyCellOrbitals, _) = c
 
 ## convert SiteSlice -> OrbitalSliceGrouped/OrbitalSlice
-Contacts
+
 sites_to_orbs(s::SiteSelector, g) = sites_to_orbs(lattice(g)[s], g)
 sites_to_orbs(kw::NamedTuple, g) = sites_to_orbs(getindex(lattice(g); kw...), g)
 sites_to_orbs(i::Integer, g) = orbslice(selfenergies(contacts(g), i))
@@ -335,13 +335,13 @@ function sites_to_orbs(cs::CellSites, os::OrbitalBlockStructure)
     sites = siteindices(cs)
     groups = _groups(sites, os) # sites, orbranges
     orbinds = _orbinds(sites, groups, os)
-    return CellIndices(cell(cs), orbinds, OrbitalLikeGrouped(Dictionary(groups...)))
+    return CellOrbitalsGrouped(cell(cs), orbinds, Dictionary(groups...))
 end
 
 function sites_to_orbs_flat(cs::CellSites, os::OrbitalBlockStructure)
     sites = siteindices(cs)
     orbinds = _orbinds(sites, os)
-    return CellIndices(cell(cs), orbinds, OrbitalLike())
+    return CellOrbitals(cell(cs), orbinds)
 end
 
 _groups(i::Integer, os) = [i], [flatrange(os, i)]

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -174,10 +174,10 @@ needs_omega_shift(s::AppliedKPMGreenSolver) = false
 
 #region ## apply ##
 
-function apply(s::GS.KPM,  h::Hamiltonian{<:Any,<:Any,0}, cs::Contacts)
+function apply(s::GS.KPM,  h::Hamiltonian{T,<:Any,0}, cs::Contacts) where {T}
     isempty(cs) && argerror("The KPM solver requires at least one contact to be added that defiens where the Green function will be computed. A dummy contact can be created with `attach(nothing; sites...)`.")
     hmat = h(())
-    bandCH = band_ceter_halfwidth(hmat, s.bandrange, s.padfactor)
+    bandCH = T.(band_ceter_halfwidth(hmat, s.bandrange, s.padfactor))
     ket = contact_basis(h, cs)
     momenta = momentaKPM(hmat, ket, bandCH; order = s.order, kernel = s.kernel)
     return AppliedKPMGreenSolver(momenta, bandCH)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -15,6 +15,8 @@ rdr((r1, r2)::Pair) = (0.5 * (r1 + r2), r2 - r1)
 @inline tupleflatten(x0::Tuple, x1, xs...) = tupleflatten((x0..., x1), xs...)
 @inline tupleflatten(x0::Tuple, x1::Tuple, xs...) = tupleflatten((x0..., x1...), xs...)
 
+tuplefill(x, ::Val{N}) where {N} = ntuple(Returns(x), Val(N))
+
 padtuple(t, x, N) = ntuple(i -> i <= length(t) ? t[i] : x, N)
 
 @inline tupletake(x, ::Val{N}) where {N} = ntuple(i -> x[i], Val(N))

--- a/src/types.jl
+++ b/src/types.jl
@@ -316,14 +316,17 @@ const AnyOrbitalSlice = Union{OrbitalSlice,OrbitalSliceGrouped}
 #region ## Constructors ##
 
 CellSite(cell, ind::Int) = CellIndices(sanitize_SVector(Int, cell), ind, SiteLike())
-CellSites(cell, inds = Int[]) = CellIndices(sanitize_SVector(Int, cell), inds, SiteLike())
+CellSites(cell, inds = Int[]) = CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), SiteLike())
 # exported lowercase constructor for general inds
 cellsites(cell, inds) = CellSites(cell, inds)
 
 CellOrbitals(cell, inds = Int[]) =
-    CellIndices(sanitize_SVector(Int, cell), inds, OrbitalLike())
+    CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), OrbitalLike())
 CellOrbital(cell, ind::Int) =
     CellIndices(sanitize_SVector(Int, cell), ind, OrbitalLike())
+
+CellOrbitalsGrouped(cell, inds, groups::Dictionary) =
+    CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), OrbitalLikeGrouped(groups))
 
 # LatticeSlice from an AbstractVector of CellIndices
 LatticeSlice(lat::Lattice, cs::AbstractVector{<:CellIndices}) =

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -10,7 +10,7 @@ function testgreen(h, s; kw...)
     L = Quantica.latdim(lattice(h))
     z = zero(SVector{L,Int})
     o = Quantica.unitvector(1, SVector{L,Int})
-    locs = (cellsites(z, :), cellsites(z, 2:3), cellsites(z, 2), cellsites(o, :), CellOrbitals(o, 1), CellOrbitals(z, 2:3))
+    locs = (cellsites(z, :), cellsites(z, 2), cellsites(z, 1:2), cellsites(z, (1,2)), cellsites(o, :), CellOrbitals(o, 1), CellOrbitals(z, 1:2), CellOrbitals(z, SA[2,1]))
     for loc in locs, loc´ in locs
         gs = g[loc, loc´]
         @test gs isa GreenSlice
@@ -163,6 +163,36 @@ end
         @test maximum(abs.(gc[cells = 1](0.5) - gd[cells = 1](0.5))) < 0.08
         @test all(>=(0), ldos(gc[1])(0.2))
         @test all(>=(0), ldos(gc[region = RP.circle(2)])(0.2))
+    end
+end
+
+@testset "greenfunction 32bit" begin
+    # GS.Bands
+    # skip for older versions due to https://github.com/JuliaLang/julia/issues/53054
+    # which makes solve not deterministic when adding sufficiently many band simplices
+    if VERSION >= v"1.11.0-DEV.632"
+        h = HP.graphene(type = Float32)
+        s = GS.Bands()
+        testgreen(h, s)
+    end
+    h = HP.graphene(type = Float32, a0 = 1) |> supercell(10) |> supercell
+    s = GS.SparseLU()
+    testgreen(h, s)
+
+    # GS.Schur
+    h = HP.graphene(type = Float32, a0 = 1) |> supercell((1,-1), region = r -> 0<=r[2]<=3)
+    s = GS.Schur()
+    testgreen(h, s)
+    s = GS.Schur(boundary = -1)
+    testgreen(h, s)
+
+    # GS.KPM
+    g = HP.graphene(a0 = 1, t0 = 1, orbitals = (2,1), type = Float32) |>
+        supercell(region = RP.circle(20)) |>
+        attach(nothing, region = RP.circle(1)) |> greenfunction(GS.KPM(order = 300, bandrange = (-3.1, 3.1)))
+    ρs = ldos(g[1], kernel = missing)
+    for ω in -3:0.1:3
+        @test all(>=(0), ρs(ω))
     end
 end
 


### PR DESCRIPTION
Closes #236 

Although Quantica is coded for a generic `T<:AbstractFloat`, the GreenFunction part was not tested for `T == Float32`, only for `T == Float64`. Doing so revealed a number of issues, which are fixed in this PR

- In general, the ω argument of calls to GreenFunctions needed to be cast to the appropriate T or Complex{T} type at the beginning of the call chain.
- `GreenSolvers.SparseLU`, which relies on UMFPACK, does not support `ComplexF32` eltypes yet, so we must internally work with `ComplexF64`, taking care to return `ComplexF32` if needed without making extra copies. Tim Davis mentioned on slack that `ComplexF32` support is in the short-term to-do list for UMFPACK. At that point, the corresponding part of this PR could be simplified and generalized.
- `GreenSolvers.Schur` builds on `SparseLU` for some of its internals, so it needs adjustments
- `GreenSolvers.Bands` needed a conversion of the Brillouin zone mesh to the Hamiltonian eltype to properly propagate the ComplexF32 type
- `GreenSolvers.Bands` relied on a random choice of dual numbers for degeneracy resolution. This randomness exactly cancelled out in all our tests at 64bit precision, so the results were deterministic. But on 32bit, the lower precision made the cancellation inexact, and the result would vary from run to run, or even yield divide-by-zero errors. In collaboration with Adrián Prada we devised a new algorithm to choose the optimal dual number that is deterministic and retains maximal precision
- Detailed testing of the above revealed that Apple Silicon processors would not handle BLAS operations of 32-bit numbers deterministically, due to a [subtle bug in the OpenBLAS](https://github.com/JuliaLang/julia/issues/53054#issuecomment-1911716754) bundled in Julia 1.9 and 1.10. This was fixed in OpenBLAS 0.3.24, so Julia 1.11 does not have the issue. A [backport of the fix](https://github.com/JuliaLang/julia/pull/53074) to Julia 1.10 will land soon.
