### PR TITLE
Add `densitymatrix` observable at thermal equilibrium

### DIFF
--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -67,17 +67,20 @@ The currently implemented `GreenSolver`s (abbreviated as `GS`) are the following
 
   Uses a sparse `LU` factorization to compute the inverse of `⟨i|ω - H - Σ(ω)|j⟩`, where `Σ(ω)` is the self-energy from the contacts.
 
+
 - `GS.Spectrum(; spectrum_kw...)`
 
-  For bounded (`L=0`) AbstractHamiltonians.
+  For bounded (`L=0`) Hamiltonians. This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first.
 
   Uses a diagonalization of `H`, obtained with `spectrum(H; spectrum_kw...)`, to compute the `G⁰ᵢⱼ` using the Lehmann representation `∑ₖ⟨i|ϕₖ⟩⟨ϕₖ|j⟩/(ω - ϵₖ)`. Any eigensolver supported by `spectrum` can be used here. If there are contacts, it dresses `G⁰` using a T-matrix approach, `G = G⁰ + G⁰TG⁰`.
+
 
 - `GS.KPM(order = 100, bandrange = missing, kernel = I)`
 
   For bounded (`L=0`) Hamiltonians, and restricted to sites belonging to contacts (see the section on Contacts).
 
   It precomputes the Chebyshev momenta, and incorporates the contact self energy with a T-matrix approach.
+
 
 - `GS.Schur(boundary = Inf)`
 
@@ -86,6 +89,7 @@ The currently implemented `GreenSolver`s (abbreviated as `GS`) are the following
   Uses a deflating Generalized Schur (QZ) factorization of the generalized eigenvalue problem to compute the unit-cell self energies.
   The Dyson equation then yields the Green function between arbitrary unit cells, which is further dressed using a T-matrix approach if the lead has any attached self-energy.
 
+
 - `GS.Bands(bandsargs...; boundary = missing, bandskw...)`
 
   For unbounded (`L>0`) Hamiltonians.
@@ -93,6 +97,7 @@ The currently implemented `GreenSolver`s (abbreviated as `GS`) are the following
   It precomputes a bandstructure `b = bands(h, bandsargs...; kw..., split = false)` and then uses analytic expressions for the contribution of each subband simplex to the `GreenSolution`. If `boundary = dir => cell_pos`, it takes into account the reflections on an infinite boundary perpendicular to Bravais vector number `dir`, so that all sites with cell index `c[dir] <= cell_pos` are removed. Contacts are incorporated using a T-matrix approach.
 
   To retrieve the bands from a `g::GreenFunction` that used the `GS.Bands` solver, we may use `bands(g)`.
+
 
 ## Attaching Contacts
 

--- a/docs/src/tutorial/observables.md
+++ b/docs/src/tutorial/observables.md
@@ -14,23 +14,81 @@ See the corresponding docstrings for full usage instructions. Here we will prese
 
 ## Local density of states (LDOS)
 
-Let us compute the LDOS in a cavity like in the previous section. Instead of computing the Green function between a contact to an arbitrary point, we can construct an object `ρ = ldos(g(ω))` without any contacts. By using a small imaginary part in `ω`, we broaden the discrete spectrum, and obtain a finite LDOS. Then, we can pass `ρ` directly as a site shader to `qplot`
+Let us compute the LDOS in a cavity like in the previous section. Instead of computing the Green function between a contact to an arbitrary point, we can construct an object `d = ldos(g(ω))` without any contacts. By using a small imaginary part in `ω`, we broaden the discrete spectrum, and obtain a finite LDOS. Then, we can pass `d` directly as a site shader to `qplot`
 ```julia
 julia> h = LP.square() |> onsite(4) - hopping(1) |> supercell(region = r -> norm(r) < 40*(1+0.2*cos(5*atan(r[2],r[1]))));
 
-julia> g = h|> greenfunction;
+julia> g = h |> greenfunction;
 
-julia> ρ = ldos(g(0.1 + 0.001im))
+julia> d = ldos(g(0.1 + 0.001im))
 LocalSpectralDensitySolution{Float64} : local density of states at fixed energy and arbitrary location
   kernel   : LinearAlgebra.UniformScaling{Bool}(true)
 
-julia> qplot(h, hide = :hops, sitecolor = ρ, siteradius = ρ, minmaxsiteradius = (0, 2), sitecolormap = :balance)
+julia> qplot(h, hide = :hops, sitecolor = d, siteradius = d, minmaxsiteradius = (0, 2), sitecolormap = :balance)
 ```
 ```@raw html
 <img src="../../assets/star_shape_ldos.png" alt="LDOS" width="400" class="center"/>
 ```
 
-Note that `ρ[sites...]` produces a vector with the LDOS at sites defined by `siteselector(; sites...)` (`ρ[]` is the ldos over all sites). We can also define a `kernel` to be traced over orbitals to obtain the spectral density of site-local observables (see `diagonal` slicing in the preceding section).
+Note that `d[sites...]` produces a vector with the LDOS at sites defined by `siteselector(; sites...)` (`d[]` is the ldos over all sites). We can also define a `kernel` to be traced over orbitals to obtain the spectral density of site-local observables (see `diagonal` slicing in the preceding section).
+
+We can also compute the convolution of the density of states with the Fermi distribution `f(ω)=1/(exp((ω-μ)/kBT) + 1)`, which yields the density matrix in thermal equilibrium, at a given temperature `kBT` and chemical potential `μ`. This is computed with `ρ = densitymatrix(gs, (ωmin, ωmax); kBT = kBT, mu = μ)`. Here `gs = g[sites...]` is a `GreenSlice`, and `(ωmin, ωmax)` are integration bounds (they should span the full bandwidth of the system). Then, `ρ(; params...)` will yield a matrix over the selected `sites` for a set of model `params`.
+```julia
+julia> ρ = densitymatrix(g[region = RP.circle(1)], (-0.1, 8.1), mu = 4)
+Integrator: Complex-plane integrator
+  Integration path    : (-0.1 + 1.4901161193847656e-8im, 1.95 + 2.050000014901161im, 4.0 + 1.4901161193847656e-8im)
+  Integration options : (atol = 1.0e-7,)
+  Integrand           : GFermi{Float64}
+    kBT               : 0.0
+
+julia> @time ρ(4)
+  5.436825 seconds (57.99 k allocations: 5.670 GiB, 1.54% gc time)
+5×5 Matrix{ComplexF64}:
+          0.5+0.0im          -7.34893e-10-3.94035e-15im  0.204478+1.9366e-14im   -7.34889e-10-1.44892e-15im  -5.70089e-10+5.48867e-15im
+ -7.34893e-10+3.94035e-15im           0.5+0.0im          0.200693-2.6646e-14im   -5.70089e-10-1.95251e-15im  -7.34891e-10-2.13804e-15im
+     0.204478-1.9366e-14im       0.200693+2.6646e-14im        0.5+0.0im              0.200693+3.55692e-14im      0.204779-4.27255e-14im
+ -7.34889e-10+1.44892e-15im  -5.70089e-10+1.95251e-15im  0.200693-3.55692e-14im           0.5+0.0im          -7.34885e-10-3.49861e-15im
+ -5.70089e-10-5.48867e-15im  -7.34891e-10+2.13804e-15im  0.204779+4.27255e-14im  -7.34885e-10+3.49861e-15im           0.5+0.0im
+```
+
+Note that the diagonal is `0.5`, indicating half-filling.
+
+The default algorithm used here is slow, as it relies on numerical integration in the complex plane. Some GreenSolvers have more efficient implementations. If they exist, they can be accessed by omitting the `(ωmin, ωmax)` argument. For example, using `GS.Spectrum`:
+```julia
+julia> @time g = h |> greenfunction(GS.Spectrum());
+ 38.024189 seconds (2.81 M allocations: 2.929 GiB, 0.33% gc time, 1.86% compilation time)
+
+julia> ρ = densitymatrix(g[region = RP.circle(1)])
+DensityMatrix: density matrix on specified sites with solver of type DensityMatrixSpectrumSolver
+
+julia> @time ρ(4)
+  0.000723 seconds (8 allocations: 430.531 KiB)
+5×5 Matrix{ComplexF64}:
+          0.5+0.0im  -2.21437e-15+0.0im  0.204478+0.0im   2.67668e-15+0.0im   3.49438e-16+0.0im
+ -2.21437e-15+0.0im           0.5+0.0im  0.200693+0.0im  -1.40057e-15+0.0im  -2.92995e-15+0.0im
+     0.204478+0.0im      0.200693+0.0im       0.5+0.0im      0.200693+0.0im      0.204779+0.0im
+  2.67668e-15+0.0im  -1.40057e-15+0.0im  0.200693+0.0im           0.5+0.0im   1.81626e-15+0.0im
+  3.49438e-16+0.0im  -2.92995e-15+0.0im  0.204779+0.0im   1.81626e-15+0.0im           0.5+0.0im
+```
+
+Note, however, that the computation of `g` is much slower in this case, due to the need of a full diagonalization. A better algorithm choice in this case is `GS.KPM`. It requires, however, that we define the region for the density matrix beforehand, as a `nothing` contact.
+```julia
+julia> @time g = h |> attach(nothing, region = RP.circle(1)) |> greenfunction(GS.KPM(order = 10000, bandrange = (0,8)));
+Computing moments: 100%|█████████████████████████████████████████████████████████████████████████████████| Time: 0:00:01
+  1.704793 seconds (31.04 k allocations: 11.737 MiB)
+
+julia> ρ = densitymatrix(g[1])
+DensityMatrix: density matrix on specified sites with solver of type DensityMatrixKPMSolver
+
+julia> @time ρ(4)
+  0.006521 seconds (2 allocations: 992 bytes)
+5×5 Matrix{ComplexF64}:
+         0.5+0.0im  2.15097e-17+0.0im   0.20456+0.0im  2.15097e-17+0.0im   3.9251e-17+0.0im
+ 2.15097e-17+0.0im          0.5+0.0im  0.200631+0.0im  1.05873e-16+0.0im  1.70531e-18+0.0im
+     0.20456+0.0im     0.200631+0.0im       0.5+0.0im     0.200631+0.0im      0.20482+0.0im
+ 2.15097e-17+0.0im  1.05873e-16+0.0im  0.200631+0.0im          0.5+0.0im  1.70531e-18+0.0im
+  3.9251e-17+0.0im  1.70531e-18+0.0im   0.20482+0.0im  1.70531e-18+0.0im          0.5+0.0im
+```
 
 ## Current
 

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -29,7 +29,7 @@ export sublat, bravais_matrix, lattice, sites, supercell,
        spectrum, energies, states, bands, subdiv,
        greenfunction, selfenergy, attach, contact, cellsites,
        plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults,
-       conductance, josephson, ldos, current, transmission
+       conductance, josephson, ldos, current, transmission, densitymatrix
 
 export LatticePresets, LP, RegionPresets, RP, HamiltonianPresets, HP
 export EigenSolvers, ES, GreenSolvers, GS

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1522,7 +1522,7 @@ possible keyword arguments are
 - `GS.SparseLU()` : Direct inversion solver for 0D Hamiltonians using a `SparseArrays.lu(hmat)` factorization
 - `GS.Spectrum(; spectrum_kw...)` : Diagonalization solver for 0D Hamiltonians using `spectrum(h; spectrum_kw...)`
     - `spectrum_kw...` : keyword arguments passed on to `spectrum`
-    - This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first.
+    - This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first. Contact self-energies that depend on parameters are supported.
 - `GS.Schur(; boundary = Inf)` : Solver for 1D Hamiltonians based on a deflated, generalized Schur factorization
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
 - `GS.KPM(; order = 100, bandrange = missing, kernel = I)` : Kernel polynomial method solver for 0D Hamiltonians

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -482,8 +482,9 @@ end
 
 function GreenSolutionCache(gω::GreenSolution{T,<:Any,L}) where {T,L}
     cache = Dict{Tuple{SVector{L,Int},SVector{L,Int},Int},Matrix{Complex{T}}}()
+    # if contacts exists, we preallocate columns for each of their sites
     if ncontacts(gω) > 0
-        gmat = gω[:]    # may be missing if solver does not support (or doesn't have) contacts
+        gmat = gω[:]
         g = parent(gω)
         h = hamiltonian(g)
         bs = blockstructure(h)

--- a/src/show.jl
+++ b/src/show.jl
@@ -376,7 +376,7 @@ function Base.show(io::IO, I::Integrator)
     print(io, i, summary(I), "\n",
 "$i  Integration path    : $(points(I))
 $i  Integration options : $(display_namedtuple(options(I)))
-$i  Integrand:          :\n")
+$i  Integrand           : ")
     ioindent = IOContext(io, :indent => i * "  ")
     show(ioindent, integrand(I))
 end
@@ -389,19 +389,46 @@ display_namedtuple(nt::NamedTuple) = isempty(nt) ? "()" : "$nt"
 #endregion
 
 ############################################################################################
-# Josephson
+# Josephson (integrand)
 #region
 
 function Base.show(io::IO, J::JosephsonDensity)
     i = get(io, :indent, "")
-    print(io, i, summary(J), "\n",
+    print(io, summary(J), "\n",
 "$i  kBT                     : $(temperature(J))
 $i  Contact                 : $(contact(J))
 $i  Number of phase shifts  : $(numphaseshifts(J))")
 end
 
-Base.summary(::JosephsonDensity{T}) where {T} =
-    "JosephsonDensity{$T} : Equilibrium (dc) Josephson current observable before integration over energy"
+Base.summary(::JosephsonDensity{T}) where {T} = "JosephsonDensity{$T}"
+
+#endregion
+
+############################################################################################
+# DensityMatrix
+#region
+
+function Base.show(io::IO, d::DensityMatrix)
+    i = get(io, :indent, "")
+    print(io, summary(d))
+end
+
+Base.summary(::DensityMatrix{S}) where {S} =
+    "DensityMatrix: density matrix on specified sites using solver of type $(nameof(S))"
+
+#endregion
+
+############################################################################################
+# Josephson
+#region
+
+function Base.show(io::IO, j::Josephson)
+    i = get(io, :indent, "")
+    print(io, summary(j))
+end
+
+Base.summary(::Josephson{S}) where {S} =
+    "Josephson: equilibrium Josephson current at a specific contact using solver of type $(nameof(S))"
 
 #endregion
 

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -292,6 +292,9 @@ end
 #       - SiteSlice to an OrbitalSlice
 #region
 
+
+#region ## sites_to_orbs
+
 ## no-ops
 
 sites_to_orbs(s::AnyOrbitalSlice, _) = s
@@ -301,18 +304,19 @@ sites_to_orbs(c::AnyCellOrbitals, _) = c
 # unused
 # sites_to_orbs_nogroups(cs::CellOrbitals, _) =  cs
 
-## convert SiteSlice -> OrbitalSliceGrouped/OrbitalSlice
+## DiagIndices
+
+sites_to_orbs(d::DiagIndices, g) = DiagIndices(sites_to_orbs(parent(d), g), kernel(d))
+
+## convert SiteSlice -> OrbitalSliceGrouped
 
 sites_to_orbs(kw::NamedTuple, g) = sites_to_orbs(siteselector(; kw...), g)
 sites_to_orbs(s::SiteSelector, g) = sites_to_orbs(lattice(g)[s], g)
-sites_to_orbs(i::Integer, g) = orbslice(selfenergies(contacts(g), i))
+sites_to_orbs(i::Union{Colon,Integer}, g) = orbslice(contacts(g), i)
 sites_to_orbs(l::SiteSlice, g) =
     OrbitalSliceGrouped(lattice(l), sites_to_orbs(cellsdict(l), blockstructure(g)))
 
-sites_to_orbs_nogroups(l::SiteSlice, g) =
-    OrbitalSlice(lattice(l), sites_to_orbs_nogroups(cellsdict(l), blockstructure(g)))
-
-## convert CellSitesDict to CellOrbitalsGroupedDict/CellOrbitalsDict
+## convert CellSitesDict to CellOrbitalsGroupedDict
 
 sites_to_orbs(c::CellSitesDict, g) = sites_to_orbs(c, blockstructure(g))
 
@@ -322,15 +326,7 @@ function sites_to_orbs(cellsdict::CellSitesDict{L}, os::OrbitalBlockStructure) w
     return CellOrbitalsGroupedDict(co)
 end
 
-sites_to_orbs_nogroups(c::CellSitesDict, g) = sites_to_orbs_nogroups(c, blockstructure(g))
-
-function sites_to_orbs_nogroups(cellsdict::CellSitesDict{L}, os::OrbitalBlockStructure) where {L}
-    # inference fails if cellsdict is empty, so we need to specify eltype
-    co = CellOrbitals{L,Vector{Int}}[sites_to_orbs_nogroups(cellsites, os) for cellsites in cellsdict]
-    return CellOrbitalsDict(co)
-end
-
-## convert CellSites -> CellOrbitalsGrouped or CellOrbitals
+## convert CellSites -> CellOrbitalsGrouped
 
 sites_to_orbs(c::CellSites, g) = sites_to_orbs(c, blockstructure(g))
 
@@ -340,6 +336,27 @@ function sites_to_orbs(cs::CellSites, os::OrbitalBlockStructure)
     orbinds = _orbinds(sites, groups, os)
     return CellOrbitalsGrouped(cell(cs), orbinds, Dictionary(groups...))
 end
+
+#endregion
+
+#region ## sites_to_orbs_nogroups
+
+## convert SiteSlice -> OrbitalSlice
+
+sites_to_orbs_nogroups(l::SiteSlice, g) =
+    OrbitalSlice(lattice(l), sites_to_orbs_nogroups(cellsdict(l), blockstructure(g)))
+
+## convert CellSitesDict to CellOrbitalsDict
+
+sites_to_orbs_nogroups(c::CellSitesDict, g) = sites_to_orbs_nogroups(c, blockstructure(g))
+
+function sites_to_orbs_nogroups(cellsdict::CellSitesDict{L}, os::OrbitalBlockStructure) where {L}
+    # inference fails if cellsdict is empty, so we need to specify eltype
+    co = CellOrbitals{L,Vector{Int}}[sites_to_orbs_nogroups(cellsites, os) for cellsites in cellsdict]
+    return CellOrbitalsDict(co)
+end
+
+## convert CellSites -> CellOrbitals
 
 function sites_to_orbs_nogroups(cs::CellSites, os::OrbitalBlockStructure)
     sites = siteindices(cs)
@@ -352,7 +369,9 @@ end
 # unused
 # sites_to_orbs_nogroups(cs::CellOrbitalsGrouped, _) = CellOrbitals(cell(cs), orbindices(cs))
 
-## core functions
+#endregion
+
+#region ## CORE FUNCTIONS
 
 _groups(i::Integer, os) = [i], [flatrange(os, i)]
 _groups(::Colon, os) = _groups(siterange(os), os)
@@ -391,4 +410,5 @@ function _orbinds(sites, os)
     return orbinds
 end
 
+#endregion
 #endregion

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -9,7 +9,7 @@ Base.getindex(lat::Lattice, ls::LatticeSlice) = ls
 
 Base.getindex(lat::Lattice, ss::SiteSelector) = lat[apply(ss, lat)]
 
-Base.getindex(lat::Lattice, ::UnboundedSiteSelector) = lat[siteselector(; cells = zerocell(lat))]
+Base.getindex(lat::Lattice, ::SiteSelectorAll) = lat[siteselector(; cells = zerocell(lat))]
 
 function Base.getindex(lat::Lattice, as::AppliedSiteSelector)
     L = latdim(lat)
@@ -287,7 +287,7 @@ end
 #       - AnyOrbitalSlice
 #       - AnyCellOrbitalsDict
 #       - AnyCellOrbitals
-# sites_to_orbs_flat: converts sites to orbitals, without site groups
+# sites_to_orbs_nogroups: converts sites to orbitals, without site groups
 #   conversion rules:
 #       - SiteSlice to an OrbitalSlice
 #region
@@ -298,16 +298,19 @@ sites_to_orbs(s::AnyOrbitalSlice, _) = s
 sites_to_orbs(c::AnyCellOrbitalsDict, _) = c
 sites_to_orbs(c::AnyCellOrbitals, _) = c
 
+# unused
+# sites_to_orbs_nogroups(cs::CellOrbitals, _) =  cs
+
 ## convert SiteSlice -> OrbitalSliceGrouped/OrbitalSlice
 
+sites_to_orbs(kw::NamedTuple, g) = sites_to_orbs(siteselector(; kw...), g)
 sites_to_orbs(s::SiteSelector, g) = sites_to_orbs(lattice(g)[s], g)
-sites_to_orbs(kw::NamedTuple, g) = sites_to_orbs(getindex(lattice(g); kw...), g)
 sites_to_orbs(i::Integer, g) = orbslice(selfenergies(contacts(g), i))
 sites_to_orbs(l::SiteSlice, g) =
     OrbitalSliceGrouped(lattice(l), sites_to_orbs(cellsdict(l), blockstructure(g)))
 
-sites_to_orbs_flat(l::SiteSlice, g) =
-    OrbitalSlice(lattice(l), sites_to_orbs_flat(cellsdict(l), blockstructure(g)))
+sites_to_orbs_nogroups(l::SiteSlice, g) =
+    OrbitalSlice(lattice(l), sites_to_orbs_nogroups(cellsdict(l), blockstructure(g)))
 
 ## convert CellSitesDict to CellOrbitalsGroupedDict/CellOrbitalsDict
 
@@ -319,15 +322,15 @@ function sites_to_orbs(cellsdict::CellSitesDict{L}, os::OrbitalBlockStructure) w
     return CellOrbitalsGroupedDict(co)
 end
 
-sites_to_orbs_flat(c::CellSitesDict, g) = sites_to_orbs_flat(c, blockstructure(g))
+sites_to_orbs_nogroups(c::CellSitesDict, g) = sites_to_orbs_nogroups(c, blockstructure(g))
 
-function sites_to_orbs_flat(cellsdict::CellSitesDict{L}, os::OrbitalBlockStructure) where {L}
+function sites_to_orbs_nogroups(cellsdict::CellSitesDict{L}, os::OrbitalBlockStructure) where {L}
     # inference fails if cellsdict is empty, so we need to specify eltype
-    co = CellOrbitals{L,Vector{Int}}[sites_to_orbs_flat(cellsites, os) for cellsites in cellsdict]
+    co = CellOrbitals{L,Vector{Int}}[sites_to_orbs_nogroups(cellsites, os) for cellsites in cellsdict]
     return CellOrbitalsDict(co)
 end
 
-## convert CellSites -> CellOrbitalsGrouped
+## convert CellSites -> CellOrbitalsGrouped or CellOrbitals
 
 sites_to_orbs(c::CellSites, g) = sites_to_orbs(c, blockstructure(g))
 
@@ -338,11 +341,18 @@ function sites_to_orbs(cs::CellSites, os::OrbitalBlockStructure)
     return CellOrbitalsGrouped(cell(cs), orbinds, Dictionary(groups...))
 end
 
-function sites_to_orbs_flat(cs::CellSites, os::OrbitalBlockStructure)
+function sites_to_orbs_nogroups(cs::CellSites, os::OrbitalBlockStructure)
     sites = siteindices(cs)
     orbinds = _orbinds(sites, os)
     return CellOrbitals(cell(cs), orbinds)
 end
+
+## convert CellOrbitalsGrouped -> CellOrbitals
+
+# unused
+# sites_to_orbs_nogroups(cs::CellOrbitalsGrouped, _) = CellOrbitals(cell(cs), orbindices(cs))
+
+## core functions
 
 _groups(i::Integer, os) = [i], [flatrange(os, i)]
 _groups(::Colon, os) = _groups(siterange(os), os)

--- a/src/solvers/green/bands.jl
+++ b/src/solvers/green/bands.jl
@@ -633,7 +633,7 @@ function coupled_orbslice(condition, h, seedcell, dir)
     ls = grow(lat[CellSites(seedcell, :)], h)
     sc´ = [projected_cellsites(c, dir) for c in cellsdict(ls) if condition(cell(c)[dir])]
     sslice = SiteSlice(lat, CellSitesDict(sc´))
-    oslice = sites_to_orbs_flat(sslice, h)
+    oslice = sites_to_orbs_nogroups(sslice, h)
     return oslice
 end
 

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -240,9 +240,9 @@ function densitymatrix(s::AppliedKPMGreenSolver, gs::GreenSlice{T}) where {T}
 end
 
 function slice_momenta(momenta, gs)
-    rows = _maybe_contactinds(gs, slicerows(gs))
-    cols = _maybe_contactinds(gs, slicecols(gs))
-    momenta´ = [view(m, rows, cols) for m in momenta]
+    r = _maybe_contactinds(gs, rows(gs))
+    c = _maybe_contactinds(gs, cols(gs))
+    momenta´ = [view(m, r, c) for m in momenta]
     return momenta´
 end
 

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -80,9 +80,10 @@ end
 ## Constructor
 
 function densitymatrix(s::AppliedSpectrumGreenSolver, gs::GreenSlice)
-    # SpectrumGreenSlicer is 0D
-    i, j = only(cellsdict(slicerows(gs))), only(cellsdict(slicerows(gs)))
-    oi, oj = orbindices(i), orbindices(j)   # because GreenSlice already converted to orbs
+    # SpectrumGreenSlicer is 0D, so there is a single cellorbs in dict.
+    # If rows/cols are contacts, we need their orbrows/orbcols (unlike for gs(ω; params...))
+    i, j = only(cellsdict(orbrows(gs))), only(cellsdict(orbcols(gs)))
+    oi, oj = orbindices(i), orbindices(j)
     es, psis = spectrum(s)
     solver = DensityMatrixSpectrumSolver(es, _maybe_view(psis, oi), _maybe_view(psis, oj))
     return DensityMatrix(solver)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -28,8 +28,11 @@ minimal_callsafe_copy(s::SpectrumGreenSlicer) = SpectrumGreenSlicer(s.ω, s.solv
 
 #region ## apply ##
 
-apply(s::GS.Spectrum, h::AbstractHamiltonian0D, ::Contacts) =
+apply(s::GS.Spectrum, h::Hamiltonian{<:Any,<:Any,0}, ::Contacts) =
     AppliedSpectrumGreenSolver(spectrum(h; s.spectrumkw...))
+
+apply(s::GS.Spectrum, h::ParametricHamiltonian, ::Contacts) =
+    argerror("Cannot use GS.Spectrum with ParametricHamiltonian. Apply parameters with h(;params...) first.")
 
 apply(::GS.Spectrum, h::AbstractHamiltonian, ::Contacts) =
     argerror("Can only use Spectrum with bounded Hamiltonians")
@@ -63,4 +66,40 @@ end
 
 #endregion
 
+############################################################################################
+# densitymatrix
+#   specialized DensityMatrix method for GS.Spectrum
+#region
+
+struct DensityMatrixSpectrumSolver{T,R,C}
+    es::Vector{Complex{T}}
+    psirows::R
+    psicols::C
+end
+
+## Constructor
+
+function densitymatrix(s::AppliedSpectrumGreenSolver, gs::GreenSlice)
+    # SpectrumGreenSlicer is 0D
+    i, j = only(cellsdict(slicerows(gs))), only(cellsdict(slicerows(gs)))
+    oi, oj = orbindices(i), orbindices(j)   # because GreenSlice already converted to orbs
+    es, psis = spectrum(s)
+    solver = DensityMatrixSpectrumSolver(es, _maybe_view(psis, oi), _maybe_view(psis, oj))
+    return DensityMatrix(solver)
+end
+
+## API
+
+## call
+
+function (d::DensityMatrixSpectrumSolver)(mu, kBT; params...)
+    vi = d.psirows
+    vj´ = d.psicols' .* fermi.(d.es .- mu, kBT)
+    return vi * vj´
+end
+
+# if the orbindices cover all the unit cell, use matrices instead of
+_maybe_view(m, oi) = length(oi) == size(m, 1) ? m : view(m, oi, :)
+
+#endregion
 #endregion

--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -35,9 +35,9 @@ end
 #region ## API ##
 
 function SelfEnergy(hparent::AbstractHamiltonian, gslice::GreenSlice, model::AbstractModel; sites...)
-    slicerows(gslice) === slicecols(gslice) ||
+    rows(gslice) === cols(gslice) ||
         argerror("To attach a Greenfunction with `attach(h, g[cols, rows], coupling; ...)`, we must have `cols == rows`")
-    lsbath = sites_to_orbs(latslice(parent(gslice), slicerows(gslice)), parent(gslice))
+    lsbath = orbrows(gslice)
     lat0bath = lattice0D(lsbath)
     lsparent = sites_to_orbs(getindex(lattice(hparent); sites...), hparent)
     lat0parent = lattice0D(lsparent)

--- a/src/solvers/selfenergy/nothing.jl
+++ b/src/solvers/selfenergy/nothing.jl
@@ -21,6 +21,8 @@ call!(s::SelfEnergyEmptySolver, ω; params...) = s.emptymat
 
 call!_output(s::SelfEnergyEmptySolver) = s.emptymat
 
+has_selfenergy(::SelfEnergyEmptySolver) = false
+
 minimal_callsafe_copy(s::SelfEnergyEmptySolver) = s
 
 #endregion

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -11,8 +11,8 @@ function testgreen(h, s; kw...)
     z = zero(SVector{L,Int})
     o = Quantica.unitvector(1, SVector{L,Int})
     conts = ntuple(identity, ncontacts(h))
-    locs = (cellsites(z, :), cellsites(z, 2), cellsites(z, 1:2), cellsites(z, (1,2)),
-            cellsites(o, :), CellOrbitals(o, 1), CellOrbitals(z, 1:2), CellOrbitals(z, SA[2,1]),
+    locs = (cellsites(z, :), cellsites(z, 2), cellsites(o, 1:2), cellsites(o, (1,2)),
+            CellOrbitals(o, 1), CellOrbitals(z, 1:2), CellOrbitals(z, SA[2,1]),
             conts...)
     for loc in locs, loc´ in locs
         gs = g[loc, loc´]
@@ -281,6 +281,12 @@ end
     ρ1, ρ2, ρ3 = densitymatrix(gLU[reg], (-3,3)), densitymatrix(gSpectrum[reg]), densitymatrix(gKPM[1])
     @test ρ1() ≈ ρ2() atol = 0.00001
     @test ρ2() ≈ ρ3() atol = 0.00001
+    gLU´ = h |> attach(nothing; reg...) |> greenfunction(GS.SparseLU());
+    ρ1´ = densitymatrix(gLU´[1], (-3, 3))
+    @test ρ1() ≈ ρ1´()
+    gSpectrum´ = h |> attach(nothing; reg...) |> greenfunction(GS.Spectrum());
+    ρ2´ = densitymatrix(gSpectrum´[1])
+    @test ρ2() ≈ ρ2´()
 
     glead = LP.square() |> hamiltonian(hopping(1)) |> supercell((0,1), region = r -> -1 <= r[1] <= 1) |> attach(nothing; cells = SA[10]) |> greenfunction(GS.Schur(boundary = 0));
     contact1 = r -> r[1] ≈ 5 && -1 <= r[2] <= 1

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -35,4 +35,10 @@
     h = first(hs)
     g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing))
     @test nothing === show(stdout, josephson(g[1], 2))
+    @test nothing === show(stdout, densitymatrix(g[1], 2))
+    h = supercell(h, 3) |> supercell
+    g = greenfunction(supercell(h) |> attach(nothing), GS.KPM())
+    @test nothing === show(stdout, densitymatrix(g[1]))
+    g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing), GS.Spectrum())
+    @test nothing === show(stdout, densitymatrix(g[1]))
 end


### PR DESCRIPTION
This PR introduces `densitymatrix(::GreenSlice,...)`, which produces a `ρ::DensityMatrix` over a set of sites. To evaluate the matrix itself at a given temperature and chemical potential, and for a set of system parameters, we do `ρ(mu, kBT; params...)`

We implement three algorithms in this PR: a generic one that relies on numerical integration on the complex plane of `G(ω)*f(ω)`, another for `GreenSolver.Spectrum` and another for `GreenSolver.KPM` at zero temperature. More can be added at a later time.