### PR TITLE
Add `OrbitalSliceArray`

### DIFF
--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -131,7 +131,7 @@ function _hoppingprimitives(ls::LatticeSlice{<:Any,E}, h, opts, siteradii) where
     hp = HoppingPrimitives{E}()
     hp´ = HoppingPrimitives{E}()
     lat = parent(ls)
-    sdict = sitedict(ls)
+    sdict = Quantica.siteindexdict(ls)
     for (j´, cs) in enumerate(Quantica.cellsites(ls))
         nj = Quantica.cell(cs)
         j = Quantica.siteindex(cs)
@@ -144,7 +144,7 @@ function _hoppingprimitives(ls::LatticeSlice{<:Any,E}, h, opts, siteradii) where
             for ptr in nzrange(mat, j)
                 i = rows[ptr]
                 Quantica.isonsite((i, j), dn) && continue
-                i´ = get(sdict, (i, ni), nothing)
+                i´ = get(sdict, Quantica.CellSite(ni, i), nothing)
                 if i´ === nothing
                     opts´ = maybe_getindex.(opts, j´)
                     push_hopprimitive!(hp´, opts´, lat, (i, j), (ni, nj), siteradius, mat[i, j], false)
@@ -157,9 +157,6 @@ function _hoppingprimitives(ls::LatticeSlice{<:Any,E}, h, opts, siteradii) where
     end
     return hp, hp´
 end
-
-sitedict(ls::LatticeSlice) =
-    Dict([(Quantica.siteindex(cs), Quantica.cell(cs)) => j for (j, cs) in enumerate(Quantica.cellsites(ls))])
 
 maybe_evaluate_observable(o::Quantica.IndexableObservable, ls) = o[ls]
 maybe_evaluate_observable(x, ls) = x

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -29,7 +29,8 @@ export sublat, bravais_matrix, lattice, sites, supercell,
        spectrum, energies, states, bands, subdiv,
        greenfunction, selfenergy, attach, contact, cellsites,
        plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults,
-       conductance, josephson, ldos, current, transmission, densitymatrix
+       conductance, josephson, ldos, current, transmission, densitymatrix,
+       OrbitalSliceArray, OrbitalSliceVector, OrbitalSliceMatrix, orbaxes
 
 export LatticePresets, LP, RegionPresets, RP, HamiltonianPresets, HP
 export EigenSolvers, ES, GreenSolvers, GS

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -298,10 +298,15 @@ end
 
 apply(c::CellSites{L,Vector{Int}}, ::Lattice{<:Any,<:Any,L}) where {L} = c
 
+apply(c::CellSites{L,Int}, ::Lattice{<:Any,<:Any,L}) where {L} = c
+
 apply(c::CellSites{L,Colon}, l::Lattice{<:Any,<:Any,L}) where {L} =
     CellSites(cell(c), collect(siterange(l)))
 
 apply(c::CellSites{L}, l::Lattice{<:Any,<:Any,L}) where {L} =
     CellSites(cell(c), [i for i in siteindices(c) if i in siterange(l)])
+
+apply(::CellSites{L}, l::Lattice{<:Any,<:Any,L´}) where {L,L´} =
+    argerror("Cell sites must have $(L´)-dimensional cell indices")
 
 #endregion

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -23,7 +23,10 @@ Sublat{T,E}(s::Sublat, name = s.name) where {T<:AbstractFloat,E} =
     Sublat{T,E}([sanitize_SVector(SVector{E,T}, site) for site in sites(s)], name)
 
 CellSites{L,V}(c::CellSites) where {L,V} =
-    CellSites{L,V}(convert(SVector{L,Int}, cell(c)), convert(V, siteindices(c)))
+    CellIndices(convert(SVector{L,Int}, cell(c)), convert(V, siteindices(c)), SiteLike())
+
+CellSites{L,V}(c::CellSite) where {L,V<:Vector} =
+    CellIndices(convert(SVector{L,Int}, cell(c)), convert(V, [siteindices(c)]), SiteLike())
 
 function Hamiltonian{E}(h::Hamiltonian) where {E}
     lat = lattice(h)

--- a/src/sanitizers.jl
+++ b/src/sanitizers.jl
@@ -88,8 +88,16 @@ end
 
 # an inds::Tuple fails some tests because convert(Tuple, ::UnitRange) doesnt exist, but
 # convert(SVector, ::UnitRange) does. Used e.g. in compute_or_retrieve_green @ sparselu.jl
-sanitize_cellindices(inds::Tuple) = SVector(inds)
-sanitize_cellindices(inds) = inds
+# We should also demand indices to be unique, since siteindsdict cannot have duplicates
+sanitize_cellindices(inds::Tuple) = SVector(_check_unique(inds))
+sanitize_cellindices(inds) = _check_unique(inds)
+
+_check_unique(x::Colon) = x
+
+function _check_unique(inds)
+    allunique(inds) || argerror("Cell indices should be unique")
+    return inds
+end
 
 #endregion
 

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -2,11 +2,13 @@
 # selector constructors
 #region
 
+siteselector(s::NamedTuple) = siteselector(; s...)
 siteselector(; region = missing, sublats = missing, cells = missing) =
     SiteSelector(region, sublats, cells)
 siteselector(s::SiteSelector; region = s.region, sublats = s.sublats, cells = s.cells) =
     SiteSelector(region, sublats, cells)
 
+hopselector(h::NamedTuple) = hopselector(; h...)
 hopselector(; region = missing, sublats = missing, dcells = missing, range = neighbors(1)) =
     HopSelector(region, sublats, dcells, range)
 hopselector(s::HopSelector; region = s.region, sublats = s.sublats, dcells = s.dcells, range = s.range) =

--- a/src/show.jl
+++ b/src/show.jl
@@ -55,16 +55,23 @@ displayname(s::Sublat) = sublatname(s) == Symbol(:_) ? "pending" : string(":", s
 # LatticeSlice
 #region
 
-Base.summary(::LatticeSlice{T,E,L}) where {T,E,L} =
-    "LatticeSlice{$T,$E,$L} : collection of subcells for a $(L)D lattice in $(E)D space"
+Base.summary(::SiteSlice{T,E,L}) where {T,E,L} =
+    "SiteSlice{$T,$E,$L} : collection of subcells of sites for a $(L)D lattice in $(E)D space"
+
+Base.summary(::OrbitalSliceGrouped{T,E,L}) where {T,E,L} =
+    "OrbitalSliceGrouped{$T,$E,$L} : collection of subcells of orbitals (grouped by sites) for a $(L)D lattice in $(E)D space"
+
 
 function Base.show(io::IO, ls::LatticeSlice)
     i = get(io, :indent, "")
     print(io, i, summary(ls), "\n",
 "$i  Cells       : $(length(cellsdict(ls)))
 $i  Cell range  : $(isempty(ls) ? "empty" : boundingbox(ls))
-$i  Total sites : $(nsites(ls))")
+$i  Total sites : $(missing_or_nsites(ls))")
 end
+
+missing_or_nsites(::OrbitalSlice) = "unknown"
+missing_or_nsites(s) = nsites(s)
 
 #endregion
 

--- a/src/solvers/green/bands.jl
+++ b/src/solvers/green/bands.jl
@@ -632,7 +632,7 @@ function coupled_orbslice(condition, h, seedcell, dir)
     lat = lattice(h)
     ls = grow(lat[CellSites(seedcell, :)], h)
     sc´ = [projected_cellsites(c, dir) for c in cellsdict(ls) if condition(cell(c)[dir])]
-    sslice = SiteSlice(lat, CellSitesDict(sc´))
+    sslice = SiteSlice(lat, cellinds_to_dict(sc´))
     oslice = sites_to_orbs_nogroups(sslice, h)
     return oslice
 end

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -236,7 +236,7 @@ function densitymatrix(s::AppliedKPMGreenSolver, gs::GreenSlice{T}) where {T}
     has_selfenergy(gs) && argerror("The KPM densitymatrix solver currently support only `nothing` contacts")
     momenta = slice_momenta(s.momenta, gs)
     solver = DensityMatrixKPMSolver(momenta, s.bandCH)
-    return DensityMatrix(solver)
+    return DensityMatrix(solver, gs)
 end
 
 function slice_momenta(momenta, gs)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -86,7 +86,7 @@ function densitymatrix(s::AppliedSpectrumGreenSolver, gs::GreenSlice)
     oi, oj = orbindices(i), orbindices(j)
     es, psis = spectrum(s)
     solver = DensityMatrixSpectrumSolver(es, _maybe_view(psis, oi), _maybe_view(psis, oj))
-    return DensityMatrix(solver)
+    return DensityMatrix(solver, gs)
 end
 
 ## API

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -1,4 +1,4 @@
-using Quantica: Sublat, Lattice, transform!, translate!
+using Quantica: Sublat, Lattice, transform!, translate!, nsites
 
 @testset "Internal API" begin
     s = sublat((0,0,0))
@@ -164,13 +164,23 @@ end
     lat = LP.honeycomb() |> supercell(2)
     ls1 = lat[sublats = :B, region = RP.ellipse((10, 20), (0, 1/√3))]
     ls2 = lat[sublats = :A, region = RP.ellipse((10, 20))]
+    ls3 = lat[region = RP.ellipse((10, 20))]
     @test length(ls1) == length(ls2)
     @test ls2[2] isa Tuple{SVector{2, Int}, Int}
     ls = ls1[sublats = :B]
     @test isempty(ls)
+    ls = ls3[sublats = :B, region = RP.ellipse((1, 2))]
+    @test !isempty(ls)
+    ls´ = ls3[(; sublats = :B, region = RP.ellipse((1, 2)))]
+    @test nsites(ls) == nsites(ls´)
     ls = lat[cells = n -> 5 < norm(n) < 10]
     @test !isempty(Quantica.cells(ls)) && all(n -> 5 < norm(n) < 10, Quantica.cells(ls))
     ls = lat[region = r -> 5 < norm(r) < 10]
     @test !isempty(Quantica.cells(ls)) && all(r -> 5 < norm(r) < 10, Quantica.sites(ls))
-
+    ls = lat[cellsites(SA[1,0], 1:3)]
+    @test ls isa Quantica.SiteSlice
+    @test nsites(ls) == 3
+    ls = lat[cellsites(SA[1,0], 2)]
+    @test ls isa Quantica.SiteSlice
+    @test nsites(ls) == 1
 end


### PR DESCRIPTION
Closes #232 

We define a new type of `OrbitalSliceArray`, following the discussion in #232, that is designed to hold (in principle dense) matrices defined over the orbitals in a given `OrbitalSlice`. This is now the default output of fully evaluating a Green function, and of observables such as `ldos` (which gives an `OrbitalSliceVector`) and `densitymatrix` (which gives an `OrbitalSliceMatrix`). The orbital axes of an `m::OrbitalSliceArray` can be obtained with `orbaxes(m)`, and are in general a tuple of `OrbitalSliceGrouped` (which represents groups of orbitals over a lattice grouped by sites). 

For non-orbital dimensions these `orbaxes` could also be `Missing`. This possibility was brought up by @BacAmorim in #232

One critical property of this PR is that `view(::OrbitalSliceMatrix, cellsites(cell1, i::Int), cellsites(cell2, j::Int))` is a non-allocating view of the underlying matrix. This allows us to compute a `densitymatrix(...)::OrbitalSliceMatrix`, and use it as a parameter for a mean field model, which will now be able to do fast lookups over this `OrbitalSliceMatrix` for individual sites to update  a `ParametricHamiltonian` in-place, hence implementing a self-consistent mean field efficiently. The remaining changes required to close #229 are now relatively simple. 

