### PR TITLE
Non-spatial models (e.g. mean-field models)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,8 @@ makedocs(;
             "Hamiltonians" => "tutorial/hamiltonians.md",
             "Bandstructures" => "tutorial/bandstructures.md",
             "GreenFunctions" => "tutorial/greenfunctions.md",
-            "Observables" => "tutorial/observables.md"
+            "Observables" => "tutorial/observables.md",
+            "Advanced topics" => "tutorial/advanced.md"
             ],
         "Examples" => "examples.md",
         "API" => "api.md",

--- a/docs/src/tutorial/advanced.md
+++ b/docs/src/tutorial/advanced.md
@@ -89,3 +89,6 @@ julia> (ρsol, ρerror, iters) = @time afps(ρf(hρ; U = 0.4), real(ρ0), tol = 
 
 !!! note "Bring your own fixed-point solution!"
     Note that fixed-point calculations can be tricky, and the search algorithm can have a huge impact in convergence (if the problem converges at all!). For this reason, Quantica.jl does not provide built-in fixed-point routines, only the functionality to write functions such as `ρf` above.
+
+!!! tip "Sparse mean fields"
+    The method explained above to build a Hamiltonian supports all the `SiteSelector` and `HopSelector` functionality of conventional models. Therefore, although the density matrix computed above is dense, its application to the Hamiltonian is sparse: it only touches the onsite matrix elements. Likewise, we could for example use `@hopping!` with a finite `range` to apply a Fock mean field within a finite range. In the future we will support built-in Hartree-Fock model presets with adjustable sparsity.

--- a/docs/src/tutorial/advanced.md
+++ b/docs/src/tutorial/advanced.md
@@ -1,0 +1,91 @@
+# Non-spatial models and self-consistent mean-field problems
+
+As briefly mentioned when discussing parametric models and modifiers, we have a special syntax that allows models to depend on sites directly, instead of on their spatial location. We call these non-spatial models. A simple example, with an onsite energy proportional to the site **index**
+```julia
+julia> model = @onsite((i; p = 1) --> ind(i) * p)
+ParametricModel: model with 1 term
+  ParametricOnsiteTerm{ParametricFunction{1}}
+    Region            : any
+    Sublattices       : any
+    Cells             : any
+    Coefficient       : 1
+    Argument type     : non-spatial
+    Parameters        : [:p]
+```
+or a modifier that changes a hopping between different cells
+```julia
+julia> modifier = @hopping!((t, i, j; dir = 1) --> (cell(i) - cell(j))[dir])
+HoppingModifier{ParametricFunction{3}}:
+  Region            : any
+  Sublattice pairs  : any
+  Cell distances    : any
+  Hopping range     : Inf
+  Reverse hops      : false
+  Argument type     : non-spatial
+  Parameters        : [:dir]
+```
+
+Note that we use the special syntax `-->` instead of `->`. This indicates that the positional arguments of the function, here called `i` and `j`, are no longer site positions as up to now. These `i, j` are non-spatial arguments, as noted by the `Argument type` property shown above. Instead of a position, a non-spatial argument `i` represent an individual site, whose index is `ind(i)`, its position is `pos(i)` and the cell it occupies on the lattice is `cell(i)`.
+
+Technically `i` is of type `CellSitePos`, which is an internal type not meant for the end user to instantiate. One special property of this type, however, is that it can efficiently index `OrbitalSliceArray`s. We can use this to build a Hamiltonian that depends on an observable, such as a `densitymatrix`. A simple example of a four-site chain with onsite energies shifted by a potential proportional to the local density on each site:
+```julia
+julia> h = LP.linear() |> onsite(2) - hopping(1) |> supercell(4) |> supercell;
+
+julia> h(SA[])
+4×4 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 10 stored entries:
+  2.0+0.0im  -1.0+0.0im       ⋅           ⋅
+ -1.0+0.0im   2.0+0.0im  -1.0+0.0im       ⋅
+      ⋅      -1.0+0.0im   2.0+0.0im  -1.0+0.0im
+      ⋅           ⋅      -1.0+0.0im   2.0+0.0im
+
+julia> g = greenfunction(h, GS.Spectrum());
+
+julia> ρ = densitymatrix(g[])(0.5, 0) ## density matrix at chemical potential `µ=0.5` and temperature `kBT = 0`  on all sites
+4×4 OrbitalSliceMatrix{Matrix{ComplexF64}}:
+ 0.138197+0.0im  0.223607+0.0im  0.223607+0.0im  0.138197+0.0im
+ 0.223607+0.0im  0.361803+0.0im  0.361803+0.0im  0.223607+0.0im
+ 0.223607+0.0im  0.361803+0.0im  0.361803+0.0im  0.223607+0.0im
+ 0.138197+0.0im  0.223607+0.0im  0.223607+0.0im  0.138197+0.0im
+
+julia> hρ = h |> @onsite!((o, i; U = 0, ρ) --> o + U * ρ[i])
+ParametricHamiltonian{Float64,1,0}: Parametric Hamiltonian on a 0D Lattice in 1D space
+  Bloch harmonics  : 1
+  Harmonic size    : 4 × 4
+  Orbitals         : [1]
+  Element type     : scalar (ComplexF64)
+  Onsites          : 4
+  Hoppings         : 6
+  Coordination     : 1.5
+  Parameters       : [:U, :ρ]
+
+julia> hρ(SA[]; U = 1, ρ = ρ0)
+4×4 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 10 stored entries:
+ 2.1382+0.0im    -1.0+0.0im         ⋅             ⋅
+   -1.0+0.0im  2.3618+0.0im    -1.0+0.0im         ⋅
+        ⋅        -1.0+0.0im  2.3618+0.0im    -1.0+0.0im
+        ⋅             ⋅        -1.0+0.0im  2.1382+0.0im
+```
+
+Note the `ρ[i]` above. This indexes `ρ` at site `i`. For a multiorbital hamiltonian, this will be a matrix (the local density matrix on each site `i`). Here it is just a number, either ` 0.138197` (sites 1 and 4) or `0.361803` (sites 2 and 3).
+
+The above provides the tools to implement self-consistent mean field. We just need to find a fixed point `ρf(ρ) = ρ` of the function `ρf` that produces the density matrix of the system.
+
+In the following example we use the FixedPoint.jl package. It provides a simple utility `afps(f, x0)` that computes the solution of `f(x) = x` with initial condition `x0`. The package requires `x0` to be a (real) `AbstractArray`. Note that any other fixed-point search routine that work with `AbstractArray`s should also work.
+```julia
+julia> using FixedPoint
+
+julia> ρf(hρ; µ = 0.5, kBT = 0, U = 0.1) = ρ -> densitymatrix(greenfunction(hρ(; U, ρ), GS.Spectrum())[])(µ, kBT)
+ρf (generic function with 1 method)
+
+julia> (ρsol, ρerror, iters) = @time afps(ρf(hρ; U = 0.4), real(ρ0), tol = 1e-8, ep = 0.95, vel = 0.0); @show iters, ρerror; ρsol
+  0.000627 seconds (1.91 k allocations: 255.664 KiB)
+(iters, ρerror) = (8, 2.0632459629688071e-10)
+4×4 OrbitalSliceMatrix{Matrix{ComplexF64}}:
+ 0.145836+0.0im  0.227266+0.0im  0.227266+0.0im  0.145836+0.0im
+ 0.227266+0.0im  0.354164+0.0im  0.354164+0.0im  0.227266+0.0im
+ 0.227266+0.0im  0.354164+0.0im  0.354164+0.0im  0.227266+0.0im
+ 0.145836+0.0im  0.227266+0.0im  0.227266+0.0im  0.145836+0.0im
+```
+
+!!! note "Bring your own fixed-point solution!"
+    Note that fixed-point calculations can be tricky, and the search algorithm can have a huge impact in convergence (if the problem converges at all!). For this reason, Quantica.jl does not provide built-in fixed-point routines, only the functionality to write functions such as `ρf` above.

--- a/docs/src/tutorial/glossary.md
+++ b/docs/src/tutorial/glossary.md
@@ -29,6 +29,5 @@ This is a summary of the type of objects you will be studying.
 - **`GreenFunction`**: an `OpenHamiltonian` combined with a `GreenSolver`, which is an algorithm that can in general compute the retarded or advanced Green function at any energy between any subset of sites of the underlying lattice.
   - **`GreenSlice`**: a `GreenFunction` evaluated on a specific set of sites, but at an unspecified energy
   - **`GreenSolution`**: a `GreenFunction` evaluated at a specific energy, but on an unspecified set of sites
-- **`Observable`**: a physical observable that can be expressed in terms of a `GreenFunction`.
-
-  Examples of supported observables include local density of states, current density, transmission probability, conductance and Josephson current
+- **`OrbitalSliceArray`**: an `AbstractArray` that can be indexed with a `SiteSelector`, in addition to the usual scalar indexing. Particular cases are `OrbitalSliceMatrix` and `OrbitalSliceVector`. This is the most common type obtained from `GreenFunction`s and observables obtained from them.
+- **Observables**: Supported observables, obtained from Green functions using various algorithms, include **local density of states**, **density matrices**, **current densities**, **transmission probabilities**, **conductance** and **Josephson currents**

--- a/docs/src/tutorial/models.md
+++ b/docs/src/tutorial/models.md
@@ -120,7 +120,8 @@ ParametricModel: model with 1 term
     Hopping range     : Neighbors(1)
     Reverse hops      : false
     Coefficient       : 1
-    Parameters        : [:B, :t]
+    Argument type     : spatial
+    Parameters        : [:Bz, :t]
 ```
 
 One can linearly combine parametric and non-parametric models freely, omit parameter default values, and use any of the functional argument forms described for `onsite` and `hopping` (although not the constant argument form):
@@ -134,6 +135,7 @@ ParametricModel: model with 2 terms
     Hopping range     : Neighbors(1)
     Reverse hops      : false
     Coefficient       : -4
+    Argument type     : spatial
     Parameters        : [:t]
   OnsiteTerm{Int64}:
     Region            : any
@@ -141,6 +143,10 @@ ParametricModel: model with 2 terms
     Cells             : any
     Coefficient       : 2
 ```
+
+!!! tip "Non-spatial parametric models with -->"
+    The `->` in the above parametric models `@onsite` and `@hopping`, but also in the modifiers below, can be changed to `-->`. This indicates that the function arguments are no longer treated as site or link positions `r` and `dr`, but as objects `i, j` representing destination and source sites. This allows to address sites directly instead of through their spatial location. See the Mean Field section for further details.
+
 
 ## Modifiers
 
@@ -160,6 +166,7 @@ HoppingModifier{ParametricFunction{3}}:
   Cell distances    : any
   Hopping range     : Inf
   Reverse hops      : false
+  Argument type     : spatial
   Parameters        : [:B]
 ```
 The difference with `model_perierls` is that `model_perierls!` will never add any new hoppings. It will only modify previously existing hoppings in a model. Modifiers are not models themselves, and cannot be summed to other models. They are instead meant to be applied sequentially after applying a model.

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -21,10 +21,9 @@ using Statistics: mean
 using QuadGK
 using SpecialFunctions
 
-export sublat, bravais_matrix, lattice, sites, supercell,
-       hopping, onsite, @onsite, @hopping, @onsite!, @hopping!, plusadjoint, neighbors,
-       siteselector, hopselector, diagonal,
-       hamiltonian,
+export sublat, bravais_matrix, lattice, sites, supercell, hamiltonian,
+       hopping, onsite, @onsite, @hopping, @onsite!, @hopping!, pos, ind, cell,
+       plusadjoint, neighbors, siteselector, hopselector, diagonal,
        unflat, torus, transform, translate, combine,
        spectrum, energies, states, bands, subdiv,
        greenfunction, selfenergy, attach, contact, cellsites,

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -130,10 +130,10 @@ end
 apply(m::TightbindingModel, latos) = TightbindingModel(apply.(terms(m), Ref(latos)))
 
 apply(t::ParametricOnsiteTerm, lat::Lattice) =
-    ParametricOnsiteTerm(functor(t), apply(selector(t), lat), coefficient(t), is_spacial(t))
+    ParametricOnsiteTerm(functor(t), apply(selector(t), lat), coefficient(t), is_spatial(t))
 
 apply(t::ParametricHoppingTerm, lat::Lattice) =
-    ParametricHoppingTerm(functor(t), apply(selector(t), lat), coefficient(t), is_spacial(t))
+    ParametricHoppingTerm(functor(t), apply(selector(t), lat), coefficient(t), is_spatial(t))
 
 apply(m::ParametricModel, lat) = ParametricModel(apply.(terms(m), Ref(lat)))
 
@@ -152,8 +152,8 @@ function apply(m::OnsiteModifier, h::Hamiltonian, shifts = missing)
     asel = apply(sel, lattice(h))
     ptrs = pointers(h, asel, shifts)
     B = blocktype(h)
-    spacial = is_spacial(m)
-    return AppliedOnsiteModifier(sel, B, f, ptrs, spacial)
+    spatial = is_spatial(m)
+    return AppliedOnsiteModifier(sel, B, f, ptrs, spatial)
 end
 
 function apply(m::HoppingModifier, h::Hamiltonian, shifts = missing)
@@ -162,8 +162,8 @@ function apply(m::HoppingModifier, h::Hamiltonian, shifts = missing)
     asel = apply(sel, lattice(h))
     ptrs = pointers(h, asel, shifts)
     B = blocktype(h)
-    spacial = is_spacial(m)
-    return AppliedHoppingModifier(sel, B, f, ptrs, spacial)
+    spatial = is_spatial(m)
+    return AppliedHoppingModifier(sel, B, f, ptrs, spatial)
 end
 
 function pointers(h::Hamiltonian{T,E,L,B}, s::AppliedSiteSelector{T,E,L}, shifts) where {T,E,L,B}

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -168,7 +168,7 @@ end
 
 function pointers(h::Hamiltonian{T,E,L,B}, s::AppliedSiteSelector{T,E,L}, shifts) where {T,E,L,B}
     isempty(cells(s)) || argerror("Cannot constrain cells in an onsite modifier, cell periodicity is assumed.")
-    ptrs = Tuple{Int,SVector{E,T},CellSitePos{T,E,L},Int}[]
+    ptrs = Tuple{Int,SVector{E,T},CellSitePos{T,E,L,B},Int}[]
     lat = lattice(h)
     har0 = first(harmonics(h))
     dn0 = zerocell(lat)
@@ -191,7 +191,7 @@ end
 
 function pointers(h::Hamiltonian{T,E,L,B}, s::AppliedHopSelector{T,E,L}, shifts) where {T,E,L,B}
     hars = harmonics(h)
-    ptrs = [Tuple{Int,SVector{E,T},SVector{E,T},CellSitePos{T,E,L},CellSitePos{T,E,L},Tuple{Int,Int}}[] for _ in hars]
+    ptrs = [Tuple{Int,SVector{E,T},SVector{E,T},CellSitePos{T,E,L,B},CellSitePos{T,E,L,B},Tuple{Int,Int}}[] for _ in hars]
     lat = lattice(h)
     dn0 = zerocell(lat)
     norbs = norbitals(h)

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -779,6 +779,16 @@ params...)`, to obtain a regular `Hamiltonian` without reconstructing it from sc
 
 Special form of a parametric onsite potential meant to model a self-energy (see `attach`).
 
+    @onsite((i; params...) --> ...; sites...)
+    @onsite((ω, i; params...) --> ...; sites...)
+
+The `-->` syntax allows to treat the argument `i` as a site index, instead of a position. In
+fact, the type of `i` is `CellSitePos`, so they can be used to index `OrbitalSliceArray`s
+(see doctrings for details). The functions `pos(i)`, `cell(i)` and `ind(i)` yield the
+position, cell and site index of the site. This syntax is useful to implement models that
+depend on observables (in the form of `OrbitalSliceArray`s), like in self-consistent mean
+field calculations.
+
 ## Model algebra
 
 Parametric models can be combined using `+`, `-` and `*`, or conjugated with `'`, e.g.
@@ -794,12 +804,14 @@ ParametricModel: model with 2 terms
     Sublattices       : A
     Cells             : any
     Coefficient       : 1
+    Argument type     : spatial
     Parameters        : [:dμ]
   ParametricOnsiteTerm{ParametricFunction{0}}
     Region            : any
     Sublattices       : B
     Cells             : any
     Coefficient       : 1
+    Argument type     : spatial
     Parameters        : [:dμ]
 
 julia> LP.honeycomb() |> supercell(2) |> hamiltonian(model, orbitals = 2)
@@ -815,7 +827,7 @@ ParametricHamiltonian{Float64,2,2}: Parametric Hamiltonian on a 2D Lattice in 2D
 ```
 
 # See also
-    `onsite`, `hopping`, `@hopping`, `@onsite!`, `@hopping!`, `attach`, `hamiltonian`
+    `onsite`, `hopping`, `@hopping`, `@onsite!`, `@hopping!`, `attach`, `hamiltonian`, `OrbitalSliceArray`
 """
 macro onsite end
 
@@ -845,6 +857,17 @@ params...)`, to obtain a regular `Hamiltonian` without reconstructing it from sc
 
 Special form of a parametric hopping amplitude meant to model a self-energy (see `attach`).
 
+    @hopping((i, j; params...) --> ...; sites...)
+    @hopping((ω, i, j; params...) --> ...; sites...)
+
+The `-->` syntax allows to treat the arguments `i, j` as a site indices, instead of a
+positions. Here `i` is the destination (row) and `j` the source (column) site. In fact, the
+type of `i` and `j` is `CellSitePos`, so they can be used to index `OrbitalSliceArray`s (see
+doctrings for details). The functions `pos(i)`, `cell(i)` and `ind(i)` yield the position,
+cell and site index of the site. This syntax is useful to implement models that depend on
+observables (in the form of `OrbitalSliceArray`s), like in self-consistent mean field
+calculations.
+
 ## Model algebra
 
 Parametric models can be combined using `+`, `-` and `*`, or conjugated with `'`, e.g.
@@ -862,6 +885,7 @@ ParametricModel: model with 1 term
     Hopping range     : Neighbors(1)
     Reverse hops      : false
     Coefficient       : 1
+    Argument type     : spatial
     Parameters        : [:t, :A]
 
 julia> LP.honeycomb() |> supercell(2) |> hamiltonian(model)
@@ -877,7 +901,7 @@ ParametricHamiltonian{Float64,2,2}: Parametric Hamiltonian on a 2D Lattice in 2D
 ```
 
 # See also
-    `onsite`, `hopping`, `@onsite`, `@onsite!`, `@hopping!`, `attach`, `hamiltonian`
+    `onsite`, `hopping`, `@onsite`, `@onsite!`, `@hopping!`, `attach`, `hamiltonian`, `OrbitalSliceArray`
 """
 macro hopping end
 
@@ -899,6 +923,15 @@ particular, if no onsite model has been applied to a specific site, its onsite p
 will be zero, and will not be modified by any `@onsite!` modifier. Conversely, if an onsite
 model has been applied, `@onsite!` may modify the onsite potential even if it is zero. The
 same applies to `@hopping!`.
+
+    @onsite((o, i; params...) --> ...; sites...)
+
+The `-->` syntax allows to treat the argument `i` as a site index, instead of a position. In
+fact, the type of `i` is `CellSitePos`, so they can be used to index `OrbitalSliceArray`s
+(see doctrings for details). The functions `pos(i)`, `cell(i)` and `ind(i)` yield the
+position, cell and site index of the site. This syntax is useful to implement models that
+depend on observables (in the form of `OrbitalSliceArray`s), like in self-consistent mean
+field calculations.
 
 # Examples
 ```jldoctest
@@ -922,7 +955,7 @@ ParametricHamiltonian{Float64,2,2}: Parametric Hamiltonian on a 2D Lattice in 2D
 ```
 
 # See also
-    `onsite`, `hopping`, `@onsite`, `@hopping`, `@hopping!`, `hamiltonian`
+    `onsite`, `hopping`, `@onsite`, `@hopping`, `@hopping!`, `hamiltonian`, `OrbitalSliceArray`
 """
 macro onsite! end
 
@@ -945,6 +978,16 @@ particular, if no onsite model has been applied to a specific site, its onsite p
 will be zero, and will not be modified by any `@onsite!` modifier. Conversely, if an onsite
 model has been applied, `@onsite!` may modify the onsite potential even if it is zero. The
 same applies to `@hopping!`.
+
+    @hopping!((t, i, j; params...) --> ...; sites...)
+
+The `-->` syntax allows to treat the arguments `i, j` as a site indices, instead of a
+positions. Here `i` is the destination (row) and `j` the source (column) site. In fact, the
+type of `i` and `j` is `CellSitePos`, so they can be used to index `OrbitalSliceArray`s (see
+doctrings for details). The functions `pos(i)`, `cell(i)` and `ind(i)` yield the position,
+cell and site index of the site. This syntax is useful to implement models that depend on
+observables (in the form of `OrbitalSliceArray`s), like in self-consistent mean field
+calculations.
 
 # Examples
 ```jldoctest
@@ -970,7 +1013,7 @@ ParametricHamiltonian{Float64,2,2}: Parametric Hamiltonian on a 2D Lattice in 2D
 ```
 
 # See also
-    `onsite`, `hopping`, `@onsite`, `@hopping`, `@onsite!`, `hamiltonian`
+    `onsite`, `hopping`, `@onsite`, `@hopping`, `@onsite!`, `hamiltonian`, `OrbitalSliceArray`
 """
 macro hopping! end
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -940,6 +940,7 @@ OnsiteModifier{ParametricFunction{1}}:
   Region            : any
   Sublattices       : any
   Cells             : any
+  Argument type     : spatial
   Parameters        : [:W]
 
 julia> LP.honeycomb() |> hamiltonian(model) |> supercell(10) |> hamiltonian(disorder)
@@ -998,6 +999,7 @@ HoppingModifier{ParametricFunction{3}}:
   Cell distances    : any
   Hopping range     : Inf
   Reverse hops      : false
+  Argument type     : spatial
   Parameters        : [:A]
 
 julia> LP.honeycomb() |> hamiltonian(model) |> supercell(10) |> hamiltonian(peierls)

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -172,7 +172,7 @@ function applyterm!(builder, block, term::AppliedOnsiteTerm)
     foreach_site(sel, dn0) do s, i, r
         isinblock(i, block) || return nothing
         n = bsizes[s]
-        if is_spacial(term)
+        if is_spatial(term)
             vr = term(r, n)
             push!(ijv, (i, i, vr))
         else
@@ -196,7 +196,7 @@ function applyterm!(builder, block, term::AppliedHoppingTerm)
             isinblock(i, j, block) || return nothing
             ni = bsizes[si]
             nj = bsizes[sj]
-            if is_spacial(term)
+            if is_spatial(term)
                 vr = term(r, dr, (ni, nj))
                 push!(ijv, (i, j, vr))
             else
@@ -398,7 +398,7 @@ applymodifiers!(h, m::Modifier; kw...) = applymodifiers!(h, apply(m, h); kw...)
 
 function applymodifiers!(h, m::AppliedOnsiteModifier; kw...)
     nz = nonzeros(unflat(first(harmonics(h))))
-    if is_spacial(m)    # Branch outside loop
+    if is_spatial(m)    # Branch outside loop
         @simd for p in pointers(m)
             (ptr, r, s, norbs) = p
             @inbounds nz[ptr] = m(nz[ptr], r, norbs; kw...)   # @inbounds too risky?
@@ -414,7 +414,7 @@ end
 
 function applymodifiers!(h, m::AppliedOnsiteModifier{B}; kw...) where {B<:SMatrixView}
     nz = nonzeros(unflat(first(harmonics(h))))
-    if is_spacial(m)    # Branch outside loop
+    if is_spatial(m)    # Branch outside loop
         @simd for p in pointers(m)
             (ptr, r, s, norbs) = p
             val = view(nz[ptr], 1:norbs, 1:norbs)  # this might be suboptimal - do we need view?
@@ -433,7 +433,7 @@ end
 function applymodifiers!(h, m::AppliedHoppingModifier; kw...)
     for (har, ptrs) in zip(harmonics(h), pointers(m))
         nz = nonzeros(unflat(har))
-        if is_spacial(m)    # Branch outside loop
+        if is_spatial(m)    # Branch outside loop
             @simd for p in ptrs
                 (ptr, r, dr, si, sj, orborb) = p
                 @inbounds nz[ptr] = m(nz[ptr], r, dr, orborb; kw...)
@@ -451,7 +451,7 @@ end
 function applymodifiers!(h, m::AppliedHoppingModifier{B}; kw...) where {B<:SMatrixView}
     for (har, ptrs) in zip(harmonics(h), pointers(m))
         nz = nonzeros(unflat(har))
-        if is_spacial(m)    # Branch outside loop
+        if is_spatial(m)    # Branch outside loop
             @simd for p in ptrs
                 (ptr, r, dr, si, sj, (oi, oj)) = p
                 val = view(nz[ptr], 1:oi, 1:oj)  # this might be suboptimal - do we need view?

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -172,14 +172,9 @@ function applyterm!(builder, block, term::AppliedOnsiteTerm)
     foreach_site(sel, dn0) do s, i, r
         isinblock(i, block) || return nothing
         n = bsizes[s]
-        if is_spatial(term)
-            vr = term(r, n)
-            push!(ijv, (i, i, vr))
-        else
-            sitei = CellSitePos(dn0, i, r, B)
-            vs = term(sitei, n)
-            push!(ijv, (i, i, vs))
-        end
+        # conventional terms are never non-spatial, only modifiers can be
+        vr = term(r, n)
+        push!(ijv, (i, i, vr))
     end
     return nothing
 end
@@ -196,15 +191,9 @@ function applyterm!(builder, block, term::AppliedHoppingTerm)
             isinblock(i, j, block) || return nothing
             ni = bsizes[si]
             nj = bsizes[sj]
-            if is_spatial(term)
-                vr = term(r, dr, (ni, nj))
-                push!(ijv, (i, j, vr))
-            else
-                sitei = CellSitePos(dn, i, r + 0.5*dr, B)
-                sitej = CellSite(zero(dn), j, r - 0.5*dr, B)
-                vs = term(sitei, sitej, (ni, nj))
-                push!(ijv, (i, j, vs))
-            end
+            # conventional terms are never non-spatial, only modifiers can be
+            vr = term(r, dr, (ni, nj))
+            push!(ijv, (i, j, vr))
         end
         return found
     end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -453,15 +453,15 @@ function applymodifiers!(h, m::AppliedHoppingModifier{B}; kw...) where {B<:SMatr
         nz = nonzeros(unflat(har))
         if is_spacial(m)    # Branch outside loop
             @simd for p in ptrs
-                (ptr, r, dr, si, sj, orborb) = p
-                val = view(nz[ptr], 1:orborb, 1:orborb)  # this might be suboptimal - do we need view?
-                @inbounds nz[ptr] = m(val, r, dr, orborb; kw...)
+                (ptr, r, dr, si, sj, (oi, oj)) = p
+                val = view(nz[ptr], 1:oi, 1:oj)  # this might be suboptimal - do we need view?
+                @inbounds nz[ptr] = m(val, r, dr, (oi, oj); kw...)
             end
         else
             @simd for p in ptrs
-                (ptr, r, dr, si, sj, orborb) = p
-                val = view(nz[ptr], 1:orborb, 1:orborb)
-                @inbounds nz[ptr] = m(val, si, sj, orborb; kw...)
+                (ptr, r, dr, si, sj, (oi, oj)) = p
+                val = view(nz[ptr], 1:oi, 1:oj)
+                @inbounds nz[ptr] = m(val, si, sj, (oi, oj); kw...)
             end
         end
     end

--- a/src/models.jl
+++ b/src/models.jl
@@ -122,9 +122,6 @@ function parse_term(f, msg)
     return f´, N, params, spatial
 end
 
-replace_equal_to_kw!(ex::Expr) = ex.head == :(=) && (ex.head = :kw)
-replace_equal_to_kw!(ex) = nothing
-
 get_kwname(x::Symbol) = x
 get_kwname(x::Expr) = x.head === :kw ? x.args[1] : x.head  # x.head == :...
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -111,9 +111,11 @@ function parse_term(f, msg)
             spacial = false
         end
         # fix := to :kw in [...; param = ...]
-        f2 = f1.args[1]
-        if !spacial && f2 isa Expr && f2.head == :parameters
-            replace_equal_to_kw!.(f2.args)
+        if !spacial && !isempty(f1.args)
+            f2 = f1.args[1]
+            if f2 isa Expr && f2.head == :parameters
+                replace_equal_to_kw!.(f2.args)
+            end
         end
     end
     d = ExprTools.splitdef(f)

--- a/src/models.jl
+++ b/src/models.jl
@@ -91,11 +91,6 @@ macro hopping!(f)
     return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange(), $(spatial))))
 end
 
-# Replaces syntax [..; ...] -> ... to (...; ...) -> ..., and returns true if found
-function parse_spatial(f)
-    return f, true
-end
-
 # Extracts normalized f, number of arguments and kwarg names from an anonymous function f
 function parse_term(f, msg)
     (f isa Expr && (f.head == :-> || f.head == :-->)) || throw(ArgumentError(msg))

--- a/src/models.jl
+++ b/src/models.jl
@@ -22,9 +22,9 @@ _onsite(o::OnsiteTerm; kw...) =
 _hopping(t::HoppingTerm; kw...) =
     TightbindingModel(HoppingTerm(functor(t), hopselector(selector(t); kw...), coefficient(t)))
 _onsite(o::ParametricOnsiteTerm; kw...) =
-    ParametricModel(ParametricOnsiteTerm(functor(o), siteselector(selector(o); kw...), coefficient(o)))
+    ParametricModel(ParametricOnsiteTerm(functor(o), siteselector(selector(o); kw...), coefficient(o), is_spacial(o)))
 _hopping(t::ParametricHoppingTerm; kw...) =
-    ParametricModel(ParametricHoppingTerm(functor(t), hopselector(selector(t); kw...), coefficient(t)))
+    ParametricModel(ParametricHoppingTerm(functor(t), hopselector(selector(t); kw...), coefficient(t), is_spacial(t)))
 
 #endregion
 
@@ -42,59 +42,82 @@ _hopping(t::ParametricHoppingTerm; kw...) =
 
 # version with site selector kwargs
 macro onsite(kw, f)
-    f, N, params = get_f_N_params(f, "Only @onsite(args -> body; kw...) syntax supported. Mind the `;`.")
+    f, N, params, spacial = parse_term(f, "Only @onsite(args -> body; kw...) syntax supported. Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricOnsiteTerm(
-        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), 1))))
+        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), 1, $(spacial)))))
 end
 
 # version without site selector kwargs
 macro onsite(f)
-    f, N, params = get_f_N_params(f, "Only @onsite(args -> body; kw...) syntax supported.  Mind the `;`.")
+    f, N, params, spacial = parse_term(f, "Only @onsite(args -> body; kw...) syntax supported.  Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricOnsiteTerm(
-            Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), 1))))
+            Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), 1, $(spacial)))))
 end
 
 # version with hop selector kwargs
 macro hopping(kw, f)
-    f, N, params = get_f_N_params(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
+    f, N, params, spacial = parse_term(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricHoppingTerm(
-        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector($kw), 1))))
+        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector($kw), 1, $(spacial)))))
 end
 
 # version without hop selector kwargs
 macro hopping(f)
-    f, N, params = get_f_N_params(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
+    f, N, params, spacial = parse_term(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricHoppingTerm(
-        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector(), 1))))
+        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector(), 1, $(spacial)))))
 end
 
 ## Model modifiers ##
 
 macro onsite!(kw, f)
-    f, N, params = get_f_N_params(f, "Only @onsite!(args -> body; kw...) syntax supported. Mind the `;`.")
-    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw))))
+    f, N, params, spacial = parse_term(f, "Only @onsite!(args -> body; kw...) syntax supported. Mind the `;`.")
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), $(spacial))))
 end
 
 macro onsite!(f)
-    f, N, params = get_f_N_params(f, "Only @onsite!(args -> body; kw...) syntax supported.  Mind the `;`.")
-    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector())))
+    f, N, params, spacial = parse_term(f, "Only @onsite!(args -> body; kw...) syntax supported.  Mind the `;`.")
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), $(spacial))))
 end
 
 # Since the default hopping range is neighbors(1), we need change the default to Inf for @hopping!
 macro hopping!(kw, f)
-    f, N, params = get_f_N_params(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
-    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange($kw))))
+    f, N, params, spacial = parse_term(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange($kw), $(spacial))))
 end
 
 macro hopping!(f)
-    f, N, params = get_f_N_params(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
-    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange())))
+    f, N, params, spacial = parse_term(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange(), $(spacial))))
+end
+
+# Replaces syntax [..; ...] -> ... to (...; ...) -> ..., and returns true if found
+function parse_spacial(f)
+    return f, true
 end
 
 # Extracts normalized f, number of arguments and kwarg names from an anonymous function f
-function get_f_N_params(f, msg)
+function parse_term(f, msg)
     (f isa Expr && f.head == :->) || throw(ArgumentError(msg))
+    # change [...] -> ... to (...) -> ..., and record change in spacial
+    spacial = true
+    f1 = f.args[1]
+    if f1 isa Expr
+        if f1.head == :vect
+            f1.head = :tuple
+            spacial = false
+        elseif f1.head == :vcat
+            f1.head = :block
+            spacial = false
+        end
+        # fix := to :kw in [...; param = ...]
+        f2 = f1.args[1]
+        if !spacial && f2 isa Expr && f2.head == :parameters
+            replace_equal_to_kw!.(f2.args)
+        end
+    end
     d = ExprTools.splitdef(f)
+    # process keyword arguments, add splat
     kwargs = convert(Vector{Any}, get!(d, :kwargs, []))
     d[:kwargs] = kwargs  # in case it wasn't Vector{Any} originally
     if isempty(kwargs)
@@ -110,8 +133,11 @@ function get_f_N_params(f, msg)
     end
     N = haskey(d, :args) ? length(d[:args]) : 0
     f´ = ExprTools.combinedef(d)
-    return f´, N, params
+    return f´, N, params, spacial
 end
+
+replace_equal_to_kw!(ex::Expr) = ex.head == :(=) && (ex.head = :kw)
+replace_equal_to_kw!(ex) = nothing
 
 get_kwname(x::Symbol) = x
 get_kwname(x::Expr) = x.head === :kw ? x.args[1] : x.head  # x.head == :...
@@ -122,6 +148,7 @@ hopselector_infrange(; kw...) = hopselector(; range = Inf, kw...)
 
 ############################################################################################
 # @onsite, @hopping conversions
+#   each ParametricTerm gets converted, using `basemodel` and `modifier`, into two pieces
 #region
 
 zero_model(term::ParametricOnsiteTerm) =
@@ -132,13 +159,13 @@ zero_model(term::ParametricHoppingTerm) =
 function modifier(term::ParametricOnsiteTerm{N}) where {N}
     f = (o, args...; kw...) -> o + term(args...; kw...)
     pf = ParametricFunction{N+1}(f, parameters(term))
-    return OnsiteModifier(pf, selector(term))
+    return OnsiteModifier(pf, selector(term), is_spacial(term))
 end
 
 function modifier(term::ParametricHoppingTerm{N}) where {N}
     f = (t, args...; kw...) -> t + term(args...; kw...)
     pf = ParametricFunction{N+1}(f, parameters(term))
-    return HoppingModifier(pf, selector(term))
+    return HoppingModifier(pf, selector(term), is_spacial(term))
 end
 
 basemodel(m::ParametricModel) = nonparametric(m) + TightbindingModel(zero_model.(terms(m)))
@@ -153,14 +180,14 @@ function model_ω_to_param(term::ParametricOnsiteTerm{N}, default = 0) where {N}
     # parameters(term) only needed for reporting, we omit adding :ω_internal
     f = (args...; ω_internal = default, kw...) -> term(ω_internal, args...; kw...)
     pf = ParametricFunction{N-1}(f, parameters(term))
-    return ParametricOnsiteTerm(pf, selector(term), coefficient(term))
+    return ParametricOnsiteTerm(pf, selector(term), coefficient(term), is_spacial(term))
 end
 
 function model_ω_to_param(term::ParametricHoppingTerm{N}, default = 0) where {N}
     # parameters(term) only needed for reporting, we omit adding :ω_internal
     f = (args...; ω_internal = default, kw...) -> term(ω_internal, args...; kw...)
     pf = ParametricFunction{N-1}(f, parameters(term))
-    return ParametricHoppingTerm(pf, selector(term), coefficient(term))
+    return ParametricHoppingTerm(pf, selector(term), coefficient(term), is_spacial(term))
 end
 
 #endregion

--- a/src/models.jl
+++ b/src/models.jl
@@ -22,9 +22,9 @@ _onsite(o::OnsiteTerm; kw...) =
 _hopping(t::HoppingTerm; kw...) =
     TightbindingModel(HoppingTerm(functor(t), hopselector(selector(t); kw...), coefficient(t)))
 _onsite(o::ParametricOnsiteTerm; kw...) =
-    ParametricModel(ParametricOnsiteTerm(functor(o), siteselector(selector(o); kw...), coefficient(o), is_spacial(o)))
+    ParametricModel(ParametricOnsiteTerm(functor(o), siteselector(selector(o); kw...), coefficient(o), is_spatial(o)))
 _hopping(t::ParametricHoppingTerm; kw...) =
-    ParametricModel(ParametricHoppingTerm(functor(t), hopselector(selector(t); kw...), coefficient(t), is_spacial(t)))
+    ParametricModel(ParametricHoppingTerm(functor(t), hopselector(selector(t); kw...), coefficient(t), is_spatial(t)))
 
 #endregion
 
@@ -42,76 +42,76 @@ _hopping(t::ParametricHoppingTerm; kw...) =
 
 # version with site selector kwargs
 macro onsite(kw, f)
-    f, N, params, spacial = parse_term(f, "Only @onsite(args -> body; kw...) syntax supported. Mind the `;`.")
+    f, N, params, spatial = parse_term(f, "Only @onsite(args -> body; kw...) syntax supported. Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricOnsiteTerm(
-        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), 1, $(spacial)))))
+        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), 1, $(spatial)))))
 end
 
 # version without site selector kwargs
 macro onsite(f)
-    f, N, params, spacial = parse_term(f, "Only @onsite(args -> body; kw...) syntax supported.  Mind the `;`.")
+    f, N, params, spatial = parse_term(f, "Only @onsite(args -> body; kw...) syntax supported.  Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricOnsiteTerm(
-            Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), 1, $(spacial)))))
+            Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), 1, $(spatial)))))
 end
 
 # version with hop selector kwargs
 macro hopping(kw, f)
-    f, N, params, spacial = parse_term(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
+    f, N, params, spatial = parse_term(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricHoppingTerm(
-        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector($kw), 1, $(spacial)))))
+        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector($kw), 1, $(spatial)))))
 end
 
 # version without hop selector kwargs
 macro hopping(f)
-    f, N, params, spacial = parse_term(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
+    f, N, params, spatial = parse_term(f, "Only @hopping(args -> body; kw...) syntax supported. Mind the `;`.")
     return esc(:(Quantica.ParametricModel(Quantica.ParametricHoppingTerm(
-        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector(), 1, $(spacial)))))
+        Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector(), 1, $(spatial)))))
 end
 
 ## Model modifiers ##
 
 macro onsite!(kw, f)
-    f, N, params, spacial = parse_term(f, "Only @onsite!(args -> body; kw...) syntax supported. Mind the `;`.")
-    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), $(spacial))))
+    f, N, params, spatial = parse_term(f, "Only @onsite!(args -> body; kw...) syntax supported. Mind the `;`.")
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector($kw), $(spatial))))
 end
 
 macro onsite!(f)
-    f, N, params, spacial = parse_term(f, "Only @onsite!(args -> body; kw...) syntax supported.  Mind the `;`.")
-    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), $(spacial))))
+    f, N, params, spatial = parse_term(f, "Only @onsite!(args -> body; kw...) syntax supported.  Mind the `;`.")
+    return esc(:(Quantica.OnsiteModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.siteselector(), $(spatial))))
 end
 
 # Since the default hopping range is neighbors(1), we need change the default to Inf for @hopping!
 macro hopping!(kw, f)
-    f, N, params, spacial = parse_term(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
-    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange($kw), $(spacial))))
+    f, N, params, spatial = parse_term(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange($kw), $(spatial))))
 end
 
 macro hopping!(f)
-    f, N, params, spacial = parse_term(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
-    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange(), $(spacial))))
+    f, N, params, spatial = parse_term(f, "Only @hopping!(args -> body; kw...) syntax supported. Mind the `;`.")
+    return esc(:(Quantica.HoppingModifier(Quantica.ParametricFunction{$N}($f, $(params)), Quantica.hopselector_infrange(), $(spatial))))
 end
 
 # Replaces syntax [..; ...] -> ... to (...; ...) -> ..., and returns true if found
-function parse_spacial(f)
+function parse_spatial(f)
     return f, true
 end
 
 # Extracts normalized f, number of arguments and kwarg names from an anonymous function f
 function parse_term(f, msg)
     (f isa Expr && f.head == :->) || throw(ArgumentError(msg))
-    # change [...] -> ... to (...) -> ..., and record change in spacial
-    spacial = true
+    # change [...] -> ... to (...) -> ..., and record change in spatial
+    spatial = true
     f1 = f.args[1]
     if f1 isa Expr
         if f1.head == :vect
             f1.head = :tuple
-            spacial = false
+            spatial = false
         elseif f1.head == :vcat
             f1.head = :block
-            spacial = false
+            spatial = false
         end
         # fix := to :kw in [...; param = ...]
-        if !spacial && !isempty(f1.args)
+        if !spatial && !isempty(f1.args)
             f2 = f1.args[1]
             if f2 isa Expr && f2.head == :parameters
                 replace_equal_to_kw!.(f2.args)
@@ -135,7 +135,7 @@ function parse_term(f, msg)
     end
     N = haskey(d, :args) ? length(d[:args]) : 0
     f´ = ExprTools.combinedef(d)
-    return f´, N, params, spacial
+    return f´, N, params, spatial
 end
 
 replace_equal_to_kw!(ex::Expr) = ex.head == :(=) && (ex.head = :kw)
@@ -161,13 +161,13 @@ zero_model(term::ParametricHoppingTerm) =
 function modifier(term::ParametricOnsiteTerm{N}) where {N}
     f = (o, args...; kw...) -> o + term(args...; kw...)
     pf = ParametricFunction{N+1}(f, parameters(term))
-    return OnsiteModifier(pf, selector(term), is_spacial(term))
+    return OnsiteModifier(pf, selector(term), is_spatial(term))
 end
 
 function modifier(term::ParametricHoppingTerm{N}) where {N}
     f = (t, args...; kw...) -> t + term(args...; kw...)
     pf = ParametricFunction{N+1}(f, parameters(term))
-    return HoppingModifier(pf, selector(term), is_spacial(term))
+    return HoppingModifier(pf, selector(term), is_spatial(term))
 end
 
 basemodel(m::ParametricModel) = nonparametric(m) + TightbindingModel(zero_model.(terms(m)))
@@ -182,14 +182,14 @@ function model_ω_to_param(term::ParametricOnsiteTerm{N}, default = 0) where {N}
     # parameters(term) only needed for reporting, we omit adding :ω_internal
     f = (args...; ω_internal = default, kw...) -> term(ω_internal, args...; kw...)
     pf = ParametricFunction{N-1}(f, parameters(term))
-    return ParametricOnsiteTerm(pf, selector(term), coefficient(term), is_spacial(term))
+    return ParametricOnsiteTerm(pf, selector(term), coefficient(term), is_spatial(term))
 end
 
 function model_ω_to_param(term::ParametricHoppingTerm{N}, default = 0) where {N}
     # parameters(term) only needed for reporting, we omit adding :ω_internal
     f = (args...; ω_internal = default, kw...) -> term(ω_internal, args...; kw...)
     pf = ParametricFunction{N-1}(f, parameters(term))
-    return ParametricHoppingTerm(pf, selector(term), coefficient(term), is_spacial(term))
+    return ParametricHoppingTerm(pf, selector(term), coefficient(term), is_spatial(term))
 end
 
 #endregion

--- a/src/sanitizers.jl
+++ b/src/sanitizers.jl
@@ -102,6 +102,19 @@ end
 #endregion
 
 ############################################################################################
+# block sanitizers
+#   if a is the result of indexing an OrbitalSliceArray with an CellSitePos, ensure it can
+#   be the result of a model term function. Required for e.g. mean-field models.
+#region
+
+sanitize_block(::Type{C}, a) where {C<:Number} = complex(C)(only(a))
+sanitize_block(::Type{C}, a) where {C<:SMatrix} = C(a)
+# here we assume a is already of the correct size and let if fail later otherwise
+sanitize_block(::Type{C}, a) where {C<:SMatrixView} = a
+
+#endregion
+
+############################################################################################
 # Supercell sanitizers
 #region
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -140,6 +140,7 @@ function Base.show(io::IO, t::Union{AbstractModelTerm,Modifier})
         print(io, "\n", "$(i)  Coefficient       : $(t.coefficient)")
     end
     if t isa AbstractParametricTerm || t isa Modifier
+        print(io, "\n", "$(i)  Argument type     : $(display_argument_type(t))")
         print(io, "\n", "$(i)  Parameters        : $(parameters(t))")
     end
 end
@@ -152,6 +153,8 @@ Base.summary(::ParametricOnsiteTerm{N}) where {N} = "ParametricOnsiteTerm{Parame
 Base.summary(::ParametricHoppingTerm{N}) where {N} = "ParametricHoppingTerm{ParametricFunction{$N}}"
 Base.summary(::OnsiteModifier{N}) where {N} = "OnsiteModifier{ParametricFunction{$N}}:"
 Base.summary(::HoppingModifier{N}) where {N} = "HoppingModifier{ParametricFunction{$N}}:"
+
+display_argument_type(t) = is_spatial(t) ? "spatial" : "non-spatial"
 
 #endregion
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -475,3 +475,21 @@ Base.summary(::CurrentDensitySlice{T}) where {T} =
     "CurrentDensitySlice{$T} : current density at a fixed location and arbitrary energy"
 
 #endregion
+
+############################################################################################
+# OrbitalSliceMatrix
+#region
+
+# For simplified printing of the array typename
+
+function Base.showarg(io::IO, ::OrbitalSliceMatrix{<:Any,M}, toplevel) where {M}
+    toplevel || print(io, "::")
+    print(io,  "OrbitalSliceMatrix{$M}")
+end
+
+function Base.showarg(io::IO, ::OrbitalSliceVector{<:Any,M}, toplevel) where {M}
+    toplevel || print(io, "::")
+    print(io,  "OrbitalSliceVector{$M}")
+end
+
+#endregion

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -233,6 +233,7 @@ end
 ## Constructor
 
 function densitymatrix(s::AppliedKPMGreenSolver, gs::GreenSlice{T}) where {T}
+    check_nodiag_axes(gs)
     has_selfenergy(gs) && argerror("The KPM densitymatrix solver currently support only `nothing` contacts")
     momenta = slice_momenta(s.momenta, gs)
     solver = DensityMatrixKPMSolver(momenta, s.bandCH)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -82,6 +82,7 @@ end
 function densitymatrix(s::AppliedSpectrumGreenSolver, gs::GreenSlice)
     # SpectrumGreenSlicer is 0D, so there is a single cellorbs in dict.
     # If rows/cols are contacts, we need their orbrows/orbcols (unlike for gs(ω; params...))
+    check_nodiag_axes(gs)
     i, j = only(cellsdict(orbrows(gs))), only(cellsdict(orbcols(gs)))
     oi, oj = orbindices(i), orbindices(j)
     es, psis = spectrum(s)

--- a/src/types.jl
+++ b/src/types.jl
@@ -263,12 +263,80 @@ Base.NamedTuple(s::HopSelector) =
 #endregion
 
 ############################################################################################
+# MatrixElementTypes
+#region
+
+struct SMatrixView{N,M,T,NM}
+    s::SMatrix{N,M,T,NM}
+    SMatrixView{N,M,T,NM}(mat) where {N,M,T,NM} = new(sanitize_SMatrix(SMatrix{N,M,T}, mat))
+end
+
+const MatrixElementType{T} = Union{
+    Complex{T},
+    SMatrix{N,N,Complex{T}} where {N},
+    SMatrixView{N,N,Complex{T}} where {N}}
+
+const MatrixElementUniformType{T} = Union{
+    Complex{T},
+    SMatrix{N,N,Complex{T}} where {N}}
+
+const MatrixElementNonscalarType{T,N} = Union{
+    SMatrix{N,N,Complex{T}},
+    SMatrixView{N,N,Complex{T}}}
+
+#region ## Constructors ##
+
+SMatrixView(mat::SMatrix{N,M,T,NM}) where {N,M,T,NM} = SMatrixView{N,M,T,NM}(mat)
+
+SMatrixView{N,M}(mat::AbstractMatrix{T}) where {N,M,T} = SMatrixView{N,M,T}(mat)
+
+SMatrixView{N,M,T}(mat) where {N,M,T} = SMatrixView{N,M,T,N*M}(mat)
+
+SMatrixView(::Type{SMatrix{N,M,T,NM}}) where {N,M,T,NM} = SMatrixView{N,M,T,NM}
+
+MatrixElementType(::Type{C}, a) where {C<:Number} = complex(C)(only(a))
+MatrixElementType(::Type{C}, a) where {C<:MatrixElementNonscalarType} = C(a)
+
+#endregion
+
+#region ## API ##
+
+unblock(s::SMatrixView) = s.s
+unblock(s) = s
+
+Base.parent(s::SMatrixView) = s.s
+
+Base.view(s::SMatrixView, i...) = view(s.s, i...)
+
+Base.getindex(s::SMatrixView, i...) = getindex(s.s, i...)
+
+Base.zero(::Type{SMatrixView{N,M,T,NM}}) where {N,M,T,NM} = SMatrixView(zero(SMatrix{N,M,T,NM}))
+Base.zero(::S) where {S<:SMatrixView} = zero(S)
+
+Base.adjoint(s::SMatrixView) = SMatrixView(s.s')
+
+Base.:+(s::SMatrixView...) = SMatrixView(+(parent.(s)...))
+Base.:-(s::SMatrixView) = SMatrixView(-parent.(s))
+Base.:*(s::SMatrixView, x::Number) = SMatrixView(parent(s) * x)
+Base.:*(x::Number, s::SMatrixView) = SMatrixView(x * parent(s))
+
+Base.:(==)(s::SMatrixView, s´::SMatrixView) = parent(s) == parent(s´)
+
+#endregion
+#endregion
+
+############################################################################################
 # LatticeSlice - see slices.jl for methods
 #   Encodes subsets of sites (or orbitals) of a lattice in different cells. Produced e.g. by
 #   lat[siteselector]. No ordering is guaranteed, but cells and sites must both be unique
 #region
 
 struct SiteLike end
+
+struct SiteLikePos{T,E,B<:MatrixElementType{T}}
+    r::SVector{E,T}
+    blocktype::Type{B}
+end
 
 struct OrbitalLike end
 
@@ -277,16 +345,20 @@ struct OrbitalLikeGrouped
                                             # (non-selected sites are not present)
 end
 
-struct CellIndices{L,I,G<:Union{SiteLike,OrbitalLike,OrbitalLikeGrouped}}
+struct CellIndices{L,I,G<:Union{SiteLike,SiteLikePos,OrbitalLike,OrbitalLikeGrouped}}
     cell::SVector{L,Int}
     inds::I    # can be anything: Int, Colon, Vector{Int}, etc.
     type::G    # can be SiteLike, OrbitalLike or OrbitalLikeGrouped
 end
 
 const CellSites{L,I} = CellIndices{L,I,SiteLike}
+const CellSite{L} = CellIndices{L,Int,SiteLike}
+const CellSitePos{T,E,L,B} = CellIndices{L,Int,SiteLikePos{T,E,B}} # for non-spacial models
+const AnyCellSite = Union{CellSite,CellSitePos}
+const AnyCellSites = Union{CellSites,CellSitePos}
+
 const CellOrbitals{L,I} = CellIndices{L,I,OrbitalLike}
 const CellOrbitalsGrouped{L,I} = CellIndices{L,I,OrbitalLikeGrouped}
-const CellSite{L} = CellSites{L,Int}
 const CellOrbital{L} = CellIndices{L,Int,OrbitalLike}
 const AnyCellOrbitals = Union{CellOrbital,CellOrbitals,CellOrbitalsGrouped}
 
@@ -319,6 +391,7 @@ const AnyOrbitalSlice = Union{OrbitalSlice,OrbitalSliceGrouped}
 #region ## Constructors ##
 
 CellSite(cell, ind::Int) = CellIndices(sanitize_SVector(Int, cell), ind, SiteLike())
+CellSite(c::CellSitePos) = CellSite(c.cell, c.inds)
 CellSites(cell, inds = Int[]) = CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), SiteLike())
 # exported lowercase constructor for general inds
 cellsites(cell, inds) = CellSites(cell, inds)
@@ -330,6 +403,9 @@ CellOrbital(cell, ind::Int) =
 
 CellOrbitalsGrouped(cell, inds, groups::Dictionary) =
     CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), OrbitalLikeGrouped(groups))
+
+# B <: MatrixElementType{T}
+CellSitePos(cell, ind, r, B) = CellIndices(sanitize_SVector(Int, cell), ind, SiteLikePos(r, B))
 
 # LatticeSlice from an AbstractVector of CellIndices
 LatticeSlice(lat::Lattice, cs::AbstractVector{<:CellIndices}) =
@@ -376,9 +452,10 @@ lattice(ls::LatticeSlice) = ls.lat
 siteindices(s::CellSites) = s.inds
 siteindices(s::CellOrbitalsGrouped) = keys(s.type.groups)
 orbindices(s::AnyCellOrbitals) = s.inds
-siteindex(s::CellSite) = s.inds
+siteindex(s::AnyCellSite) = s.inds
 orbindex(s::CellOrbital) = s.inds
 
+indexcollection(l::LatticeSlice, c::CellSitePos) = siteindexdict(l)[CellSite(c)]
 indexcollection(l::LatticeSlice, c::CellSite) = siteindexdict(l)[c]
 indexcollection(l::LatticeSlice, cs::CellSites) =
     [j for i in siteindices(cs) for j in indexcollection(l, CellSite(cell(cs), i))]
@@ -413,6 +490,11 @@ findsubcell(cell::SVector, d::CellIndicesDict) = get(d, cell, nothing)
 findsubcell(cell::SVector, l::LatticeSlice) = findsubcell(cell, cellsdict(l))
 
 boundingbox(l::LatticeSlice) = boundingbox(keys(cellsdict(l)))
+
+# interface for non-spacial models
+pos(s::CellSitePos) = s.type.r
+ind(s::CellSitePos) = s.inds
+cell(s::CellSitePos) = s.cell
 
 # iterators
 
@@ -504,12 +586,14 @@ struct ParametricOnsiteTerm{N,S<:Union{SiteSelector,AppliedSiteSelector},F<:Para
     f::F
     selector::S
     coefficient::T
+    spacial::Bool   # If true, f is a function of position r. Otherwise it takes a single CellSite
 end
 
 struct ParametricHoppingTerm{N,S<:Union{HopSelector,AppliedHopSelector},F<:ParametricFunction{N},T<:Number} <: AbstractModelTerm
     f::F
     selector::S
     coefficient::T
+    spacial::Bool   # If true, f is a function of positions r, dr. Otherwise it takes two CellSite's
 end
 
 const AbstractParametricTerm{N} = Union{ParametricOnsiteTerm{N},ParametricHoppingTerm{N}}
@@ -574,6 +658,9 @@ Base.parent(m::InterblockModel) = m.model
 
 block(m::InterblockModel) = m.block
 
+is_spacial(t::AbstractParametricTerm) = t.spacial
+is_spacial(t) = true
+
 ## call API##
 
 (term::OnsiteTerm{<:Function})(r) = term.coefficient * term.f(r)
@@ -596,12 +683,12 @@ block(m::InterblockModel) = m.block
 # orbital structure, not only to a site selection
 function (t::ParametricOnsiteTerm{N})(; kw...) where {N}
     f = ParametricFunction{N}((args...) -> t.f(args...; kw...)) # no params
-    return ParametricOnsiteTerm(f, t.selector, t.coefficient)
+    return ParametricOnsiteTerm(f, t.selector, t.coefficient, t.spacial)
 end
 
 function (t::ParametricHoppingTerm{N})(; kw...) where {N}
     f = ParametricFunction{N}((args...) -> t.f(args...; kw...)) # no params
-    return ParametricHoppingTerm(f, t.selector, t.coefficient)
+    return ParametricHoppingTerm(f, t.selector, t.coefficient, t.spacial)
 end
 
 ## Model term algebra
@@ -623,9 +710,9 @@ Base.:-(m::AbstractModel, m´::AbstractModel) = m + (-m´)
 Base.:*(x::Number, o::OnsiteTerm) = OnsiteTerm(o.f, o.selector, x * o.coefficient)
 Base.:*(x::Number, t::HoppingTerm) = HoppingTerm(t.f, t.selector, x * t.coefficient)
 Base.:*(x::Number, o::ParametricOnsiteTerm) =
-    ParametricOnsiteTerm(o.f, o.selector, x * o.coefficient)
+    ParametricOnsiteTerm(o.f, o.selector, x * o.coefficient, o.spacial)
 Base.:*(x::Number, t::ParametricHoppingTerm) =
-    ParametricHoppingTerm(t.f, t.selector, x * t.coefficient)
+    ParametricHoppingTerm(t.f, t.selector, x * t.coefficient, t.spacial)
 
 Base.adjoint(m::TightbindingModel) = TightbindingModel(adjoint.(terms(m))...)
 Base.adjoint(m::ParametricModel) = ParametricModel(adjoint.(terms(m))...)
@@ -636,12 +723,12 @@ Base.adjoint(t::HoppingTerm) = HoppingTerm(t.f', t.selector', t.coefficient')
 
 function Base.adjoint(o::ParametricOnsiteTerm{N}) where {N}
     f = ParametricFunction{N}((args...; kw...) -> o.f(args...; kw...)', o.f.params)
-    return ParametricOnsiteTerm(f, o.selector, o.coefficient')
+    return ParametricOnsiteTerm(f, o.selector, o.coefficient', o.spacial)
 end
 
 function Base.adjoint(t::ParametricHoppingTerm{N}) where {N}
     f = ParametricFunction{N}((args...; kw...) -> t.f(args...; kw...)', t.f.params)
-    return ParametricHoppingTerm(f, t.selector, t.coefficient')
+    return ParametricHoppingTerm(f, t.selector, t.coefficient', t.spacial)
 end
 
 #endregion
@@ -656,27 +743,31 @@ abstract type AbstractModifier end
 struct OnsiteModifier{N,S<:SiteSelector,F<:ParametricFunction{N}} <: AbstractModifier
     f::F
     selector::S
+    spacial::Bool
 end
 
-struct AppliedOnsiteModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:SiteSelector} <: AbstractModifier
+struct AppliedOnsiteModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:SiteSelector,P<:CellSitePos} <: AbstractModifier
     parentselector::S        # unapplied selector, needed to grow a ParametricHamiltonian
     blocktype::Type{B}  # These are needed to cast the modification to the sublat block type
     f::F
-    ptrs::Vector{Tuple{Int,R,Int}}
-    # [(ptr, r, norbs)...] for each selected site, dn = 0 harmonic
+    ptrs::Vector{Tuple{Int,R,P,Int}}
+    # [(ptr, r, si, norbs)...] for each selected site, dn = 0 harmonic
+    spacial::Bool   # If true, f is a function of position r. Otherwise it takes a single CellSite
 end
 
 struct HoppingModifier{N,S<:HopSelector,F<:ParametricFunction{N}} <: AbstractModifier
     f::F
     selector::S
+    spacial::Bool  # If true, f is a function of positions r, dr. Otherwise it takes two CellSite's
 end
 
-struct AppliedHoppingModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:HopSelector} <: AbstractModifier
+struct AppliedHoppingModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:HopSelector,P<:CellSitePos} <: AbstractModifier
     parentselector::S        # unapplied selector, needed to grow a ParametricHamiltonian
     blocktype::Type{B}  # These are needed to cast the modification to the sublat block type
     f::F
-    ptrs::Vector{Vector{Tuple{Int,R,R,Tuple{Int,Int}}}}
-    # [[(ptr, r, dr, (norbs, norbs´)), ...], ...] for each selected hop on each harmonic
+    ptrs::Vector{Vector{Tuple{Int,R,R,P,P,Tuple{Int,Int}}}}
+    # [[(ptr, r, dr, si, sj, (norbs, norbs´)), ...], ...] for each selected hop on each harmonic
+    spacial::Bool  # If true, f is a function of positions r, dr. Otherwise it takes two CellSite's
 end
 
 const Modifier = Union{OnsiteModifier,HoppingModifier}
@@ -685,10 +776,10 @@ const AppliedModifier = Union{AppliedOnsiteModifier,AppliedHoppingModifier}
 #region ## Constructors ##
 
 AppliedOnsiteModifier(m::AppliedOnsiteModifier, ptrs) =
-    AppliedOnsiteModifier(m.parentselector, m.blocktype, m.f, ptrs)
+    AppliedOnsiteModifier(m.parentselector, m.blocktype, m.f, ptrs, m.spacial)
 
 AppliedHoppingModifier(m::AppliedHoppingModifier, ptrs) =
-    AppliedHoppingModifier(m.parentselector, m.blocktype, m.f, ptrs)
+    AppliedHoppingModifier(m.parentselector, m.blocktype, m.f, ptrs, m.spacial)
 
 #endregion
 
@@ -705,6 +796,8 @@ pointers(m::AppliedModifier) = m.ptrs
 
 blocktype(m::AppliedModifier) = m.blocktype
 
+is_spacial(m::AbstractModifier) = m.spacial
+
 @inline (m::AppliedOnsiteModifier{B,1})(o, r, orbs; kw...) where {B} =
     mask_block(B, m.f.f(o; kw...), (orbs, orbs))
 @inline (m::AppliedOnsiteModifier{B,2})(o, r, orbs; kw...) where {B} =
@@ -715,10 +808,10 @@ blocktype(m::AppliedModifier) = m.blocktype
 @inline (m::AppliedHoppingModifier{B,3})(t, r, dr, orborb; kw...) where {B} =
     mask_block(B, m.f.f(t, r, dr; kw...), orborb)
 
-Base.similar(m::A) where {A <: AppliedModifier} = A(m.blocktype, m.f, similar(m.ptrs, 0))
+Base.similar(m::A) where {A <: AppliedModifier} = A(m.blocktype, m.f, similar(m.ptrs, 0), m.spacial)
 
-Base.parent(m::AppliedOnsiteModifier) = OnsiteModifier(m.f, m.parentselector)
-Base.parent(m::AppliedHoppingModifier) = HoppingModifier(m.f, m.parentselector)
+Base.parent(m::AppliedOnsiteModifier) = OnsiteModifier(m.f, m.parentselector, m.spacial)
+Base.parent(m::AppliedHoppingModifier) = HoppingModifier(m.f, m.parentselector, m.spacial)
 
 #endregion
 #endregion
@@ -727,11 +820,6 @@ Base.parent(m::AppliedHoppingModifier) = HoppingModifier(m.f, m.parentselector)
 # OrbitalBlockStructure
 #    Block structure for Hamiltonians, sorted by sublattices
 #region
-
-struct SMatrixView{N,M,T,NM}
-    s::SMatrix{N,M,T,NM}
-    SMatrixView{N,M,T,NM}(mat) where {N,M,T,NM} = new(sanitize_SMatrix(SMatrix{N,M,T}, mat))
-end
 
 struct OrbitalBlockStructure{B}
     blocksizes::Vector{Int}       # number of orbitals per site in each sublattice
@@ -744,28 +832,7 @@ struct OrbitalBlockStructure{B}
     end
 end
 
-const MatrixElementType{T} = Union{
-    Complex{T},
-    SMatrix{N,N,Complex{T}} where {N},
-    SMatrixView{N,N,Complex{T}} where {N}}
-
-const MatrixElementUniformType{T} = Union{
-    Complex{T},
-    SMatrix{N,N,Complex{T}} where {N}}
-
-const MatrixElementNonscalarType{T,N} = Union{
-    SMatrix{N,N,Complex{T}},
-    SMatrixView{N,N,Complex{T}}}
-
 #region ## Constructors ##
-
-SMatrixView(mat::SMatrix{N,M,T,NM}) where {N,M,T,NM} = SMatrixView{N,M,T,NM}(mat)
-
-SMatrixView{N,M}(mat::AbstractMatrix{T}) where {N,M,T} = SMatrixView{N,M,T}(mat)
-
-SMatrixView{N,M,T}(mat) where {N,M,T} = SMatrixView{N,M,T,N*M}(mat)
-
-SMatrixView(::Type{SMatrix{N,M,T,NM}}) where {N,M,T,NM} = SMatrixView{N,M,T,NM}
 
 @inline function OrbitalBlockStructure(T, orbitals, subsizes)
     orbitals´ = sanitize_orbitals(orbitals) # <:Union{Val,distinct_collection}
@@ -804,7 +871,7 @@ flatsize(b::OrbitalBlockStructure) = blocksizes(b)' * subsizes(b)
 flatsize(b::OrbitalBlockStructure{B}, ls::SiteSlice) where {B<:Union{Complex,SMatrix}} =
     length(ls) * blocksize(b)
 flatsize(b::OrbitalBlockStructure, ls::SiteSlice) = sum(cs -> flatsize(b, cs), cellsites(ls); init = 0)
-flatsize(b::OrbitalBlockStructure, cs::CellSite) = blocksize(b, siteindex(cs))
+flatsize(b::OrbitalBlockStructure, cs::AnyCellSite) = blocksize(b, siteindex(cs))
 
 unflatsize(b::OrbitalBlockStructure) = sum(subsizes(b))
 
@@ -890,27 +957,6 @@ unflatindex_and_blocksize(::OrbitalBlockStructure{<:Number}, iflat::Integer) = (
 
 Base.copy(b::OrbitalBlockStructure{B}) where {B} =
     OrbitalBlockStructure{B}(copy(blocksizes(b)), copy(subsizes(b)))
-
-unblock(s::SMatrixView) = s.s
-unblock(s) = s
-
-Base.parent(s::SMatrixView) = s.s
-
-Base.view(s::SMatrixView, i...) = view(s.s, i...)
-
-Base.getindex(s::SMatrixView, i...) = getindex(s.s, i...)
-
-Base.zero(::Type{SMatrixView{N,M,T,NM}}) where {N,M,T,NM} = SMatrixView(zero(SMatrix{N,M,T,NM}))
-Base.zero(::S) where {S<:SMatrixView} = zero(S)
-
-Base.adjoint(s::SMatrixView) = SMatrixView(s.s')
-
-Base.:+(s::SMatrixView...) = SMatrixView(+(parent.(s)...))
-Base.:-(s::SMatrixView) = SMatrixView(-parent.(s))
-Base.:*(s::SMatrixView, x::Number) = SMatrixView(parent(s) * x)
-Base.:*(x::Number, s::SMatrixView) = SMatrixView(x * parent(s))
-
-Base.:(==)(s::SMatrixView, s´::SMatrixView) = parent(s) == parent(s´)
 
 Base.:(==)(b::OrbitalBlockStructure{B}, b´::OrbitalBlockStructure{B}) where {B} =
     b.blocksizes == b´.blocksizes && b.subsizes == b´.subsizes
@@ -2181,9 +2227,13 @@ function Base.getindex(a::OrbitalSliceMatrix, i::SiteSelector, j::SiteSelector =
 end
 
 # CellSites: return an unwrapped Matrix or a view thereof (non-allocating)
-Base.getindex(a::OrbitalSliceMatrix, i::CellSites, j::CellSites = i) = copy(view(a, i, j))
+Base.getindex(a::OrbitalSliceMatrix, i::AnyCellSites, j::AnyCellSites = i) =
+    copy(view(a, i, j))
 
-function Base.view(a::OrbitalSliceMatrix, i::CellSites, j::CellSites = i)
+Base.getindex(a::OrbitalSliceMatrix, i::C, j::C = i) where {B,C<:CellSitePos{<:Any,<:Any,<:Any,B}} =
+    MatrixElementType(B, view(a, i, j))
+
+function Base.view(a::OrbitalSliceMatrix, i::AnyCellSites, j::AnyCellSites = i)
     rowslice, colslice = orbaxes(a)
     i´, j´ = apply(i, lattice(rowslice)), apply(j, lattice(colslice))
     rows = indexcollection(rowslice, i´)

--- a/src/types.jl
+++ b/src/types.jl
@@ -2246,17 +2246,6 @@ function Base.view(a::OrbitalSliceMatrix, i::AnyCellSites, j::AnyCellSites = i)
     return view(a.parent, rows, cols)
 end
 
-# For simplified printing
-function Base.showarg(io::IO, ::OrbitalSliceMatrix{<:Any,M}, toplevel) where {M}
-    toplevel || print(io, "::")
-    print(io,  "OrbitalSliceMatrix{$M}")
-end
-
-function Base.showarg(io::IO, ::OrbitalSliceVector{<:Any,M}, toplevel) where {M}
-    toplevel || print(io, "::")
-    print(io,  "OrbitalSliceVector{$M}")
-end
-
 ## conversion
 
 maybe_OrbitalSliceArray(i) = x -> maybe_OrbitalSliceArray(x, i)

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -55,7 +55,7 @@ end
     s1´ = GS.Schur(boundary = -1)
     sites´ = (; region = r -> abs(r[2]) < 2 && r[1] == 0)
     # non-hermitian Σ model
-    mod = @onsite((ω, r; o = 1) -> (o - im*ω)*I) +
+    mod = @onsite((ω, r; o = 1) -> (o - im*ω)*I) + @onsite([ω, s; o = 1, b = 2] -> o*b*pos(s)[1]*I)
           plusadjoint(@onsite((ω; p=1)-> p*I) +  @hopping((ω, r, dr; t = 1) -> im*dr[1]*t*I; range = 1))
     g0, g0´, g1´ = greenfunction(h0, s0), greenfunction(h0, s0´), greenfunction(h1, s1´)
     for (h, s) in zip((h0, h0, h1, h1), (s0, s0´, s1, s1´))

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -55,8 +55,8 @@ end
     s1´ = GS.Schur(boundary = -1)
     sites´ = (; region = r -> abs(r[2]) < 2 && r[1] == 0)
     # non-hermitian Σ model
-    mod = @onsite((ω, r; o = 1) -> (o - im*ω)*I) + @onsite((ω, s; o = 1, b = 2) --> o*b*pos(s)[1]*I)
-          plusadjoint(@onsite((ω; p=1)-> p*I) +  @hopping((ω, r, dr; t = 1) -> im*dr[1]*t*I; range = 1))
+    mod = @onsite((ω, r; o = 1) -> (o - im*ω)*I) + @onsite((ω, s; o = 1, b = 2) --> o*b*pos(s)[1]*I) +
+          plusadjoint(@onsite((ω; p=1)-> p*I) + @hopping((ω, r, dr; t = 1) -> im*dr[1]*t*I; range = 1))
     g0, g0´, g1´ = greenfunction(h0, s0), greenfunction(h0, s0´), greenfunction(h1, s1´)
     for (h, s) in zip((h0, h0, h1, h1), (s0, s0´, s1, s1´))
         oh = h |> attach(nothing; sites´...)
@@ -348,12 +348,16 @@ end
 end
 
 @testset "mean-field models" begin
-    h0 = LP.honeycomb() |> supercell(2) |> supercell |> hamiltonian(onsite(0I) + hopping(I), orbitals = (1,2))
-    ρ0 = densitymatrix(greenfunction(h0, GS.Spectrum())[cells = SA[]])();
-    h = h0 |> @onsite!((o, s; ρ = ρ0, t) --> o + t*ρ[s])
-    @test diag(h(t = 2)[()]) ≈ 2*diag(ρ0) atol = 0.0000001
-    h = h0 |> @hopping!((t, si, sj; ρ = ρ0, α = 2) --> α*ρ[si, sj])
-    @test h() isa Quantica.Hamiltonian
-    diff = (h()[()] - 2ρ0) .* h()[()]
-    @test iszero(diff)
+    h1 = LP.honeycomb() |> supercell(2) |> supercell |> hamiltonian(onsite(0I) + hopping(I), orbitals = 1)
+    h2 = LP.honeycomb() |> supercell(2) |> supercell |> hamiltonian(onsite(0I) + hopping(I), orbitals = 2)
+    h3 = LP.honeycomb() |> supercell(2) |> supercell |> hamiltonian(onsite(0I) + hopping(I), orbitals = (1,2))
+    for h0 in (h1, h2, h3)
+        ρ0 = densitymatrix(greenfunction(h0, GS.Spectrum())[cells = SA[]])();
+        h = h0 |> @onsite!((o, s; ρ = ρ0, t) --> o + t*ρ[s])
+        @test diag(h(t = 2)[()]) ≈ 2*diag(ρ0) atol = 0.0000001
+        h = h0 |> @hopping!((t, si, sj; ρ = ρ0, α = 2) --> α*ρ[si, sj])
+        @test h() isa Quantica.Hamiltonian
+        diff = (h()[()] - 2ρ0) .* h()[()]
+        @test iszero(diff)
+    end
 end

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -55,7 +55,7 @@ end
     s1´ = GS.Schur(boundary = -1)
     sites´ = (; region = r -> abs(r[2]) < 2 && r[1] == 0)
     # non-hermitian Σ model
-    mod = @onsite((ω, r; o = 1) -> (o - im*ω)*I) + @onsite([ω, s; o = 1, b = 2] -> o*b*pos(s)[1]*I)
+    mod = @onsite((ω, r; o = 1) -> (o - im*ω)*I) + @onsite((ω, s; o = 1, b = 2) --> o*b*pos(s)[1]*I)
           plusadjoint(@onsite((ω; p=1)-> p*I) +  @hopping((ω, r, dr; t = 1) -> im*dr[1]*t*I; range = 1))
     g0, g0´, g1´ = greenfunction(h0, s0), greenfunction(h0, s0´), greenfunction(h1, s1´)
     for (h, s) in zip((h0, h0, h1, h1), (s0, s0´, s1, s1´))
@@ -350,9 +350,9 @@ end
 @testset "mean-field models" begin
     h0 = LP.honeycomb() |> supercell(2) |> supercell |> hamiltonian(onsite(0I) + hopping(I), orbitals = (1,2))
     ρ0 = densitymatrix(greenfunction(h0, GS.Spectrum())[cells = SA[]])();
-    h = h0 |> @onsite!([o, s; ρ = ρ0, t] -> o + t*ρ[s])
+    h = h0 |> @onsite!((o, s; ρ = ρ0, t) --> o + t*ρ[s])
     @test diag(h(t = 2)[()]) ≈ 2*diag(ρ0) atol = 0.0000001
-    h = h0 |> @hopping!([t, si, sj; ρ = ρ0, α = 2] -> α*ρ[si, sj])
+    h = h0 |> @hopping!((t, si, sj; ρ = ρ0, α = 2) --> α*ρ[si, sj])
     @test h() isa Quantica.Hamiltonian
     diff = (h()[()] - 2ρ0) .* h()[()]
     @test iszero(diff)

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -329,6 +329,11 @@ end
     @test ρ0[cellsites(SA[0], 1), cellsites(SA[1], 1)] isa Matrix
     @test size(view(ρ0, cellsites(SA[0], 1), cellsites(SA[1], 1))) == (2, 2)
 
+    # Diagonal slicing not yet supported
+    @test_broken densitymatrix(g1[diagonal(cells = SA[1])], 5)
+    @test_broken densitymatrix(gSpectrum[diagonal(cells = SA[])])
+    @test_broken densitymatrix(gKPM[diagonal(1)])
+
     glead = LP.square() |> hamiltonian(hopping(1)) |> supercell((0,1), region = r -> -1 <= r[1] <= 1) |> attach(nothing; cells = SA[10]) |> greenfunction(GS.Schur(boundary = 0));
     contact1 = r -> r[1] ≈ 5 && -1 <= r[2] <= 1
     contact2 = r -> r[2] ≈ 5 && -1 <= r[1] <= 1

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -346,3 +346,14 @@ end
     testcond(g0; nambu = true)
     testjosephson(g0)
 end
+
+@testset "mean-field models" begin
+    h0 = LP.honeycomb() |> supercell(2) |> supercell |> hamiltonian(onsite(0I) + hopping(I), orbitals = (1,2))
+    ρ0 = densitymatrix(greenfunction(h0, GS.Spectrum())[cells = SA[]])();
+    h = h0 |> @onsite!([o, s; ρ = ρ0, t] -> o + t*ρ[s])
+    @test diag(h(t = 2)[()]) ≈ 2*diag(ρ0) atol = 0.0000001
+    h = h0 |> @hopping!([t, si, sj; ρ = ρ0, α = 2] -> α*ρ[si, sj])
+    @test h() isa Quantica.Hamiltonian
+    diff = (h()[()] - 2ρ0) .* h()[()]
+    @test iszero(diff)
+end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -118,9 +118,9 @@ end
 
 @testset "models" begin
     mo = (onsite(1), onsite(r-> r[1]), @onsite((; o) -> o), @onsite((r; o=2) -> r[1]*o),
-         @onsite([s,; o, p] -> pos(s)[1]*o))
+         @onsite((s; o, p) --> pos(s)[1]*o))
     mh = (hopping(1), hopping((r, dr)-> im*dr[1]), @hopping((; t) -> t), @hopping((r, dr; t) -> r[1]*t),
-        @hopping([si, sj]-> im*ind(si)), @hopping([si, sj; t, p = 2] -> pos(sj)[1]*t))
+        @hopping((si, sj) --> im*ind(si)), @hopping((si, sj; t, p = 2) --> pos(sj)[1]*t))
     argso, argsh = (0, 1, 0, 1, 1), (0, 2, 0, 2, 2, 2)
     for (o, no) in zip(mo, argso)
         @test Quantica.narguments(only(Quantica.terms(o))) == no

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -117,8 +117,10 @@ end
 end
 
 @testset "models" begin
-    mo = (onsite(1), onsite(r-> r[1]), @onsite((; o) -> o), @onsite((r; o) -> r[1]*o))
-    mh = (hopping(1), hopping((r, dr)-> im*dr[1]), @hopping((; t) -> t), @hopping((r, dr; t) -> r[1]*t))
+    mo = (onsite(1), onsite(r-> r[1]), @onsite((; o) -> o), @onsite((r; o) -> r[1]*o),
+         @onsite([s; o] -> pos(s)[1]*o))
+    mh = (hopping(1), hopping((r, dr)-> im*dr[1]), @hopping((; t) -> t), @hopping((r, dr; t) -> r[1]*t),
+        hopping([si, sj]-> im*ind(si)), @hopping([si, sj; t] -> pos(sj)[1]*t))
     for o in mo, h in mh
         @test length(Quantica.allterms(-o - 2*h)) == 2
         @test Quantica.ParametricModel(o+h) isa Quantica.ParametricModel

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -338,7 +338,12 @@ end
     h0 = LP.square() |> hopping(1) |> supercell(3) |> @hopping!((t, r, dr; A = SA[1,2]) -> t*cis(A'dr))
     h = torus(h0, (0.2,:))
     @test h0((0.2, 0.3)) ≈ h((0.3,))
+    # non-spatial models
+    h = LP.linear() |> @hopping((i,j) --> ind(i) + ind(j)) + @onsite((i; k = 1) --> pos(i)[k])
+    @test ishermitian(h())
+
 end
+
 
 @testset "hamiltonian nrange" begin
     lat = LatticePresets.honeycomb(a0 = 2)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -117,10 +117,17 @@ end
 end
 
 @testset "models" begin
-    mo = (onsite(1), onsite(r-> r[1]), @onsite((; o) -> o), @onsite((r; o) -> r[1]*o),
-         @onsite([s; o] -> pos(s)[1]*o))
+    mo = (onsite(1), onsite(r-> r[1]), @onsite((; o) -> o), @onsite((r; o=2) -> r[1]*o),
+         @onsite([s,; o, p] -> pos(s)[1]*o))
     mh = (hopping(1), hopping((r, dr)-> im*dr[1]), @hopping((; t) -> t), @hopping((r, dr; t) -> r[1]*t),
-        hopping([si, sj]-> im*ind(si)), @hopping([si, sj; t] -> pos(sj)[1]*t))
+        @hopping([si, sj]-> im*ind(si)), @hopping([si, sj; t, p = 2] -> pos(sj)[1]*t))
+    argso, argsh = (0, 1, 0, 1, 1), (0, 2, 0, 2, 2, 2)
+    for (o, no) in zip(mo, argso)
+        @test Quantica.narguments(only(Quantica.terms(o))) == no
+    end
+    for (h, nh) in zip(mh, argsh)
+        @test Quantica.narguments(only(Quantica.terms(h))) == nh
+    end
     for o in mo, h in mh
         @test length(Quantica.allterms(-o - 2*h)) == 2
         @test Quantica.ParametricModel(o+h) isa Quantica.ParametricModel

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -2,7 +2,7 @@
     hs = HP.graphene(orbitals = 2), HP.graphene(orbitals = (2,1))
     for h in hs
         b = bands(h, subdiv(0,2pi,10), subdiv(0,2pi,10))
-        g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing))
+        g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing), GS.Spectrum())
         @test nothing === show(stdout, sublat((0,0)))
         @test nothing === show(stdout, LP.honeycomb())
         @test nothing === show(stdout, LP.honeycomb()[cells = (0,0)])
@@ -24,6 +24,7 @@
         @test nothing === show(stdout, Quantica.slice(b, (0,0)))
         @test nothing === show(stdout, g)
         @test nothing === show(stdout, g[cells = ()])
+        @test nothing === show(stdout, MIME("text/plain"), g[diagonal(cells = ())](0.1))
         @test nothing === show(stdout, g(0.1))
         @test nothing === show(stdout, ldos(g[1]))
         @test nothing === show(stdout, ldos(g(0.1)))
@@ -31,6 +32,8 @@
         @test nothing === show(stdout, current(g(0.1)))
         @test nothing === show(stdout, conductance(g[1]))
         @test nothing === show(stdout, transmission(g[1,2]))
+        @test nothing === show(stdout, densitymatrix(g[1]))
+        @test nothing === show(stdout, MIME("text/plain"), densitymatrix(g[1])())
     end
     h = first(hs)
     g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing))


### PR DESCRIPTION
Closes #229 

This introduces the final piece required to construct mean field models. These are one example of non-spatial models, i.e. models that cannot be written as a function of site positions, but require to know site indices and cells to then index into a mean field matrix (and OrbitalSliceMatrix to be precise, see #245).

~~The syntax for a non-spatial model is `@onsite([sitei,; params...] -> field(sitei; params...); ...)`, or `@hopping([sitei, sitej; params...] -> field(sitei, sitej; params...); ...)`, etc (this works with all types of model terms and modifiers). Note the square brackets instead of parenthesis.~~

The update syntax uses `-->` instead of `->`: 
```julia
@onsite((i; params...) --> field(i; params...); ...)
@hopping((i, j; params...) --> field(i, j; params...); ...)
@onsite!((o i; params...) --> modif(i; params...); ...)
@hopping!((t, i, j; params...) --> modif(i, j; params...); ...)
...
```
This works with all types of model terms and modifiers.

In fact `i` and `j` are instances of `CellSitePos` objects, constructed internally, which can efficiently index into `OrbitalSliceMatrices`. Thus, we could write a model like `@onsite((s; ρ = ρ0) --> ρ[s] * V(pos(s))) `, where `ρ` is an `OrbitalSliceMatrix`, obtained by evaluating for example a density matrix, `V` is a function of position, and `pos(s)` returns the position of the site. We also have `cell(s)` and `ind(s)` to access cell and site indices. Examples of this kind of application will be found in the documentation.

~~Note: due to a current limitation of the Julia parser, we cannot do `@onsite([s; p1, p2]->...)` (i.e. a single site argument, two or more parameters), see https://github.com/JuliaLang/julia/issues/53530. For the moment, we can use the workaroung `@onsite([s,; p1, p2]->...)`, i.e. adding a comma after the s argument.~~ The new `-->` syntax sidesteps this issue

EDIT: updated the implemented syntax to make it simpler internally and with less corner cases.
