### PR TITLE
Fix boundary construction in `GS.Bands`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -395,6 +395,8 @@ CellSite(c::CellSitePos) = CellSite(c.cell, c.inds)
 CellSites(cell, inds = Int[]) = CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), SiteLike())
 # exported lowercase constructor for general inds
 cellsites(cell, inds) = CellSites(cell, inds)
+# no check for unique inds
+unsafe_cellsites(cell, inds) = CellIndices(cell, inds, SiteLike())
 
 CellOrbitals(cell, inds = Int[]) =
     CellIndices(sanitize_SVector(Int, cell), sanitize_cellindices(inds), OrbitalLike())
@@ -414,6 +416,8 @@ LatticeSlice(lat::Lattice, cs::AbstractVector{<:CellIndices}) =
 # CellIndices to Dictionary(cell=>cellind)
 cellinds_to_dict(cs::AbstractVector{C}) where {L,C<:CellIndices{L}} =
     CellIndicesDict{L,C}(cell.(cs), cs)
+cellinds_to_dict(cells::AbstractVector{SVector{L,Int}}, cs::AbstractVector{C}) where {L,C<:CellIndices{L}} =
+    CellIndicesDict{L,C}(cells, cs)
 cellinds_to_dict(cs::CellIndices{L}) where {L} = cellinds_to_dict(SVector(cs))
 # don't allow single-cellsites in dictionaries (it polutes the LatticeSlice type diversity)
 cellinds_to_dict(cs::AbstractVector{C}) where {L,C<:CellSite{L}} =

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -197,6 +197,12 @@ end
         @test all(>=(0), ldos(gc[1])(0.2))
         @test all(>=(0), ldos(gc[region = RP.circle(2)])(0.2))
     end
+    # Issue #252
+    g = LP.honeycomb() |> hopping(1, range = 3) |> supercell((1,-1), (1,1)) |>
+        attach(nothing, region = RP.circle(1, SA[2,3])) |> attach(nothing, region = RP.circle(1, SA[3,-3])) |>
+        greenfunction(GS.Bands(subdiv(-π, π, 13), subdiv(-π, π, 13), boundary = 2=>-3))
+    @test g isa GreenFunction
+    @test iszero(g[cells = SA[1,-3]](0.2))
 end
 
 @testset "greenfunction 32bit" begin


### PR DESCRIPTION
Closes  #252

The issue was in the construction of orbsleft and orbsright `LatticeSlice`s, which wrongly assumed that the sites coupled to a cell to the left (right) of the boundary spanned a single cell. These `LatticeSlice`s are used to compute the G0 components that, combined, implement the boundary condition.

Note: the `GS.Bands` solver still allocates too much, specially with boundaries. There is probably still some low-hanging fruit here.