### PR TITLE
Distinguish between null and unspecified selectors

### DIFF
--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -24,12 +24,12 @@ neighbors(n::Int, lat::Lattice) = nrange(n, lat)
 #region
 
 function Base.in((s, r)::Tuple{Int,SVector{E,T}}, sel::AppliedSiteSelector{T,E}) where {T,E}
-    return inregion(r, sel) &&
+    return !isnull(sel) && inregion(r, sel) &&
            insublats(s, sel)
 end
 
 function Base.in((s, r, cell)::Tuple{Int,SVector{E,T},SVector{L,Int}}, sel::AppliedSiteSelector{T,E,L}) where {T,E,L}
-    return incells(cell, sel) &&
+    return !isnull(sel) && incells(cell, sel) &&
            inregion(r, sel) &&
            insublats(s, sel)
 end
@@ -51,7 +51,7 @@ end
 # end
 
 function Base.in(((sj, si), (r, dr), dcell)::Tuple{Pair,Tuple,SVector}, sel::AppliedHopSelector)
-    return !isonsite(dr) &&
+    return !isnull(sel) && !isonsite(dr) &&
             indcells(dcell, sel) &&
             insublats(sj => si, sel) &&
             iswithinrange(dr, sel) &&
@@ -70,6 +70,7 @@ isonsite(dr) = iszero(dr)
 # foreach_cell(f,...) should be called with a boolean function f that returns whether the
 # cell should be mark as accepted when BoxIterated
 function foreach_cell(f, sel::AppliedSiteSelector)
+    isnull(sel) && return nothing
     lat = lattice(sel)
     cells_list = cells(sel)
     if isempty(cells_list)      # no cells specified
@@ -92,6 +93,7 @@ end
 
 
 function foreach_cell(f, sel::AppliedHopSelector)
+    isnull(sel) && return nothing
     lat = lattice(sel)
     dcells_list = dcells(sel)
     if isempty(dcells_list) # no dcells specified
@@ -109,6 +111,7 @@ function foreach_cell(f, sel::AppliedHopSelector)
 end
 
 function foreach_site(f, sel::AppliedSiteSelector, cell::SVector)
+    isnull(sel) && return nothing
     lat = lattice(sel)
     for s in sublats(lat)
         insublats(s, sel) || continue
@@ -122,6 +125,7 @@ function foreach_site(f, sel::AppliedSiteSelector, cell::SVector)
 end
 
 function foreach_hop(f, sel::AppliedHopSelector, kdtrees::Vector{<:KDTree}, ni::SVector = zerocell(lattice(sel)))
+    isnull(sel) && return nothing
     lat = lattice(sel)
     _, rmax = sel.range
     # source cell at origin

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -14,18 +14,20 @@ Base.getindex(lat::Lattice, ::SiteSelectorAll) = lat[siteselector(; cells = zero
 function Base.getindex(lat::Lattice, as::AppliedSiteSelector)
     L = latdim(lat)
     csites = CellSites{L,Vector{Int}}[]
-    sinds = Int[]
-    foreach_cell(as) do cell
-        isempty(sinds) || (sinds = Int[])
-        cs = CellSites(cell, sinds)
-        foreach_site(as, cell) do s, i, r
-            push!(siteindices(cs), i)
-        end
-        if isempty(cs)
-            return false
-        else
-            push!(csites, cs)
-            return true
+    if !isnull(as)
+        sinds = Int[]
+        foreach_cell(as) do cell
+            isempty(sinds) || (sinds = Int[])
+            cs = CellSites(cell, sinds)
+            foreach_site(as, cell) do s, i, r
+                push!(siteindices(cs), i)
+            end
+            if isempty(cs)
+                return false
+            else
+                push!(csites, cs)
+                return true
+            end
         end
     end
     cellsdict = CellSitesDict{L}(cell.(csites), csites)
@@ -60,6 +62,7 @@ function Base.getindex(latslice::SiteSlice, as::AppliedSiteSelector)
     lat = parent(latslice)
     L = latdim(lat)
     cellsdict´ = CellSitesDict{L}()
+    isnull(as) && return SiteSlice(lat, cellsdict´)
     sinds = Int[]
     for subcell in cellsdict(latslice)
         dn = cell(subcell)
@@ -82,6 +85,7 @@ function Base.getindex(latslice::OrbitalSliceGrouped, as::AppliedSiteSelector)
     lat = parent(latslice)
     L = latdim(lat)
     cellsdict´ = CellOrbitalsGroupedDict{L}()
+    isnull(as) && return OrbitalSliceGrouped(lat, cellsdict´)
     oinds = Int[]
     ogroups = Dictionary{Int,UnitRange{Int}}()
     for subcell in cellsdict(latslice)

--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -88,6 +88,7 @@ function supercell_sitelist!!(sitelist, masklist, smatperp, seedperp, lat, appli
     masklist´ = copy(masklist)
     empty!(masklist)
     empty!(sitelist)
+    isnull(applied_selector) && return nothing
     cs = cells(applied_selector)
     csbool = zeros(Bool, length(cs))
     iter = BoxIterator(seedperp)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -341,7 +341,11 @@ end
     # non-spatial models
     h = LP.linear() |> @hopping((i,j) --> ind(i) + ind(j)) + @onsite((i; k = 1) --> pos(i)[k])
     @test ishermitian(h())
-
+    # null selectors
+    h0 = LP.square() |> onsite(0) + hopping(0) |> supercell(3) |> @onsite!((t, r) -> 1; sublats = Symbol[])
+    @test iszero(h0())
+    h0 = LP.square() |> hopping(0) |> supercell(3) |> @hopping!((t, r, dr) -> 1; dcells = SVector{2,Int}[])
+    @test iszero(h0())
 end
 
 

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -183,4 +183,12 @@ end
     ls = lat[cellsites(SA[1,0], 2)]
     @test ls isa Quantica.SiteSlice
     @test nsites(ls) == 1
+    # test the difference between a null selector and an unspecified one
+    ls = lat[cells = SVector{2,Int}[]]
+    @test isempty(ls)
+    ls = lat[cells = missing]
+    @test !isempty(ls)
+    ls = lat[region = RP.circle(4)]
+    ls´ = ls[cells = n -> !isreal(n[1])]
+    @test isempty(ls´)
 end


### PR DESCRIPTION
To reduce latency and type proliferation, a generic siteselector that gets applied to a lattice becomes an `AppliedSiteSelector` with minimal type parameters. That means that e.g. `cells`, which can be many things becomes a `Vector{SVector{L,Int}}`. If `cells` was not specified (it was `missing`), it becomes an empty `Vector{SVector{L,Int}}`. The codebase knows that if it encounters an empty applied `cells`, this means "unconstrained" cells. The other option was to introduce `Union{Vector{SVector{L,Int}}, Missing}`, which I don't trust to always behave under type inference, so it was discarded.

The problem comes when one passes a function to cells, `cells = n -> is_cell_in_subset(n)` for example. If that ends up empty upon application to lattice, we currently don't distinguish this from the unconstrained `cells=missing` case. This causes bugs in corner cases in different places. One particular example
```
h = LP.square() |> hopping(0) |> supercell(3) |> @hopping!((t, r, dr) -> 1; sublats = Symbol[])
```
This `h` should be zero, but before this PR it is not, because an empty `sublats::Vector{Int}` results after application, which is indistinguishable from `sublats = missing` (or simply absent `sublats`) above.


The solution taken in this PR is to make `AppliedSiteSelector` and `AppliedHopSelector` know if they are an empty selector by adding an `isnull` field that is checked before everything else. Therefore, an empty applied `cells` that does not come from `cells = missing` will cause `isnull == true`, and the selector will behave as expected. The solution is quite minimal and has no performance or complexity drawbacks. 