### PR TITLE
New algorithm for duals in `GS.Bands`

### DIFF
--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -197,12 +197,20 @@ end
         @test all(>=(0), ldos(gc[1])(0.2))
         @test all(>=(0), ldos(gc[region = RP.circle(2)])(0.2))
     end
+
     # Issue #252
     g = LP.honeycomb() |> hopping(1, range = 3) |> supercell((1,-1), (1,1)) |>
         attach(nothing, region = RP.circle(1, SA[2,3])) |> attach(nothing, region = RP.circle(1, SA[3,-3])) |>
         greenfunction(GS.Bands(subdiv(-π, π, 13), subdiv(-π, π, 13), boundary = 2=>-3))
     @test g isa GreenFunction
     @test iszero(g[cells = SA[1,-3]](0.2))
+
+    # Issue #257
+    h = LP.square() |> hopping(-1)
+    ϕs = subdiv(0, 0.6π, 2)
+    b = bands(h, ϕs, ϕs, showprogress = false)
+    g = h |> attach(@onsite(ω->-im), cells = SA[20,0]) |> greenfunction(GS.Bands(ϕs, ϕs))
+    @test g(-1)[cellsites(SA[1,-1], 1), cellsites(SA[0,0],1)] isa AbstractMatrix
 end
 
 @testset "greenfunction 32bit" begin


### PR DESCRIPTION
Closes #257 

The Green Bands solver (integrator over simplices of bands) needs to establish dual numbers for phase ϕ = k*r on simplex vertices. If a vertex is ϕ-degenerate and `r != 0`, the integration algorithm needs to have finite duals at a number of places, e.g. at α-coefficients which involve inverses of vandermonde determinants. There are many ways to choose the value of duals. Originally we chose them randomly (equivalent to doing a Taylor expansion around infinitesimal random simplex distortions). This led to problems of nondeterministic numeric noise. In #238 we introduced a better algorithm that would choose the duals in a deterministic way, so that the vandermonde determinants are never zero. However, the algorithm was not very elegant, as it was likely to fail for simplex dimension greater than three (damn obsession of generality!). We also missed an important edge case that caused #257: even if the vandermonde determinant is nonzero, there is also the Λ-coefficients in the integrator formula, which involve a different type of inverse (`1/t^j_l`) that could be zero with the duals of the #238 algorithm.

In this PR we choose duals dϕ so that `t_n = (dϕ_0-dϕ_n)/(ϵ_0-ϵ_n)` maximizes `M=t_1 * t_2 * t_3*...*(t_1-t_2)*(t_1-t_3)*...*(t_{D-1}-t_D)`. This is a modified vandermonde determinant where powers go from 1 to D instead of 0 to D-1 (thanks Adrian Prada for the key clue!). It includes all the factors that are inverted in the integration algorithm. Using this fact, we numerically solved the maximization problem, and found an approximate but very accurate solution for `t_n = (-1)^n\sqrt(0.5*(1+n^2))` that is very fast to compute and works up to at least D = 7 (didn't care to check further, as the numerical problem becomes very hard).

The black curve is the approximate solution, the colored curves are the numerical solutions for D = 2 to 7, normalized to `t_1`

![Screenshot 2024-03-29 at 21 17 32](https://github.com/pablosanjose/Quantica.jl/assets/4310809/a542af6d-582e-49ea-8591-6338472250eb)
