### PR TITLE
Add a @static version/OS check on the #235 workaround

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -264,7 +264,7 @@ function apply(solver::AbstractEigenSolver, h::AbstractHamiltonian, ::Type{S}, m
     end
     # for some reason, unless this is called, h´ may be GC'ed despite the asolver closure in
     # some systems, leading to segfaults. TODO: clarify why this is needed
-    sfunc(zero(S))
+    @static (v"1.10" <= VERSION < v"1.11.0-alpha1" && sfunc(zero(S)))
     asolver = AppliedEigenSolver(FunctionWrapper{EigenComplex{T},Tuple{S}}(sfunc))
     return asolver
 end

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -262,9 +262,9 @@ function apply(solver::AbstractEigenSolver, h::AbstractHamiltonian, ::Type{S}, m
         apply_transform!(eigen, transform)
         return eigen
     end
-    # for some reason, unless this is called, h´ may be GC'ed despite the asolver closure in
-    # some systems, leading to segfaults. TODO: clarify why this is needed
-    @static (v"1.10" <= VERSION < v"1.11.0-alpha1" && sfunc(zero(S)))
+    # issue #235: for some reason, unless this is called, h´ may be GC'ed despite the
+    # asolver closure in some systems, leading to segfaults. TODO: why this is needed?
+    @static (Sys.islinux() && v"1.10" <= VERSION < v"1.11.0-alpha1" && sfunc(zero(S)))
     asolver = AppliedEigenSolver(FunctionWrapper{EigenComplex{T},Tuple{S}}(sfunc))
     return asolver
 end


### PR DESCRIPTION
Since the workaround to #235 is only required in 1.10 under linux, and since it incurs a non-negligible overhead when computing a single `spectrum` call, we statically apply the workaround from #234 only in the required cases.

Closes #235