### PR TITLE
Factor out Hamiltonian builders

### DIFF
--- a/src/builders.jl
+++ b/src/builders.jl
@@ -31,10 +31,10 @@ SparseArrays.sparse(c::IJV, m::Integer, n::Integer) = sparse(c.i, c.j, c.v, m, n
 #endregion
 
 ############################################################################################
-# CSC Hamiltonian builder
+# CSC sparse matrix builder
 #region
 
-mutable struct CSC{B}
+mutable struct CSC{B}   # must be mutable to update counters
     colptr::Vector{Int}
     rowval::Vector{Int}
     nzval::Vector{B}
@@ -126,4 +126,179 @@ end
 
 Base.isempty(s::CSC) = length(s.nzval) == 0
 
+#endregion
+
+############################################################################################
+# Harmonic and Hamiltonian builders
+#region
+
+abstract type AbstractHarmonicBuilder{L,B} end
+abstract type AbstractHamiltonianBuilder{T,E,L,B} end
+
+struct IJVHarmonic{L,B} <: AbstractHarmonicBuilder{L,B}
+    dn::SVector{L,Int}
+    collector::IJV{B}
+end
+
+struct CSCHarmonic{L,B} <: AbstractHarmonicBuilder{L,B}
+    dn::SVector{L,Int}
+    collector::CSC{B}
+end
+
+struct IJVBuilder{T,E,L,B} <: AbstractHamiltonianBuilder{T,E,L,B}
+    lat::Lattice{T,E,L}
+    blockstruct::OrbitalBlockStructure{B}
+    harmonics::Vector{IJVHarmonic{L,B}}
+    kdtrees::Vector{KDTree{SVector{E,T},Euclidean,T}}
+end
+
+struct CSCBuilder{T,E,L,B} <: AbstractHamiltonianBuilder{T,E,L,B}
+    lat::Lattice{T,E,L}
+    blockstruct::OrbitalBlockStructure{B}
+    harmonics::Vector{CSCHarmonic{L,B}}
+end
+
+## Constructors ##
+
+function CSCBuilder(lat::Lattice{<:Any,<:Any,L}, blockstruct::OrbitalBlockStructure{B}) where {L,B}
+    harmonics = CSCHarmonic{L,B}[]
+    return CSCBuilder(lat, blockstruct, harmonics)
+end
+
+function IJVBuilder(lat::Lattice{T,E,L}, blockstruct::OrbitalBlockStructure{B}) where {E,T,L,B}
+    harmonics = IJVHarmonic{L,B}[]
+    kdtrees = Vector{KDTree{SVector{E,T},Euclidean,T}}(undef, nsublats(lat))
+    return IJVBuilder(lat, blockstruct, harmonics, kdtrees)
+end
+
+function IJVBuilder(lat::Lattice{T}, hams::AbstractHamiltonian...) where {T}
+    orbs = vcat(norbitals.(hams)...)
+    builder = IJVBuilder(lat, orbs)
+    push_ijvharmonics!(builder, hams...)
+    return builder
+end
+
+IJVBuilder(lat::Lattice{T}, orbitals) where {T} =
+    IJVBuilder(lat, OrbitalBlockStructure(T, orbitals, sublatlengths(lat)))
+
+push_ijvharmonics!(builder, ::OrbitalBlockStructure) = builder
+push_ijvharmonics!(builder) = builder
+
+function push_ijvharmonics!(builder::IJVBuilder, hs::AbstractHamiltonian...)
+    offset = 0
+    for h in hs
+        for har in harmonics(h)
+            ijv = builder[dcell(har)]
+            hmat = unflat(matrix(har))
+            I,J,V = findnz(hmat)
+            append!(ijv, (I .+ offset, J .+ offset, V))
+        end
+        offset += nsites(lattice(h))
+    end
+    return builder
+end
+
+empty_harmonic(b::CSCBuilder{<:Any,<:Any,L,B}, dn) where {L,B} =
+    CSCHarmonic{L,B}(dn, CSC{B}(nsites(b.lat)))
+
+empty_harmonic(::IJVBuilder{<:Any,<:Any,L,B}, dn) where {L,B} =
+    IJVHarmonic{L,B}(dn, IJV{B}())
+
+## API ##
+
+collector(har::AbstractHarmonicBuilder) = har.collector  # for IJVHarmonic and CSCHarmonic
+
+dcell(har::AbstractHarmonicBuilder) = har.dn
+
+kdtrees(b::IJVBuilder) = b.kdtrees
+
+finalizecolumn!(b::CSCBuilder, x...) =
+    foreach(har -> finalizecolumn!(collector(har), x...), b.harmonics)
+
+Base.isempty(h::IJVHarmonic) = isempty(collector(h))
+Base.isempty(s::CSCHarmonic) = isempty(collector(s))
+
+lattice(b::AbstractHamiltonianBuilder) = b.lat
+
+blockstructure(b::AbstractHamiltonianBuilder) = b.blockstruct
+
+blocktype(::AbstractHamiltonianBuilder{<:Any,<:Any,<:Any,B}) where {B} = B
+
+harmonics(b::AbstractHamiltonianBuilder) = b.harmonics
+
+Base.empty!(b::IJVBuilder) = (empty!(b.harmonics); b)
+
+function Base.getindex(b::AbstractHamiltonianBuilder{<:Any,<:Any,L}, dn::SVector{L,Int}) where {L}
+    hars = b.harmonics
+    for har in hars
+        dcell(har) == dn && return collector(har)
+    end
+    har = empty_harmonic(b, dn)
+    push!(hars, har)
+    return collector(har)
+end
+
+function SparseArrays.sparse(builder::AbstractHamiltonianBuilder{T,<:Any,L,B}) where {T,L,B}
+    HT = Harmonic{T,L,B}
+    b = blockstructure(builder)
+    n = nsites(lattice(builder))
+    hars = HT[sparse(b, har, n, n) for har in harmonics(builder) if !isempty(har)]
+    return hars
+end
+
+function SparseArrays.sparse(b::OrbitalBlockStructure{B}, har::AbstractHarmonicBuilder{L,B}, m::Integer, n::Integer) where {L,B}
+    s = sparse(collector(har), m, n)
+    return Harmonic(dcell(har), HybridSparseMatrix(b, s))
+end
+
+#endregion
+
+############################################################################################
+# ParametricHamiltonianBuilder - see src/hamiltonian.jl
+#   created with b = builder(lat::Lattice; orbitals = Val(1))
+#   implements: add!(b, AbstractModel), push!(b, ::Modifier...), hamiltonian(b), empty!(b)
+#   also add!(b, val, ::CellSites...) - for internal use only, not block size checks.
+#region
+
+struct ParametricHamiltonianBuilder{T,E,L,B}
+    ijvbuilder::IJVBuilder{T,E,L,B}
+    modifiers::Vector{Any}    # modifier list need to be mutable and abritrary
+end
+
+#region ## Constructors ##
+
+ParametricHamiltonianBuilder(ijvbuilder) = ParametricHamiltonianBuilder(ijvbuilder, Any[])
+
+#endregion
+
+#region ## API ##
+
+builder(; kw...) = lat -> builder(lat; kw...)
+
+builder(lat::Lattice; orbitals = Val(1)) =
+    ParametricHamiltonianBuilder(IJVBuilder(lat, orbitals))
+
+modifiers(b::ParametricHamiltonianBuilder) = b.modifiers
+
+blockstructure(b::ParametricHamiltonianBuilder) = blockstructure(b.ijvbuilder)
+
+lattice(b::ParametricHamiltonianBuilder) = lattice(b.ijvbuilder)
+
+kdtrees(b::ParametricHamiltonianBuilder) = kdtrees(b.ijvbuilder)
+
+blocktype(b::ParametricHamiltonianBuilder) = blocktype(b.ijvbuilder)
+
+Base.parent(b::ParametricHamiltonianBuilder) = b.ijvbuilder
+
+SparseArrays.sparse(b::ParametricHamiltonianBuilder) = sparse(b.ijvbuilder)
+
+Base.push!(b::ParametricHamiltonianBuilder, ms::Modifier...) = push!(b.modifiers, ms...)
+
+Base.pop!(b::ParametricHamiltonianBuilder) = pop!(b.modifiers)
+
+Base.empty!(b::ParametricHamiltonianBuilder) = (empty!(b.ijvbuilder); empty!(b.modifiers); b)
+
+Base.getindex(b::ParametricHamiltonianBuilder, dn::SVector) = b.ijvbuilder[dn]
+
+#endregion
 #endregion

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -26,6 +26,8 @@ Base.append!(ijv::IJV, (is, js, vs)) =
 
 Base.isempty(h::IJV) = length(h.i) == 0
 
+Base.length(h::IJV) = length(h.v)
+
 SparseArrays.sparse(c::IJV, m::Integer, n::Integer) = sparse(c.i, c.j, c.v, m, n)
 
 #endregion

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -375,9 +375,9 @@ translate
 If all `lats` have compatible Bravais vectors, combine them into a single lattice.
 If necessary, sublattice names are renamed to remain unique.
 
-    combine(hams::AbstractHamiltonians...; coupling = TighbindingModel())
+    combine(hams::Hamiltonians...; coupling = TighbindingModel())
 
-Combine a collection `hams` of hamiltonians into one by combining their corresponding
+Combine a collection `hams` of Hamiltonians into one by combining their corresponding
 lattices, and optionally by adding a coupling between them, given by the hopping terms in
 `coupling`.
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -484,6 +484,9 @@ unitcell_hamiltonian(ph::ParametricHamiltonian) = unitcell_hamiltonian(hamiltoni
 
 ############################################################################################
 # combine
+#   We cannot combine anything with parameters. The reason is that coupling modifiers and
+#   modifiers of hams should only be applied to their corresponding blocks, which we
+#   currently cannot express. Needs e.g. Selectors with indices, or Modifiers with blocks.
 #region
 
 function combine(hams::Hamiltonian{T}...; coupling::TightbindingModel = TightbindingModel()) where {T}
@@ -497,9 +500,6 @@ end
 
 combine(hams::AbstractHamiltonian...; kw...) =
     argerror("Quantica can currently only combine Hamiltonians (not ParametricHamiltonians) using non-parametric couplings.")
-
-# The reason is that coupling and the modifiers of hams should only be applied to their
-# corresponding blocks, which we currently cannot express. Needs Selectors with indices.
 
 #endregion
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1,166 +1,63 @@
 ############################################################################################
-# Hamiltonian builders
+# add!(::IJVBuilder, ...)
+# add!(::ParametricHamiltonianBuilder, ...)
+#   add matrix elements to a builder before assembly into a (Parametric)Hamiltonian
 #region
 
-abstract type AbstractHamiltonianBuilder{T,E,L,B} end
+add!(m::TightbindingModel) = b -> add!(b, m)
 
-abstract type AbstractBuilderHarmonic{L,B} end
-
-struct IJVHarmonic{L,B} <: AbstractBuilderHarmonic{L,B}
-    dn::SVector{L,Int}
-    collector::IJV{B}
+# direct site indexing
+function add!(b::Union{IJVBuilder,ParametricHamiltonianBuilder}, val, c::CellSites, d::CellSites)
+    ijv = b[cell(d) - cell(c)]
+    B = blocktype(b)
+    val´ = mask_block(B, val)   # Warning: we don't check matrix size here, just conversion to B
+    add!(ijv, val´, siteindices(c), siteindices(d))
+    return b
 end
 
-mutable struct CSCHarmonic{L,B} <: AbstractBuilderHarmonic{L,B}
-    dn::SVector{L,Int}
-    collector::CSC{B}
+function add!(b::Union{IJVBuilder,ParametricHamiltonianBuilder}, val, c::CellSites)
+    ijv = b[zero(cell(c))]
+    B = blocktype(b)
+    val´ = mask_block(B, val)   # Warning: we don't check matrix size here, just conversion to B
+    add!(ijv, val´, siteindices(c))
+    return b
 end
 
-struct IJVBuilder{T,E,L,B} <: AbstractHamiltonianBuilder{T,E,L,B}
-    lat::Lattice{T,E,L}
-    blockstruct::OrbitalBlockStructure{B}
-    harmonics::Vector{IJVHarmonic{L,B}}
-    kdtrees::Vector{KDTree{SVector{E,T},Euclidean,T}}
-end
+add!(ijv::IJV, v, i::Integer, j::Integer = i) = push!(ijv, (i, j, v))
 
-struct CSCBuilder{T,E,L,B} <: AbstractHamiltonianBuilder{T,E,L,B}
-    lat::Lattice{T,E,L}
-    blockstruct::OrbitalBlockStructure{B}
-    harmonics::Vector{CSCHarmonic{L,B}}
-end
-
-## Constructors ##
-
-function CSCBuilder(lat::Lattice{<:Any,<:Any,L}, blockstruct::OrbitalBlockStructure{B}) where {L,B}
-    harmonics = CSCHarmonic{L,B}[]
-    return CSCBuilder(lat, blockstruct, harmonics)
-end
-
-function IJVBuilder(lat::Lattice{T,E,L}, blockstruct::OrbitalBlockStructure{B}) where {E,T,L,B}
-    harmonics = IJVHarmonic{L,B}[]
-    kdtrees = Vector{KDTree{SVector{E,T},Euclidean,T}}(undef, nsublats(lat))
-    return IJVBuilder(lat, blockstruct, harmonics, kdtrees)
-end
-
-function IJVBuilder(lat::Lattice{T}, hams::AbstractHamiltonian...) where {T}
-    orbs = vcat(norbitals.(hams)...)
-    bs = OrbitalBlockStructure(T, orbs, sublatlengths(lat))
-    builder = IJVBuilder(lat, bs)
-    push_ijvharmonics!(builder, hams...)
-    return builder
-end
-
-push_ijvharmonics!(builder, ::OrbitalBlockStructure) = builder
-push_ijvharmonics!(builder) = builder
-
-function push_ijvharmonics!(builder::IJVBuilder, hs::AbstractHamiltonian...)
-    bharmonics = builder.harmonics
-    offset = 0
-    for h in hs
-        for har in harmonics(h)
-            ijv = builder[dcell(har)]
-            hmat = unflat(matrix(har))
-            I,J,V = findnz(hmat)
-            append!(ijv, (I .+ offset, J .+ offset, V))
-        end
-        offset += nsites(lattice(h))
+function add!(ijv::IJV, v, is, js)
+    foreach(Iterators.product(is, js)) do (i, j)
+        push!(ijv, (i, j, v))
     end
-    return builder
+    return ijv
 end
 
-empty_harmonic(b::CSCBuilder{<:Any,<:Any,L,B}, dn) where {L,B} =
-    CSCHarmonic{L,B}(dn, CSC{B}(nsites(b.lat)))
-
-empty_harmonic(::IJVBuilder{<:Any,<:Any,L,B}, dn) where {L,B} =
-    IJVHarmonic{L,B}(dn, IJV{B}())
-
-## API ##
-
-collector(har::AbstractBuilderHarmonic) = har.collector  # for IJVHarmonic and CSCHarmonic
-
-dcell(har::AbstractBuilderHarmonic) = har.dn
-
-kdtrees(b::IJVBuilder) = b.kdtrees
-
-finalizecolumn!(b::CSCBuilder, x...) =
-    foreach(har -> finalizecolumn!(collector(har), x...), b.harmonics)
-
-Base.isempty(h::IJVHarmonic) = isempty(collector(h))
-Base.isempty(s::CSCHarmonic) = isempty(collector(s))
-
-lattice(b::AbstractHamiltonianBuilder) = b.lat
-
-blockstructure(b::AbstractHamiltonianBuilder) = b.blockstruct
-
-blocktype(::AbstractHamiltonianBuilder{<:Any,<:Any,<:Any,B}) where {B} = B
-
-harmonics(b::AbstractHamiltonianBuilder) = b.harmonics
-
-function Base.getindex(b::AbstractHamiltonianBuilder{<:Any,<:Any,L}, dn::SVector{L,Int}) where {L}
-    hars = b.harmonics
-    for har in hars
-        dcell(har) == dn && return collector(har)
+function add!(ijv::IJV, v, is)
+    foreach(is) do i
+        push!(ijv, (i, i, v))
     end
-    har = empty_harmonic(b, dn)
-    push!(hars, har)
-    return collector(har)
+    return ijv
 end
 
-function SparseArrays.sparse(builder::AbstractHamiltonianBuilder{T,<:Any,L,B}) where {T,L,B}
-    HT = Harmonic{T,L,B}
-    b = blockstructure(builder)
-    n = nsites(lattice(builder))
-    hars = HT[sparse(b, har, n, n) for har in harmonics(builder) if !isempty(har)]
-    return hars
+
+# block may be a tuple of row-col index ranges, to restrict application of model
+function add!(b::Union{IJVBuilder,ParametricHamiltonianBuilder}, model::TightbindingModel, block = missing)
+    lat = lattice(b)
+    bs = blockstructure(b)
+    amodel = apply(model, (lat, bs))
+    addterm!.(Ref(b), Ref(block), terms(amodel))
+    return b
 end
 
-function SparseArrays.sparse(b::OrbitalBlockStructure{B}, har::AbstractBuilderHarmonic{L,B}, m::Integer, n::Integer) where {L,B}
-    s = sparse(collector(har), m, n)
-    return Harmonic(dcell(har), HybridSparseMatrix(b, s))
+function add!(b::ParametricHamiltonianBuilder, model::ParametricModel, block = missing)
+    m0 = basemodel(model)
+    ms = modifier.(terms(model))
+    add!(b, m0, block)
+    push!(b, ms...)
+    return b
 end
 
-#endregion
-
-############################################################################################
-# hamiltonian
-#region
-
-(model::AbstractModel)(lat::Lattice) = hamiltonian(lat, model)
-(modifier::Modifier)(h::AbstractHamiltonian) = hamiltonian(h, modifier)
-
-hamiltonian(args...; kw...) = lat -> hamiltonian(lat, args...; kw...)
-
-hamiltonian(lat::Lattice, m0::TightbindingModel, m::Modifier, ms::Modifier...; kw...) =
-    parametric(hamiltonian(lat, m0; kw...), m, ms...)
-
-hamiltonian(lat::Lattice, m0::ParametricModel, ms::Modifier...; kw...) =
-    parametric(hamiltonian(lat, basemodel(m0); kw...), modifier.(terms(m0))..., ms...)
-
-hamiltonian(lat::Lattice, m::Modifier, ms::Modifier...; kw...) =
-    parametric(hamiltonian(lat; kw...), m, ms...)
-
-hamiltonian(h::AbstractHamiltonian, m::AbstractModifier, ms::AbstractModifier...) =
-    parametric(h, m, ms...)
-
-hamiltonian(lat::Lattice, m::AbstractBlockModel{<:TightbindingModel}; kw...) =
-    hamiltonian(lat, parent(m), block(m); kw...)
-
-hamiltonian(lat::Lattice, m::AbstractBlockModel{<:ParametricModel}; kw...) = parametric(
-    hamiltonian(lat, basemodel(parent(m)), block(m); kw...),
-    modifier.(terms(parent(m)))...)
-
-# Base.@constprop :aggressive may be needed for type-stable non-Val orbitals?
-function hamiltonian(lat::Lattice{T}, m::TightbindingModel = TightbindingModel(), block = missing; orbitals = Val(1)) where {T}
-    blockstruct = OrbitalBlockStructure(T, orbitals, sublatlengths(lat))
-    builder = IJVBuilder(lat, blockstruct)
-    apmod = apply(m, (lat, blockstruct))
-    # using foreach here foils precompilation of applyterm! for some reason
-    applyterm!.(Ref(builder), Ref(block), terms(apmod))
-    hars = sparse(builder)
-    return Hamiltonian(lat, blockstruct, hars)
-end
-
-function applyterm!(builder, block, term::AppliedOnsiteTerm)
+function addterm!(builder, block, term::AppliedOnsiteTerm)
     sel = selector(term)
     isempty(cells(sel)) || argerror("Cannot constrain cells in an onsite term, cell periodicity is assumed.")
     lat = lattice(builder)
@@ -168,7 +65,6 @@ function applyterm!(builder, block, term::AppliedOnsiteTerm)
     ijv = builder[dn0]
     bs = blockstructure(builder)
     bsizes = blocksizes(bs)
-    B = blocktype(builder)
     foreach_site(sel, dn0) do s, i, r
         isinblock(i, block) || return nothing
         n = bsizes[s]
@@ -179,12 +75,11 @@ function applyterm!(builder, block, term::AppliedOnsiteTerm)
     return nothing
 end
 
-function applyterm!(builder, block, term::AppliedHoppingTerm)
+function addterm!(builder, block, term::AppliedHoppingTerm)
     trees = kdtrees(builder)
     sel = selector(term)
     bs = blockstructure(builder)
     bsizes = blocksizes(bs)
-    B = blocktype(builder)
     foreach_cell(sel) do dn
         ijv = builder[dn]
         found = foreach_hop(sel, trees, dn) do (si, sj), (i, j), (r, dr)
@@ -216,6 +111,50 @@ end
 isinblock(i, j, rng) = isinblock(i, rng) && isinblock(j, rng)
 isinblock(i, ::Missing) = true
 isinblock(i, rng) = i in rng
+
+#endregion
+
+############################################################################################
+# hamiltonian
+#region
+
+(model::AbstractModel)(lat::Lattice) = hamiltonian(lat, model)
+(modifier::Modifier)(h::AbstractHamiltonian) = hamiltonian(h, modifier)
+
+hamiltonian(args...; kw...) = lat -> hamiltonian(lat, args...; kw...)
+
+hamiltonian(h::AbstractHamiltonian, m::AbstractModifier, ms::AbstractModifier...) =
+    parametric(h, m, ms...)
+
+hamiltonian(lat::Lattice, m0::TightbindingModel, m::Modifier, ms::Modifier...; kw...) =
+    parametric(hamiltonian(lat, m0; kw...), m, ms...)
+
+hamiltonian(lat::Lattice, m0::ParametricModel, ms::Modifier...; kw...) =
+    parametric(hamiltonian(lat, basemodel(m0); kw...), modifier.(terms(m0))..., ms...)
+
+hamiltonian(lat::Lattice, m::Modifier, ms::Modifier...; kw...) =
+    parametric(hamiltonian(lat; kw...), m, ms...)
+
+hamiltonian(lat::Lattice, m::AbstractBlockModel{<:TightbindingModel}; kw...) =
+    hamiltonian(lat, parent(m), block(m); kw...)
+
+hamiltonian(lat::Lattice, m::AbstractBlockModel{<:ParametricModel}; kw...) = parametric(
+    hamiltonian(lat, basemodel(parent(m)), block(m); kw...),
+    modifier.(terms(parent(m)))...)
+
+function hamiltonian(lat::Lattice{T}, m::TightbindingModel = TightbindingModel(), block = missing; orbitals = Val(1)) where {T}
+    b = IJVBuilder(lat, orbitals)
+    add!(b, m, block)
+    return hamiltonian(b)
+end
+
+hamiltonian(b::IJVBuilder) = Hamiltonian(lattice(b), blockstructure(b), sparse(b))
+
+hamiltonian(b::ParametricHamiltonianBuilder) =
+    maybe_parametric(hamiltonian(parent(b)), modifiers(b)...)
+
+maybe_parametric(h) = h                                     # without modifiers
+maybe_parametric(h, m, ms...) = parametric(h, m, ms...)     # with modifiers
 
 #endregion
 
@@ -553,7 +492,7 @@ function combine(hams::AbstractHamiltonian{T}...; coupling = TightbindingModel()
     interblockmodel = interblock(coupling, hams...)
     model´, blocks´ = parent(interblockmodel), block(interblockmodel)
     apmod = apply(model´, (lat, blockstruct))
-    applyterm!.(Ref(builder), Ref(blocks´), terms(apmod))
+    addterm!.(Ref(builder), Ref(blocks´), terms(apmod))
     hars = sparse(builder)
     ham = Hamiltonian(lat, blockstruct, hars)
     ms = tupleflatten(modifiers.(hams)...)

--- a/src/models.jl
+++ b/src/models.jl
@@ -183,7 +183,7 @@ interblock(m::AbstractModel, inds...) = isempty(intersect(inds...)) ?
 
 intrablock(m::AbstractModel, inds) = IntrablockModel(m, inds)
 
-function blockindices(hams::NTuple{N,<:Any}) where {N}
+function blockindices(hams::NTuple{N,Any}) where {N}
     offset = 0
     inds = ntuple(Val(N)) do i
         ns = nsites(lattice(hams[i]))

--- a/src/show.jl
+++ b/src/show.jl
@@ -499,3 +499,25 @@ function Base.showarg(io::IO, ::OrbitalSliceVector{<:Any,M}, toplevel) where {M}
 end
 
 #endregion
+
+############################################################################################
+# IJVBuilder
+#region
+
+function Base.show(io::IO, b::IJVBuilder)
+    i = get(io, :indent, "")
+    print(io, i, summary(b), "\n",
+"$i  Harmonics    : $(length(harmonics(b)))
+$i  IJV tuples   : $(display_ijvs(b))
+$i  Element type : $(displaytype(blocktype(b)))
+$i  Modifiers    : $(display_modifiers(b))")
+end
+
+display_modifiers(b::IJVBuilder) = modifiers(b) === missing ? "missing" : length(modifiers(b))
+
+display_ijvs(b::IJVBuilder) = display_as_tuple(length.(collector.(harmonics(b))))
+
+Base.summary(::IJVBuilder{T,E,L}) where {T,E,L} =
+    "IJVBuilder{$T,$E,$L}: AbstractHamiltonian builder based on IJV tuples (row, col, value)"
+
+#endregion

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -146,13 +146,23 @@ function Base.setindex!(b::HybridSparseMatrix, val::AbstractVecOrMat, i::Integer
     return val
 end
 
+checkstored(mat, i, j) = i in view(rowvals(mat), nzrange(mat, j)) ||
+    throw(ArgumentError("Adding new structural elements is not allowed"))
+
+#endregion
+
+############################################################################################
+# mask_block
+#   converts input to a specific block type B (with or without size check)
+#region
+
 @inline mask_block(::Type{B}, val::UniformScaling, size = (N, N)) where {T,N,B<:MatrixElementNonscalarType{T,N}} =
     mask_block(B, sanitize_SMatrix(SMatrix{N,N,T}, SMatrix{N,N}(val), size))
 
 @inline mask_block(::Type{B}, val::UniformScaling, size...) where {B<:Number} =
     convert(B, val.λ)
 
-@inline mask_block(::Type{B}, val, size...) where {B<:Number} = convert(B, only(val)) # conversion not needed
+@inline mask_block(::Type{B}, val, size...) where {B<:Number} = convert(B, only(val)) # conversion not needed?
 
 @inline function mask_block(B, val, size)
     @boundscheck(checkmatrixsize(val, size)) # tools.jl
@@ -177,9 +187,6 @@ mask_block(t, val) = argerror("Unexpected block size")
 
 size_or_1x1(::Number) = (1, 1)
 size_or_1x1(val) = size(val)
-
-checkstored(mat, i, j) = i in view(rowvals(mat), nzrange(mat, j)) ||
-    throw(ArgumentError("Adding new structural elements is not allowed"))
 
 #endregion
 

--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -174,10 +174,10 @@ function supercell(h::Hamiltonian, data::SupercellData; mincoordination = 0)
     # data.sitelist === sites(lat´), so any change to data will reflect in lat´ too
     lat´ = lattice(data)
     B = blocktype(h)
-    blk´ = OrbitalBlockStructure{B}(norbitals(h), sublatlengths(lat´))
-    builder = CSCBuilder(lat´, blk´)
+    bs´ = OrbitalBlockStructure{B}(norbitals(h), sublatlengths(lat´))
+    builder = CSCBuilder(lat´, bs´)
     har´ = supercell_harmonics(h, data, builder, mincoordination)
-    return Hamiltonian(lat´, blk´, har´)
+    return Hamiltonian(lat´, bs´, har´)
 end
 
 function supercell_harmonics(h, data, builder, mincoordination)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,4 +1,4 @@
-using Quantica: Hamiltonian, ParametricHamiltonian, ParametricHamiltonianBuilder,
+using Quantica: Hamiltonian, ParametricHamiltonian,
       sites, nsites, nonsites, nhoppings, coordination, flat, hybrid, transform!, nnz, nonzeros
 
 @testset "basic hamiltonians" begin
@@ -414,7 +414,7 @@ end
 
 @testset "hamiltonian builder" begin
     b = LP.linear() |> Quantica.builder(orbitals = 2)
-    @test b isa ParametricHamiltonianBuilder
+    @test b isa Quantica.IJVBuilder
     @test hamiltonian(b) isa Hamiltonian
     Quantica.add!(b, hopping(2I))
     Quantica.add!(b, @onsite((; w = 0) -> w*I))

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -44,4 +44,6 @@
     @test nothing === show(stdout, densitymatrix(g[1]))
     g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing), GS.Spectrum())
     @test nothing === show(stdout, densitymatrix(g[1]))
+    b = LP.honeycomb() |> Quantica.builder(orbitals = 2)
+    @test nothing === show(stdout, b)
 end


### PR DESCRIPTION
This is a first step towards addressing #4

Here we split (internally) the process of building a Hamiltonian, which was formerly a single step `hamiltonian(lattice, model; orbitals)`,  to a multistep process:  `b = builder(lattice; orbitals)` (of type `ParametricHamiltonianBuilder`), `add!(b, model)`, and finally `hamiltonian(b)`. We can also do `push!(b, modifiers...)` to inject `Modifiers` into the builder before assembly into a Hamiltonian.

These  `builder` and `add!` functions are unexported for the moment, and meant to be used internally only. `add!` also has a method `add!(b, value, ::CellSites, ::CellSites)` to add a single or a group of values to a Hamiltonian build before assembly. This is not exported for a good reason: we don't do matrix-size checks of value for performance reasons here. Hence, improper use in inhomogeneous multiorbital cases could in principle lead to malformed block elements (i.e. with nonzeros out of place).

The advantage of this refactor is that we can now envision making a Wannierization object that wraps two builders that are populated as the wannier90 file is read, one for the Hamiltonian and another for the position matrix elements. Then, it becomes possible to combine the hamiltonian builder inside this object with other models (even parametric models) so that we can mix Wannier90 presents with flexible parametric models and modifiers.