### PR TITLE
Add `transform` keyword to generic `attach` method

### DIFF
--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -40,7 +40,7 @@ function SelfEnergy(hparent::AbstractHamiltonian, gslice::GreenSlice, model::Abs
     lsbath = orbrows(gslice)
     lat0bath = lattice0D(lsbath)
     transform === missing || transform!(lat0bath, transform)
-    contactslice = lattice(hparent)[; sites...]
+    contactslice = lattice(hparent)[sites...]
     check_contact_slice(contactslice)  # in case it is empty
     lsparent = sites_to_orbs(contactslice, hparent)
     lat0parent = lattice0D(lsparent)

--- a/src/solvers/selfenergy/model.jl
+++ b/src/solvers/selfenergy/model.jl
@@ -30,7 +30,7 @@ end
 #region ## API ##
 
 function SelfEnergy(h::AbstractHamiltonian, model::AbstractModel; kw...)
-    contactslice = lattice(h)[; kw...]
+    contactslice = lattice(h)[kw...]
     check_contact_slice(contactslice)  # in case it is empty
     orbslice = sites_to_orbs(contactslice, h)
     solver = SelfEnergyModelSolver(h, model, contactslice, orbslice)

--- a/src/solvers/selfenergy/nothing.jl
+++ b/src/solvers/selfenergy/nothing.jl
@@ -8,7 +8,7 @@ struct SelfEnergyEmptySolver{C} <: RegularSelfEnergySolver
 end
 
 function SelfEnergy(h::AbstractHamiltonian{T}, ::Nothing; kw...) where {T}
-    contactslice = lattice(h)[; kw...]
+    contactslice = lattice(h)[kw...]
     check_contact_slice(contactslice)  # in case it is empty
     orbslice = sites_to_orbs(contactslice, h)
     norbs = norbitals(orbslice)

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -41,7 +41,7 @@ end
 # and if so, builds the extended Self Energy directly, using the same intercell coupling of
 # the lead, but using the correct site order of hparent
 function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurEmptyLead; reverse = false, transform = missing, kw...)
-    contactslice = lattice(hparent)[; kw...]
+    contactslice = lattice(hparent)[kw...]
     check_contact_slice(contactslice)  # in case it is empty
     lsparent = sites_to_orbs(contactslice, hparent)
     schursolver = solver(glead)
@@ -187,7 +187,7 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead,
     end
 
     # combine gunit and parent sites into lat0
-    contactslice = lattice(hparent)[; kw...]
+    contactslice = lattice(hparent)[kw...]
     check_contact_slice(contactslice)  # in case it is empty
     lsparent = sites_to_orbs(contactslice, hparent)
     isempty(lsparent) && argerror("No sites selected in the parent lattice")
@@ -263,7 +263,7 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead;
     xunit = boundary + ifelse(reverse, -1, 1)
     gslice = glead[cells = SA[xunit]]
     # lattice slices for parent and lead unit cell
-    contactslice = lattice(hparent)[; sites...]
+    contactslice = lattice(hparent)[sites...]
     check_contact_slice(contactslice)  # in case it is empty
     lsparent = sites_to_orbs(contactslice, hparent)
     # The above is currently broken when unitcell surface does not match full unit cell. Perhaps use some version of this:


### PR DESCRIPTION
This adds `transform` to `attach(::GreenSlice, ::AbstractModel; transform = ..., sites = ...)`

We also check against empty contact selections, which formerly threw an obscure error. Now the error is more explicit.

I messed up the commits here, I'll try to resolve the conflict next