### PR TITLE
Add `transform` keyword to generic `attach` method (second try)

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1377,12 +1377,12 @@ function `g(ω) = (ω - h´ - Σ(ω))⁻¹` of the resulting `h´`, see `greenfu
 The different forms of `args` yield different types of self-energies `Σ`. Currently
 supported forms are:
 
-    attach(h, gs::GreenSlice, coupling::AbstractModel; sites...)
+    attach(h, gs::GreenSlice, coupling::AbstractModel; transform = missing, sites...)
 
 Adds a generic self-energy `Σ(ω) = V´⋅gs(ω)⋅V` on `h`'s `sites`, where `V` and `V´` are
-couplings, given by `coupling`, between said `sites` and the `LatticeSlice` in `gs`. Allowed
-forms of `gs` include both `g[bath_sites...]` and `g[contactind::Integer]` where `g` is any
-`GreenFunction`.
+couplings (given by `coupling`) between said `sites` and the `LatticeSlice` in `gs` (after
+applying `transform` to the latter). Allowed forms of `gs` include both `g[bath_sites...]`
+and `g[contactind::Integer]` where `g` is any `GreenFunction`.
 
     attach(h, model::ParametricModel; sites...)
 

--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -39,7 +39,10 @@ function SelfEnergy(hparent::AbstractHamiltonian, gslice::GreenSlice, model::Abs
         argerror("To attach a Greenfunction with `attach(h, g[cols, rows], coupling; ...)`, we must have `cols == rows`")
     lsbath = orbrows(gslice)
     lat0bath = lattice0D(lsbath)
-    lsparent = sites_to_orbs(getindex(lattice(hparent); sites...), hparent)
+    transform === missing || transform!(lat0bath, transform)
+    contactslice = getindex(lattice(hparent); sites...)
+    check_contact_slice(contactslice)  # in case it is empty
+    lsparent = sites_to_orbs(contactslice, hparent)
     lat0parent = lattice0D(lsparent)
     lat0 = combine(lat0parent, lat0bath)
     nparent, ntotal = nsites(lat0parent), nsites(lat0)

--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -34,15 +34,13 @@ end
 
 #region ## API ##
 
-function SelfEnergy(hparent::AbstractHamiltonian, gslice::GreenSlice, model::AbstractModel; sites...)
+function SelfEnergy(hparent::AbstractHamiltonian, gslice::GreenSlice, model::AbstractModel; transform = missing, sites...)
     rows(gslice) === cols(gslice) ||
         argerror("To attach a Greenfunction with `attach(h, g[cols, rows], coupling; ...)`, we must have `cols == rows`")
     lsbath = orbrows(gslice)
     lat0bath = lattice0D(lsbath)
     transform === missing || transform!(lat0bath, transform)
-    contactslice = getindex(lattice(hparent); sites...)
-    check_contact_slice(contactslice)  # in case it is empty
-    lsparent = sites_to_orbs(contactslice, hparent)
+    lsparent = contact_orbslice(hparent; sites...)
     lat0parent = lattice0D(lsparent)
     lat0 = combine(lat0parent, lat0bath)
     nparent, ntotal = nsites(lat0parent), nsites(lat0)

--- a/src/solvers/selfenergy/model.jl
+++ b/src/solvers/selfenergy/model.jl
@@ -11,12 +11,12 @@ end
 
 #region ## Constructor ##
 
-function SelfEnergyModelSolver(h::AbstractHamiltonian, model::AbstractModel, siteslice::SiteSlice, orbslice::OrbitalSliceGrouped)
+function SelfEnergyModelSolver(h::AbstractHamiltonian, model::AbstractModel, orbslice::OrbitalSliceGrouped)
     modelω = model_ω_to_param(model)  # see models.jl - transforms ω into a ω_internal param
     siteinds = Int[]
-    # this converts siteslice to a 0D Lattice lat0
-    # and fills siteinds::Vector{Int} with the siteslice index for each lat0 site (i.e. for sites ordered by sublattices)
-    lat0 = lattice0D(siteslice, siteinds)
+    # this converts orbslice to a 0D Lattice lat0
+    # and fills siteinds::Vector{Int} with the site index for each lat0 site (i.e. for sites ordered by sublattices)
+    lat0 = lattice0D(orbslice, siteinds)
     # this is a 0D ParametricHamiltonian to build the Σ(ω) as a view over flat(ph(; ...))
     ph = hamiltonian(lat0, modelω; orbitals = norbitals(h)) # WARNING: type-unstable orbs
     # translation from orbitals in lat0 to orbslice indices
@@ -30,10 +30,8 @@ end
 #region ## API ##
 
 function SelfEnergy(h::AbstractHamiltonian, model::AbstractModel; kw...)
-    contactslice = getindex(lattice(h); kw...)
-    check_contact_slice(contactslice)  # in case it is empty
-    orbslice = sites_to_orbs(contactslice, h)
-    solver = SelfEnergyModelSolver(h, model, siteslice, orbslice)
+    orbslice = contact_orbslice(h; kw...)
+    solver = SelfEnergyModelSolver(h, model, orbslice)
     return SelfEnergy(solver, orbslice)
 end
 

--- a/src/solvers/selfenergy/model.jl
+++ b/src/solvers/selfenergy/model.jl
@@ -30,9 +30,9 @@ end
 #region ## API ##
 
 function SelfEnergy(h::AbstractHamiltonian, model::AbstractModel; kw...)
-    sel = siteselector(; kw...)
-    siteslice = lattice(h)[sel]
-    orbslice = sites_to_orbs(siteslice, h)
+    contactslice = getindex(lattice(h); kw...)
+    check_contact_slice(contactslice)  # in case it is empty
+    orbslice = sites_to_orbs(contactslice, h)
     solver = SelfEnergyModelSolver(h, model, siteslice, orbslice)
     return SelfEnergy(solver, orbslice)
 end

--- a/src/solvers/selfenergy/nothing.jl
+++ b/src/solvers/selfenergy/nothing.jl
@@ -8,8 +8,9 @@ struct SelfEnergyEmptySolver{C} <: RegularSelfEnergySolver
 end
 
 function SelfEnergy(h::AbstractHamiltonian{T}, ::Nothing; kw...) where {T}
-    sel = siteselector(; kw...)
-    orbslice = sites_to_orbs(lattice(h)[sel], h)
+    contactslice = getindex(lattice(h); kw...)
+    check_contact_slice(contactslice)  # in case it is empty
+    orbslice = sites_to_orbs(contactslice, h)
     norbs = norbitals(orbslice)
     emptyΣ = spzeros(Complex{T}, norbs, norbs)
     solver = SelfEnergyEmptySolver(emptyΣ)

--- a/src/solvers/selfenergy/nothing.jl
+++ b/src/solvers/selfenergy/nothing.jl
@@ -8,9 +8,7 @@ struct SelfEnergyEmptySolver{C} <: RegularSelfEnergySolver
 end
 
 function SelfEnergy(h::AbstractHamiltonian{T}, ::Nothing; kw...) where {T}
-    contactslice = getindex(lattice(h); kw...)
-    check_contact_slice(contactslice)  # in case it is empty
-    orbslice = sites_to_orbs(contactslice, h)
+    orbslice = contact_orbslice(h; kw...)
     norbs = norbitals(orbslice)
     emptyΣ = spzeros(Complex{T}, norbs, norbs)
     solver = SelfEnergyEmptySolver(emptyΣ)

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -41,8 +41,9 @@ end
 # and if so, builds the extended Self Energy directly, using the same intercell coupling of
 # the lead, but using the correct site order of hparent
 function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurEmptyLead; reverse = false, transform = missing, kw...)
-    sel = siteselector(; kw...)
-    lsparent = sites_to_orbs(lattice(hparent)[sel], hparent)
+    contactslice = getindex(lattice(hparent); kw...)
+    check_contact_slice(contactslice)  # in case it is empty
+    lsparent = sites_to_orbs(contactslice, hparent)
     schursolver = solver(glead)
     fsolver = schurfactorsolver(schursolver)
     boundary = schursolver.boundary
@@ -186,8 +187,9 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead,
     end
 
     # combine gunit and parent sites into lat0
-    sel = siteselector(; kw...)
-    lsparent = sites_to_orbs(lattice(hparent)[sel], hparent)
+    contactslice = getindex(lattice(hparent); kw...)
+    check_contact_slice(contactslice)  # in case it is empty
+    lsparent = sites_to_orbs(contactslice, hparent)
     isempty(lsparent) && argerror("No sites selected in the parent lattice")
     lat0parent = lattice0D(lsparent)
     lat0 = combine(lat0parent, lat0lead)
@@ -261,7 +263,9 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead;
     xunit = boundary + ifelse(reverse, -1, 1)
     gslice = glead[cells = SA[xunit]]
     # lattice slices for parent and lead unit cell
-    lsparent = sites_to_orbs(getindex(lattice(hparent); sites...), hparent)
+    contactslice = getindex(lattice(hparent); kw...)
+    check_contact_slice(contactslice)  # in case it is empty
+    lsparent = sites_to_orbs(contactslice, hparent)
     # The above is currently broken when unitcell surface does not match full unit cell. Perhaps use some version of this:
     # Compute lslead as lead unicell surface:
     #   gL and gR are unitcell GreenFunctions with ΣL and ΣR, but same ordering as gslice

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -41,9 +41,7 @@ end
 # and if so, builds the extended Self Energy directly, using the same intercell coupling of
 # the lead, but using the correct site order of hparent
 function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurEmptyLead; reverse = false, transform = missing, kw...)
-    contactslice = getindex(lattice(hparent); kw...)
-    check_contact_slice(contactslice)  # in case it is empty
-    lsparent = sites_to_orbs(contactslice, hparent)
+    lsparent = contact_orbslice(hparent; kw...)
     schursolver = solver(glead)
     fsolver = schurfactorsolver(schursolver)
     boundary = schursolver.boundary
@@ -187,9 +185,7 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead,
     end
 
     # combine gunit and parent sites into lat0
-    contactslice = getindex(lattice(hparent); kw...)
-    check_contact_slice(contactslice)  # in case it is empty
-    lsparent = sites_to_orbs(contactslice, hparent)
+    lsparent = contact_orbslice(hparent; kw...)
     isempty(lsparent) && argerror("No sites selected in the parent lattice")
     lat0parent = lattice0D(lsparent)
     lat0 = combine(lat0parent, lat0lead)
@@ -263,9 +259,7 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead;
     xunit = boundary + ifelse(reverse, -1, 1)
     gslice = glead[cells = SA[xunit]]
     # lattice slices for parent and lead unit cell
-    contactslice = getindex(lattice(hparent); kw...)
-    check_contact_slice(contactslice)  # in case it is empty
-    lsparent = sites_to_orbs(contactslice, hparent)
+    lsparent = contact_orbslice(hparent; sites...)
     # The above is currently broken when unitcell surface does not match full unit cell. Perhaps use some version of this:
     # Compute lslead as lead unicell surface:
     #   gL and gR are unitcell GreenFunctions with ΣL and ΣR, but same ordering as gslice

--- a/src/types.jl
+++ b/src/types.jl
@@ -1951,6 +1951,10 @@ has_selfenergy(c::Contacts) = any(has_selfenergy, selfenergies(c))
 check_contact_index(i, c) = 1 <= i <= ncontacts(c) ||
     argerror("Cannot get contact $i, there are $(ncontacts(c)) contacts")
 
+# for checks in contact construction
+check_contact_slice(s::LatticeSlice) =
+    isempty(s) && argerror("No contact sites found in selection")
+
 contactorbitals(c::Contacts) = c.orbitals
 
 orbslice(c::Contacts) = c.orbslice

--- a/src/types.jl
+++ b/src/types.jl
@@ -1957,6 +1957,13 @@ check_contact_slice(s::LatticeSlice) =
 
 contactorbitals(c::Contacts) = c.orbitals
 
+function contact_orbslice(h; sites...)
+    contactslice = getindex(lattice(h); sites...)
+    check_contact_slice(contactslice)  # in case it is empty
+    lsparent = sites_to_orbs(contactslice, h)
+    return lsparent
+end
+
 orbslice(c::Contacts) = c.orbslice
 orbslice(c::Contacts, ::Colon) = c.orbslice
 orbslice(c::Contacts, i::Integer) = orbslice(selfenergies(c, i))

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -94,6 +94,14 @@ end
     glead = LP.honeycomb() |> hopping(1) |> supercell((1,-1), region = r -> 0<=r[2]<=5) |> attach(nothing, cells = SA[5]) |> greenfunction(GS.Schur(boundary = 0));
     g = LP.honeycomb() |> hopping(1) |> supercell(region = r -> -6<=r[1]<=6 && 0<=r[2]<=5) |> attach(glead, region = r -> r[1] > 5.1) |> greenfunction
     @test g isa GreenFunction
+
+    # attach(gslice, model; transform)
+    Rot = r -> SA[0 -1; 1 0] * r
+    glead = LP.square(a0 = 1, dim = 2) |> onsite(4) - hopping(1) |> supercell((1,0), region = r -> -1 <= r[2] <= 1) |> greenfunction(GS.Schur(boundary = 0));
+    central = LP.honeycomb() |> onsite(4) - hopping(1) |> supercell(region = RP.rectangle((3,3))) |> transform(Rot)
+    g = central |> attach(glead[cells = 1], -hopping(1), region = r -> r[1] > 1.3 && -1.1 <= r[2] <= 1.1, transform = r -> r + SA[1.2,0]) |> greenfunction
+    @test g isa GreenFunction
+    @test_throws ArgumentError central |> attach(glead[cells = 1], -hopping(1), region = r -> r[1] > 2.3 && -1.1 <= r[2] <= 1.1, transform = r -> r + SA[1.2,0])
 end
 
 @testset "GreenSolvers applicability" begin


### PR DESCRIPTION
This adds `transform` to `attach(::GreenSlice, ::AbstractModel; transform = ..., sites = ...)`

We also check against empty contact selections, which formerly threw an obscure error. Now the error is more explicit.