### PR TITLE
Correct dealiasing in `minimal_callsafe_copy`

### DIFF
--- a/docs/src/tutorial/bandstructures.md
+++ b/docs/src/tutorial/bandstructures.md
@@ -18,7 +18,7 @@ States:
 The above destructuring syntax assigns eigenvalues and eigenvectors to `eᵢ` and `ψᵢ`, respectively. The available eigensolvers and their options can be checked in the `EigenSolvers` docstrings.
 
 !!! warning "Arpack solver is not thread-safe"
-    `EigenSolver.Arpack` relies on a Fortran library that is not currently thread-safe. If you launch Julia with multiple threads, they will not be used with this specific solver. Otherwise Arpack would segfault.
+    `EigenSolvers.Arpack` relies on a Fortran library that is not currently thread-safe. If you launch Julia with multiple threads, they will not be used with this specific solver. Otherwise Arpack would segfault.
 
 We define a "bandstructure" of an `h::AbstractHamiltonian` as a linear interpolation of its eigenpairs over a portion of the Brillouin zone, which is discretized with a base mesh of `ϕᵢ` values. At each `ϕᵢ` of the base mesh, the Bloch matrix `h(ϕᵢ)` is diagonalized with `spectrum`. The adjacent eigenpairs `eⱼ(ϕᵢ), ψⱼ(ϕᵢ)` are then connected ("stitched") together into a number of band meshes with vertices `(ϕᵢ..., eⱼ(ϕᵢ))` by maximizing the overlap of adjacent `ψⱼ(ϕᵢ)` (since the bands should be continuuous). Degenerate eigenpairs are collected into a single node of the band mesh.
 

--- a/docs/src/tutorial/glossary.md
+++ b/docs/src/tutorial/glossary.md
@@ -22,11 +22,11 @@ This is a summary of the type of objects you will be studying.
   - `ParametricHamiltonian`: like the above, but using a `ParametricModel`, which makes it dependent on a set of free parameters that can be efficiently adjusted.
 
   An `h::AbstractHamiltonian` can be used to produce a Bloch matrix `h(ϕ; params...)` of the same size as the number of orbitals per unit cell, where `ϕ = [ϕᵢ...]` are Bloch phases and `params` are values for the free parameters, if any.
-- **`Spectrum`**: the set of eigenpairs (eigenvalues and corresponding eigenvectors) of a Bloch matrix. It can be computed with a number of `EigenSolver`s.
+- **`Spectrum`**: the set of eigenpairs (eigenvalues and corresponding eigenvectors) of a Bloch matrix. It can be computed with a number of `EigenSolvers`.
 - **`Bandstructure`**: a collection of spectra, evaluated over a discrete mesh (typically a discretization of the Brillouin zone), that is connected to its mesh neighbors into a linearly-interpolated approximation of the `AbstractHamiltonian`'s bandstructure.
 - **`SelfEnergy`**: an operator `Σ(ω)` defined to act on a `LatticeSlice` of an `AbstractHamiltonian` that depends on energy `ω`.
 - **`OpenHamiltonian`**: an `AbstractHamiltonian` combined with a set of `SelfEnergies`
-- **`GreenFunction`**: an `OpenHamiltonian` combined with a `GreenSolver`, which is an algorithm that can in general compute the retarded or advanced Green function at any energy between any subset of sites of the underlying lattice.
+- **`GreenFunction`**: an `OpenHamiltonian` combined with an `AbstractGreenSolver`, which is an algorithm that can in general compute the retarded or advanced Green function at any energy between any subset of sites of the underlying lattice.
   - **`GreenSlice`**: a `GreenFunction` evaluated on a specific set of sites, but at an unspecified energy
   - **`GreenSolution`**: a `GreenFunction` evaluated at a specific energy, but on an unspecified set of sites
 - **`OrbitalSliceArray`**: an `AbstractArray` that can be indexed with a `SiteSelector`, in addition to the usual scalar indexing. Particular cases are `OrbitalSliceMatrix` and `OrbitalSliceVector`. This is the most common type obtained from `GreenFunction`s and observables obtained from them.

--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -9,7 +9,7 @@ where `i, j` are orbitals, `H` is the (possibly infinite) Hamiltonian matrix, an
 We split the problem of computing `Gʳᵢⱼ(ω)` of a given `h::AbstractHamiltonian` into four steps:
 
 1. Attach self-energies to `h` using the command `oh = attach(h, args...)`. This produces a new object `oh::OpenHamiltonian` with a number of `Contacts`, numbered `1` to `N`
-2. Use `g = greenfunction(oh, solver)` to build a `g::GreenFunction` representing `Gʳ` (at arbitrary `ω` and `i,j`), where `oh::OpenHamiltonian` and `solver::GreenSolver` (see `GreenSolvers` below for available solvers)
+2. Use `g = greenfunction(oh, solver)` to build a `g::GreenFunction` representing `Gʳ` (at arbitrary `ω` and `i,j`), where `oh::OpenHamiltonian` and `solver::AbstractGreenSolver` (see `GreenSolvers` below for available solvers)
 3. Evaluate `gω = g(ω; params...)` at fixed energy `ω` and model parameters, which produces a `gω::GreenSolution`
 4. Slice `gω[sᵢ, sⱼ]` or `gω[sᵢ] == gω[sᵢ, sᵢ]` to obtain `Gʳᵢⱼ(ω)` as a flat matrix, where `sᵢ, sⱼ` are either site selectors over sites spanning orbitals `i,j`, integers denoting contacts, `1` to `N`, or `:` denoting all contacts merged together.
 
@@ -48,7 +48,7 @@ julia> gω[cells = 1:2]  # we now ask for the Green function between orbitals in
   -0.2+0.846606im   -0.48-0.113394im    0.44+0.282715im  0.104-0.869285im
 ```
 
-Note that the result is a 4 x 4 matrix, because there are 2 orbitals (one per site) in each of the two unit cells. Note also that the Schur GreenSolver used here allows us to compute the Green function between distant cells with little overhead
+Note that the result is a 4 x 4 matrix, because there are 2 orbitals (one per site) in each of the two unit cells. Note also that the `GreenSolvers.Schur` used here allows us to compute the Green function between distant cells with little overhead
 ```julia
 julia> @time gω[cells = 1:2];
   0.000067 seconds (70 allocations: 6.844 KiB)
@@ -59,7 +59,7 @@ julia> @time gω[cells = (SA[10], SA[100000])];
 
 ## GreenSolvers
 
-The currently implemented `GreenSolver`s (abbreviated as `GS`) are the following
+The currently implemented `GreenSolvers` (abbreviated as `GS`) are the following
 
 - `GS.SparseLU()`
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1490,7 +1490,7 @@ Simple selector of sites with given `site_indices` in a given cell at `cell_inde
 cellsites
 
 """
-    greenfunction(h::Union{AbstractHamiltonian,OpenHamiltonian}, solver::GreenSolver)
+    greenfunction(h::Union{AbstractHamiltonian,OpenHamiltonian}, solver::AbstractGreenSolver)
 
 Build a `g::GreenFunction` of Hamiltonian `h` using `solver`. See `GreenSolvers` for
 available solvers. If `solver` is not provided, a default solver is chosen automatically

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -139,7 +139,7 @@ Base.getindex(s::GreenSlicer, ::CellOrbitals, ::CellOrbitals) =
 
 # fallback, for GreenSlicers that don't implement view
 Base.view(g::GreenSlicer, args...) =
-    argerror("GreenSlicer of type $(nameof(typeof(g))) doesn't implement view")
+    argerror("GreenSlicer of type $(nameof(typeof(g))) doesn't implement view for these arguments")
 
 # must ensure that orbindices is not a scalar, to consistently obtain a Matrix
 sanitize_cellorbs(c::CellOrbitals) = c

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -469,15 +469,16 @@ end
 ensure_mutable_matrix(m::SMatrix) = Matrix(m)
 ensure_mutable_matrix(m::AbstractMatrix) = m
 
-minimal_callsafe_copy(s::TMatrixSlicer, parentham) = TMatrixSlicer(
-    minimal_callsafe_copy(s.g0slicer, parentham), s.tmatrix, s.gcontacts, s.contactorbs)
+minimal_callsafe_copy(s::TMatrixSlicer, parentham, parentcontacts) = TMatrixSlicer(
+    minimal_callsafe_copy(s.g0slicer, parentham, parentcontacts),
+    s.tmatrix, s.gcontacts, s.contactorbs)
 
 Base.view(::NothingSlicer, i::Union{Integer,Colon}...) =
     internalerror("view(::NothingSlicer): unreachable reached")
 
 Base.getindex(::NothingSlicer, i::CellOrbitals...) = argerror("Slicer does not support generic indexing")
 
-minimal_callsafe_copy(s::NothingSlicer) = s
+minimal_callsafe_copy(s::NothingSlicer, parentham, parentcontacts) = s
 
 #endregion
 #endregion

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -40,7 +40,7 @@ function call!(g::GreenFunction{T}, ω::T; params...) where {T}
 end
 
 function call!(g::GreenFunction{T}, ω::Complex{T}; params...) where {T}
-    h = parent(g)
+    h = parent(g)   # not hamiltonian(h). We want the ParametricHamiltonian if it exists.
     contacts´ = contacts(g)
     call!(h; params...)
     Σblocks = call!(contacts´, ω; params...)
@@ -469,8 +469,8 @@ end
 ensure_mutable_matrix(m::SMatrix) = Matrix(m)
 ensure_mutable_matrix(m::AbstractMatrix) = m
 
-minimal_callsafe_copy(s::TMatrixSlicer) = TMatrixSlicer(minimal_callsafe_copy(s.g0slicer),
-    s.tmatrix, s.gcontacts, s.contactorbs)
+minimal_callsafe_copy(s::TMatrixSlicer, parentham) = TMatrixSlicer(
+    minimal_callsafe_copy(s.g0slicer, parentham), s.tmatrix, s.gcontacts, s.contactorbs)
 
 Base.view(::NothingSlicer, i::Union{Integer,Colon}...) =
     internalerror("view(::NothingSlicer): unreachable reached")

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -417,10 +417,8 @@ Base.getindex(h::AbstractHamiltonian, dn::HybridInds{<:Union{Integer,Tuple}}) =
 Base.getindex(h::AbstractHamiltonian{<:Any,<:Any,L}, ::HybridInds{Tuple{}}) where {L} =
     h[hybrid(zero(SVector{L,Int}))]
 
-function Base.getindex(h::ParametricHamiltonian{<:Any,<:Any,L}, dn::HybridInds{SVector{L,Int}}; params...) where {L}
-    h´ = call!(h; params...)
-    return getindex(h´, dn)
-end
+Base.getindex(h::ParametricHamiltonian{<:Any,<:Any,L}, dn::HybridInds{SVector{L,Int}}) where {L} =
+    getindex(hamiltonian(h), dn)
 
 function Base.getindex(h::Hamiltonian{<:Any,<:Any,L}, dn::HybridInds{SVector{L,Int}}) where {L}
     for har in harmonics(h)

--- a/src/solvers/green.jl
+++ b/src/solvers/green.jl
@@ -4,7 +4,7 @@
 #     - apply(solver, h::AbstractHamiltonian, c::Contacts) -> AppliedGreenSolver
 #   All new s::AppliedGreenSolver must implement (with Σblock a [possibly nested] tuple of MatrixBlock's)
 #      - s(ω, Σblocks, ::ContactOrbitals) -> GreenSlicer
-#      - minimal_callsafe_copy(s)
+#      - minimal_callsafe_copy(s, parentham)  # injects any aliases from parentham
 #      - optional: needs_omega_shift(s) (has a `true` default fallback)
 #   A gs::GreenSlicer's allows to compute G[gi, gi´]::AbstractMatrix for indices gi
 #   To do this, it must implement contact slicing (unless it relies on TMatrixSlicer)
@@ -12,7 +12,7 @@
 #      - view(gs, ::Colon, ::Colon) -> g(ω; kw...) between all contacts (has error fallback)
 #   It must also implement generic slicing, and minimal copying
 #      - gs[i::CellOrbitals, j::CellOrbitals] -> must return a Matrix for type stability
-#      - minimal_callsafe_copy(gs)
+#      - minimal_callsafe_copy(gs, parentham)
 #   The user-facing indexing API accepts:
 #      - i::Integer -> Sites of Contact number i
 #      - cellsites(cell::Tuple, sind::Int)::Subcell -> Single site in a cell

--- a/src/solvers/green.jl
+++ b/src/solvers/green.jl
@@ -4,7 +4,7 @@
 #     - apply(solver, h::AbstractHamiltonian, c::Contacts) -> AppliedGreenSolver
 #   All new s::AppliedGreenSolver must implement (with Σblock a [possibly nested] tuple of MatrixBlock's)
 #      - s(ω, Σblocks, ::ContactOrbitals) -> GreenSlicer
-#      - minimal_callsafe_copy(s, parentham)  # injects any aliases from parentham
+#      - minimal_callsafe_copy(s, parentham, parentcontacts)  # injects aliases from parent
 #      - optional: needs_omega_shift(s) (has a `true` default fallback)
 #   A gs::GreenSlicer's allows to compute G[gi, gi´]::AbstractMatrix for indices gi
 #   To do this, it must implement contact slicing (unless it relies on TMatrixSlicer)
@@ -12,7 +12,7 @@
 #      - view(gs, ::Colon, ::Colon) -> g(ω; kw...) between all contacts (has error fallback)
 #   It must also implement generic slicing, and minimal copying
 #      - gs[i::CellOrbitals, j::CellOrbitals] -> must return a Matrix for type stability
-#      - minimal_callsafe_copy(gs, parentham)
+#      - minimal_callsafe_copy(gs, parentham, parentcontacts)
 #   The user-facing indexing API accepts:
 #      - i::Integer -> Sites of Contact number i
 #      - cellsites(cell::Tuple, sind::Int)::Subcell -> Single site in a cell
@@ -22,6 +22,7 @@
 #      - sel::SiteSelector ~ NamedTuple -> forms a LatticeSlice
 #   Optional: to properly plot boundaries, an ::AbstractGreenSolver may also implement
 #      - boundaries(s::AbstractGreenSolver) -> collection of (dir => cell)::Pair{Int,Int}
+#   Aliasing: Green solvers may only alias fields from the parent Hamiltonian and Contacts
 ############################################################################################
 
 module GreenSolvers

--- a/src/solvers/green/bands.jl
+++ b/src/solvers/green/bands.jl
@@ -652,7 +652,8 @@ end
 
 #region ## API ##
 
-minimal_callsafe_copy(s::AppliedBandsGreenSolver) = s   # solver is read-only
+# Parent hamiltonian needs to be non-parametric, so no need to alias
+minimal_callsafe_copy(s::AppliedBandsGreenSolver, parentham) = s
 
 needs_omega_shift(s::AppliedBandsGreenSolver) = false
 

--- a/src/solvers/green/bands.jl
+++ b/src/solvers/green/bands.jl
@@ -653,7 +653,7 @@ end
 #region ## API ##
 
 # Parent hamiltonian needs to be non-parametric, so no need to alias
-minimal_callsafe_copy(s::AppliedBandsGreenSolver, parentham) = s
+minimal_callsafe_copy(s::AppliedBandsGreenSolver, parentham, parentcontacts) = s
 
 needs_omega_shift(s::AppliedBandsGreenSolver) = false
 
@@ -667,7 +667,7 @@ boundaries(s::AppliedBandsGreenSolver) = (s.boundaryorbs.boundary,)
 #region ## apply ##
 
 function apply(s::GS.Bands,  h::AbstractHamiltonian{T,<:Any,L}, cs::Contacts) where {T,L}
-    L == 0 && argerror("Cannot use GreenSolver.Bands with 0D AbstractHamiltonians")
+    L == 0 && argerror("Cannot use GreenSolvers.Bands with 0D AbstractHamiltonians")
     ticks = s.bandsargs
     kw = s.bandskw
     b = bands(h, ticks...; kw..., projectors = true, split = false)
@@ -889,7 +889,7 @@ view_or_copy(ψ, rows::Union{Colon,AbstractRange}, cols::Union{Colon,AbstractRan
     view(ψ, rows, cols)
 view_or_copy(ψ, rows, cols) = ψ[rows, cols]
 
-minimal_callsafe_copy(s::BandsGreenSlicer) = s  # it is read-only
+minimal_callsafe_copy(s::BandsGreenSlicer, parentham, parentcontacts) = s  # it is read-only
 
 #endregion
 

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -141,7 +141,7 @@ end
 moments(s::AppliedKPMGreenSolver) = s.moments
 
 # Parent ham needs to be non-parametric, so no need to alias
-minimal_callsafe_copy(s::AppliedKPMGreenSolver, parentham) = s
+minimal_callsafe_copy(s::AppliedKPMGreenSolver, parentham, parentcontacts) = s
 
 needs_omega_shift(s::AppliedKPMGreenSolver) = false
 

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -140,7 +140,8 @@ end
 
 moments(s::AppliedKPMGreenSolver) = s.moments
 
-minimal_callsafe_copy(s::AppliedKPMGreenSolver) = AppliedKPMGreenSolver(copy(s.momenta), s.bandCH)
+# Parent ham needs to be non-parametric, so no need to alias
+minimal_callsafe_copy(s::AppliedKPMGreenSolver, parentham) = s
 
 needs_omega_shift(s::AppliedKPMGreenSolver) = false
 

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -393,6 +393,9 @@ function minimal_callsafe_copy(s::AppliedSchurGreenSolver, parentham)
     fsolver´ = minimal_callsafe_copy(s.fsolver, parentham)
     ohL´, ohR´, oh∞´, G, G∞ = schur_openhams_types(fsolver´, parentham, s.boundary)
     s´ = AppliedSchurGreenSolver{G,G∞}(fsolver´, s.boundary, ohL´, ohR´, oh∞´)
+    isdefined(s, :gR) && (s´.gR = minimal_callsafe_copy(s.gR, parentham))
+    isdefined(s, :gL) && (s´.gL = minimal_callsafe_copy(s.gL, parentham))
+    isdefined(s, :g∞) && (s´.g∞ = minimal_callsafe_copy(s.g∞, parentham))
     return s´
 end
 

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -25,9 +25,9 @@ end
 
 struct SchurFactorsSolver{T,B}
     shift::T                                          # called Ω in the scattering.pdf notes
-    hm::HybridSparseMatrix{T,B}
-    h0::HybridSparseMatrix{T,B}
-    hp::HybridSparseMatrix{T,B}
+    hm::HybridSparseMatrix{T,B}                       # aliases parent hamiltonian
+    h0::HybridSparseMatrix{T,B}                       # aliases parent hamiltonian
+    hp::HybridSparseMatrix{T,B}                       # aliases parent hamiltonian
     l_leq_r::Bool                                     # whether l <= r (left and right surface dims)
     iG::SparseMatrixCSC{Complex{T},Int}               # to store iG = ω - h0 - Σₐᵤₓ
     ptrs::Tuple{Vector{Int},Vector{Int},Vector{Int}}  # iG ptrs for h0 nzvals, diagonal and Σₐᵤₓ surface
@@ -82,7 +82,6 @@ function nearest_cell_harmonics(h)
     end
     is_nearest ||
         argerror("Too many or too few harmonics. Perhaps try `supercell` to ensure strictly nearest-cell harmonics.")
-
     hm, h0, hp = h[hybrid(-1)], h[hybrid(0)], h[hybrid(1)]
     flat(hm) == flat(hp)' ||
         argerror("The Hamiltonian should have h[1] == h[-1]' to use the Schur solver")
@@ -208,10 +207,13 @@ end
 checkmodes(whichmodes) = sum(whichmodes) == length(whichmodes) ÷ 2 ||
     argerror("Cannot differentiate retarded from advanced modes. Consider increasing imag(ω) or check that your Hamiltonian is Hermitian")
 
-minimal_callsafe_copy(s::SchurFactorsSolver) =
-    SchurFactorsSolver(s.shift, copy(s.hm), copy(s.h0), copy(s.hp), s.l_leq_r, copy(s.iG),
-    s.ptrs, s.linds, s.rinds, s.sinds, copy(s.L), copy(s.R), copy(s.R´L´),
-    minimal_callsafe_copy(s.tmp))
+function minimal_callsafe_copy(s::SchurFactorsSolver, parentham)
+    hm´, h0´, hp´ = nearest_cell_harmonics(parentham)
+    s´ = SchurFactorsSolver(s.shift, hm´, h0´, hp´, s.l_leq_r, copy(s.iG),
+        s.ptrs, s.linds, s.rinds, s.sinds, copy(s.L), copy(s.R), copy(s.R´L´),
+        minimal_callsafe_copy(s.tmp))
+    return s´
+end
 
 minimal_callsafe_copy(s::SchurWorkspace) =
     SchurWorkspace(copy.((s.GL, s.GR, s.LG, s.RG, s.A, s.B, s.Z11, s.Z21, s.Z11´, s.Z21´,
@@ -290,13 +292,13 @@ end
 # AppliedSchurGreenSolver
 #region
 
-# We delay initialization of some fields until they are first needed (which may be never)
+# Mutable: we delay initialization of some fields until they are first needed (which may be never)
 mutable struct AppliedSchurGreenSolver{T,B,O,O∞,G,G∞} <: AppliedGreenSolver
     fsolver::SchurFactorsSolver{T,B}
     boundary::T
-    ohL::O                  # OpenHamiltonian for unitcell with ΣL
-    ohR::O                  # OpenHamiltonian for unitcell with ΣR
-    oh∞::O∞                 # OpenHamiltonian for unitcell with ΣL + ΣR
+    ohL::O                  # OpenHamiltonian for unitcell with ΣL      (aliases parent h)
+    ohR::O                  # OpenHamiltonian for unitcell with ΣR      (aliases parent h)
+    oh∞::O∞                 # OpenHamiltonian for unitcell with ΣL + ΣR (aliases parent h)
     gL::G                   # Lazy field: GreenFunction for ohL
     gR::G                   # Lazy field: GreenFunction for ohR
     g∞::G∞                  # Lazy field: GreenFunction for oh∞
@@ -327,8 +329,8 @@ boundaries(s::AppliedSchurGreenSolver) = (1 => s.boundary,)
 function Base.getproperty(s::AppliedSchurGreenSolver, f::Symbol)
     if !isdefined(s, f)
         if f == :gL
-            s.gL = greenfunction(s.ohL, GS.SparseLU())
-        elseif f == :gR
+            s.gL = greenfunction(s.ohL, GS.SparseLU())  # oh's harmonics alias parent h, but
+        elseif f == :gR                                 # not used here until called with ω
             s.gR = greenfunction(s.ohR, GS.SparseLU())
         elseif f == :g∞
             s.g∞ = greenfunction(s.oh∞, GS.SparseLU())
@@ -346,8 +348,14 @@ end
 function apply(s::GS.Schur, h::AbstractHamiltonian1D{T}, contacts::Contacts) where {T}
     h´ = hamiltonian(h)
     fsolver = SchurFactorsSolver(h´, s.shift)
-    h0 = unitcell_hamiltonian(h)
     boundary = T(round(only(s.boundary)))
+    ohL, ohR, oh∞, G, G∞ = schur_openhams_types(fsolver, h, boundary)
+    solver = AppliedSchurGreenSolver{G,G∞}(fsolver, boundary, ohL, ohR, oh∞)
+    return solver
+end
+
+function schur_openhams_types(fsolver, h, boundary)
+    h0 = unitcell_hamiltonian(h)   # h0 is non-parametric, but will alias h.h first harmonic
     rsites = stored_cols(hamiltonian(h)[unflat(1)])
     lsites = stored_cols(hamiltonian(h)[unflat(-1)])
     orbslice_l = sites_to_orbs(lattice(h0)[cellsites((), lsites)], h)
@@ -356,20 +364,21 @@ function apply(s::GS.Schur, h::AbstractHamiltonian1D{T}, contacts::Contacts) whe
     ΣL_solver = SelfEnergySchurSolver(fsolver, h, :L, boundary)
     ΣL = SelfEnergy(ΣL_solver, orbslice_l)
     ΣR = SelfEnergy(ΣR_solver, orbslice_r)
-
+    # ohL, ohR, oh∞ have no parameters, but will be updated by call!(h; params...)
     ohL = attach(h0, ΣL)
     ohR = attach(h0, ΣR)
     oh∞ = ohR |> attach(ΣL)
     G, G∞ = green_type(h0, ΣL), green_type(h0, ΣL, ΣR)
-    solver = AppliedSchurGreenSolver{G,G∞}(fsolver, boundary, ohL, ohR, oh∞)
-    return solver
+    return ohL, ohR, oh∞, G, G∞
 end
 
 apply(::GS.Schur, h::AbstractHamiltonian, cs::Contacts) =
     argerror("Can only use GreenSolver.Schur with 1D AbstractHamiltonians")
 
+const Contacts0D{T,E,N,S} = Contacts{0,N,S,OrbitalSliceGrouped{T,E,0}}
+
 const GFUnit{T,E,H,N,S} =
-    GreenFunction{T,E,0,AppliedSparseLUGreenSolver{Complex{T}},H,Contacts{0,N,S,OrbitalSliceGrouped{T,E,0}}}
+    GreenFunction{T,E,0,AppliedSparseLUGreenSolver{Complex{T},Contacts0D{T,E,N,S}},H,Contacts0D{T,E,N,S}}
 
 green_type(::H,::S) where {T,E,H<:AbstractHamiltonian{T,E},S} =
     GFUnit{T,E,H,1,Tuple{S}}
@@ -380,14 +389,10 @@ green_type(::H,::S1,::S2) where {T,E,H<:AbstractHamiltonian{T,E},S1,S2} =
 
 #region ## call API ##
 
-function minimal_callsafe_copy(s::AppliedSchurGreenSolver{<:Any,<:Any,<:Any,<:Any,G,G∞}) where {G,G∞}
-    s´ = AppliedSchurGreenSolver{G,G∞}(s.fsolver, s.boundary,
-        minimal_callsafe_copy(s.ohL),
-        minimal_callsafe_copy(s.ohR),
-        minimal_callsafe_copy(s.oh∞))
-    isdefined(s, :gR) && (s´.gR = minimal_callsafe_copy(s.gR))
-    isdefined(s, :gL) && (s´.gL = minimal_callsafe_copy(s.gL))
-    isdefined(s, :g∞) && (s´.g∞ = minimal_callsafe_copy(s.g∞))
+function minimal_callsafe_copy(s::AppliedSchurGreenSolver, parentham)
+    fsolver´ = minimal_callsafe_copy(s.fsolver, parentham)
+    ohL´, ohR´, oh∞´, G, G∞ = schur_openhams_types(fsolver´, parentham, s.boundary)
+    s´ = AppliedSchurGreenSolver{G,G∞}(fsolver´, s.boundary, ohL´, ohR´, oh∞´)
     return s´
 end
 
@@ -426,9 +431,9 @@ mutable struct SchurGreenSlicer{C,A<:AppliedSchurGreenSolver}  <: GreenSlicer{C}
     boundary::C
     L::Matrix{C}
     R::Matrix{C}
-    G₋₁₋₁::SparseLUGreenSlicer{C}
-    G₁₁::SparseLUGreenSlicer{C}
-    G∞₀₀::SparseLUGreenSlicer{C}
+    G₋₁₋₁::SparseLUGreenSlicer{C}   # After call!(solver.fsolver, ω), these are independent
+    G₁₁::SparseLUGreenSlicer{C}     # of parent hamiltonian, as they only rely on
+    G∞₀₀::SparseLUGreenSlicer{C}    # call!_output(fsolver), which has been updated
     L´G∞₀₀::Matrix{C}
     R´G∞₀₀::Matrix{C}
     G₁₁L::Matrix{C}
@@ -455,6 +460,11 @@ function Base.getproperty(s::SchurGreenSlicer, f::Symbol)
     if !isdefined(s, f)
         solver = s.solver
         d = size(s.L, 2)
+        # the result of the following call!'s depends on the current value of h0
+        # which aliases the parent h. This is only a problem if `s`` was obtained through
+        # `gs = call!(g, ω; params...)`. In that case, doing call!(g, ω; params´...) before
+        # gs[sites...] will be call!-ing e.g. solver.g∞ with the wrong h0 (the one from
+        # params´...). However, if `gs = g(ω; params...)` a copy was made, so it is safe.
         if f == :G₋₁₋₁
             s.G₋₁₋₁ = slicer(call!(solver.gL, s.ω; skipsolve_internal = true))
         elseif f == :G₁₁
@@ -582,8 +592,8 @@ maybe_SMatrix(G::Matrix, rows::SVector{L}, cols::SVector{L´}) where {L,L´} = S
 maybe_SMatrix(G, rows, cols) = G
 
 # TODO: Perhaps too conservative
-function minimal_callsafe_copy(s::SchurGreenSlicer)
-    s´ = SchurGreenSlicer(s.ω, minimal_callsafe_copy(s.solver))
+function minimal_callsafe_copy(s::SchurGreenSlicer, parentham)
+    s´ = SchurGreenSlicer(s.ω, minimal_callsafe_copy(s.solver, parentham))
     isdefined(s, :G₋₁₋₁)    && (s´.G₋₁₋₁    = minimal_callsafe_copy(s.G₋₁₋₁))
     isdefined(s, :G₁₁)      && (s´.G₁₁      = minimal_callsafe_copy(s.G₁₁))
     isdefined(s, :G∞₀₀)     && (s´.G∞₀₀     = minimal_callsafe_copy(s.G∞₀₀))

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -329,8 +329,8 @@ boundaries(s::AppliedSchurGreenSolver) = (1 => s.boundary,)
 function Base.getproperty(s::AppliedSchurGreenSolver, f::Symbol)
     if !isdefined(s, f)
         if f == :gL
-            s.gL = greenfunction(s.ohL, GS.SparseLU())  # oh's harmonics alias parent h, but
-        elseif f == :gR                                 # not used here until called with ω
+            s.gL = greenfunction(s.ohL, GS.SparseLU())  # oh's harmonics alias parent h[()],
+        elseif f == :gR                                 # but not used until called with ω
             s.gR = greenfunction(s.ohR, GS.SparseLU())
         elseif f == :g∞
             s.g∞ = greenfunction(s.oh∞, GS.SparseLU())
@@ -393,9 +393,8 @@ function minimal_callsafe_copy(s::AppliedSchurGreenSolver, parentham)
     fsolver´ = minimal_callsafe_copy(s.fsolver, parentham)
     ohL´, ohR´, oh∞´, G, G∞ = schur_openhams_types(fsolver´, parentham, s.boundary)
     s´ = AppliedSchurGreenSolver{G,G∞}(fsolver´, s.boundary, ohL´, ohR´, oh∞´)
-    isdefined(s, :gR) && (s´.gR = minimal_callsafe_copy(s.gR, parentham))
-    isdefined(s, :gL) && (s´.gL = minimal_callsafe_copy(s.gL, parentham))
-    isdefined(s, :g∞) && (s´.g∞ = minimal_callsafe_copy(s.g∞, parentham))
+    # we don't copy the lazy fields gL, gR, g∞, even if already materialized, since they
+    # must be linked to ohL´, ohR´, oh∞´, not the old ones.
     return s´
 end
 

--- a/src/solvers/green/sparselu.jl
+++ b/src/solvers/green/sparselu.jl
@@ -46,9 +46,6 @@ function minimal_callsafe_copy(s::AppliedSparseLUGreenSolver, parentham)
     return AppliedSparseLUGreenSolver(invgreen´, contacts´)
 end
 
-minimal_callsafe_copy(s::SparseLUGreenSlicer{C}) where {C} =
-    SparseLUGreenSlicer{C}(s.fact, s.nonextrng, s.unitcinds, s.unitcindsall, copy(s.source64))
-
 #endregion
 
 #region ## apply ##
@@ -106,9 +103,12 @@ Base.view(s::SparseLUGreenSlicer, ::Colon, ::Colon) =
     compute_or_retrieve_green(s, s.unitcindsall, s.unitcindsall, s.source64, s.sourceC)
 
 function Base.view(s::SparseLUGreenSlicer{C}, i::CellOrbitals, j::CellOrbitals) where {C}
-    # cannot use s.source64, because it has only ncols = number of orbitals in contacts
-    source64 = similar_source64(s, j)
-    sourceC = convert(Matrix{C}, source64)  # will alias if C == ComplexF64
+    # we only preallocate if we actually need to call ldiv! below (empty unitg cache)
+    must_call_ldiv! = !isdefined(s, :unitg)
+    # need similar because s.source64 has only ncols = number of orbitals in contacts
+    source64 = must_call_ldiv! ? similar_source64(s, j) : s.source64
+    # this will alias if C == ComplexF64
+    sourceC = must_call_ldiv! ? convert(Matrix{C}, source64) : s.sourceC
     v = compute_or_retrieve_green(s, orbindices(i), orbindices(j), source64, sourceC)
     return v
 end
@@ -116,9 +116,9 @@ end
 # Implements cache for full ldiv! solve (unitg)
 # source64 and sourceC are of size (total_orbs_including_extended, length(srcinds))
 function compute_or_retrieve_green(s::SparseLUGreenSlicer{C}, dstinds, srcinds, source64, sourceC) where {C}
-    if isdefined(s, :unitg)
+    if isdefined(s, :unitg)     # we have already computed the full-cell slice
         g = view(s.unitg, dstinds, srcinds)
-    else
+    else                        # we haven't, so we must do some work still
         fact = s.fact
         allinds = 1:size(fact, 1) # axes not defined on SparseArrays.UMFPACK.UmfpackLU
         one!(source64, srcinds)
@@ -128,7 +128,7 @@ function compute_or_retrieve_green(s::SparseLUGreenSlicer{C}, dstinds, srcinds, 
         dstinds´ = ifelse(dstinds === allinds, s.nonextrng, dstinds)
         srcinds´ = convert(typeof(srcinds), 1:length(srcinds))
         g = view(sourceC, dstinds´, srcinds´)
-        if srcinds === allinds
+        if srcinds == allinds
             s.unitg = copy(view(gext, s.nonextrng, s.nonextrng))     # exclude extended orbs
         end
     end
@@ -142,6 +142,16 @@ similar_source64(s::SparseLUGreenSlicer, j::CellOrbitals) =
 
 # getindex must return a Matrix
 Base.getindex(s::SparseLUGreenSlicer, i::CellOrbitals, j::CellOrbitals) = copy(view(s, i, j))
+
+# the lazy unitg field only aliases source64 or a copy of it. It is not necessary to
+# maintain the alias, as this is just a prealloc for a full-cell slice. We don't even need
+# to copy it, since once it is computed, it is never modified, only read
+function minimal_callsafe_copy(s::SparseLUGreenSlicer{C}) where {C}
+    s´ = SparseLUGreenSlicer{C}(s.fact, s.nonextrng, s.unitcinds, s.unitcindsall, copy(s.source64))
+    isdefined(s, :unitg) && (s´.unitg = s.unitg)
+    return s´
+end
+
 
 #endregion
 

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -21,10 +21,11 @@ end
 spectrum(s::AppliedSpectrumGreenSolver) = s.spectrum
 
 # Parent ham needs to be non-parametric, so no need to alias
-minimal_callsafe_copy(s::AppliedSpectrumGreenSolver, parentham) =
+minimal_callsafe_copy(s::AppliedSpectrumGreenSolver, parentham, parentcontacts) =
     AppliedSpectrumGreenSolver(s.spectrum)
 
-minimal_callsafe_copy(s::SpectrumGreenSlicer) = SpectrumGreenSlicer(s.ω, s.solver)
+minimal_callsafe_copy(s::SpectrumGreenSlicer, parentham, parentcontacts) =
+    SpectrumGreenSlicer(s.ω, s.solver)
 
 #endregion
 

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -20,7 +20,9 @@ end
 
 spectrum(s::AppliedSpectrumGreenSolver) = s.spectrum
 
-minimal_callsafe_copy(s::AppliedSpectrumGreenSolver) = AppliedSpectrumGreenSolver(s.spectrum)
+# Parent ham needs to be non-parametric, so no need to alias
+minimal_callsafe_copy(s::AppliedSpectrumGreenSolver, parentham) =
+    AppliedSpectrumGreenSolver(s.spectrum)
 
 minimal_callsafe_copy(s::SpectrumGreenSlicer) = SpectrumGreenSlicer(s.ω, s.solver)
 

--- a/src/solvers/selfenergy.jl
+++ b/src/solvers/selfenergy.jl
@@ -5,7 +5,7 @@
 #     - call!(s::ExtendedSelfEnergySolver, ω; params...) -> (Vᵣₑ, gₑₑ⁻¹, Vₑᵣ) AbsMats
 #         With the extended case, the equivalent Σreg reads Σreg = VᵣₑgₑₑVₑᵣ
 #     - call!_output(s::AbstractSelfEnergySolver) -> object returned by call!(s, ω; kw...)
-#     - minimal_callsafe_copy(s::AbstractSelfEnergySolver)
+#     - minimal_callsafe_copy(s::AbstractSelfEnergySolver)  # no aliasing
 #   These AbstractMatrices are flat, defined on the LatticeSlice in parent SelfEnergy
 #       Note: `params` are only needed in cases where s adds new parameters that must be
 #       applied (e.g. SelfEnergyModelSolver). Otherwise one must assume that any parent
@@ -13,6 +13,7 @@
 #   Optional: AbstractSelfEnergySolver's can also implement `selfenergy_plottables`
 #     - selfenergy_plottables(s::AbstractSelfEnergySolver, parent_latslice)
 #       -> collection of tuples to be passed to plotlattice!(axis, tup...) for visualization
+#   Aliasing: AbstractSelfEnergySolver's are not allowed to alias anything from outside
 ############################################################################################
 
 ############################################################################################

--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -64,13 +64,16 @@ end
 
 call!_output(s::SelfEnergyGenericSolver) = s.Σ
 
-minimal_callsafe_copy(s::SelfEnergyGenericSolver) =
-    SelfEnergyGenericSolver(
-        minimal_callsafe_copy(s.hcoupling),
-        minimal_callsafe_copy(s.V´),
+function minimal_callsafe_copy(s::SelfEnergyGenericSolver)
+    hcoupling´ = minimal_callsafe_copy(s.hcoupling)
+    s´ = SelfEnergyGenericSolver(
+        hcoupling´,
+        minimal_callsafe_copy(s.V´, hcoupling´),
         minimal_callsafe_copy(s.gslice),
-        minimal_callsafe_copy(s.V),
+        minimal_callsafe_copy(s.V, hcoupling´),
         copy(s.V´g), copy(s.Σ))
+    return s´
+end
 
 function selfenergy_plottables(s::SelfEnergyGenericSolver, ls::LatticeSlice)
     p1 = s.hcoupling

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -231,7 +231,7 @@ function minimal_callsafe_copy(s::SelfEnergyCouplingSchurSolver)
     gunit´ = minimal_callsafe_copy(s.gunit)
     s´ = SelfEnergyCouplingSchurSolver(gunit´, hcoupling´,
         minimal_callsafe_copy(s.V´, hcoupling´),
-        inverse_green(solver(gunit´)),
+        inverse_green(solver(gunit´)),      # alias of the invgreen from the solver
         minimal_callsafe_copy(s.V, hcoupling´))
     return s´
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1000,8 +1000,10 @@ struct HybridSparseMatrix{T,B<:MatrixElementType{T}} <: SparseArrays.AbstractSpa
     blockstruct::OrbitalBlockStructure{B}
     unflat::SparseMatrixCSC{B,Int}
     flat::SparseMatrixCSC{Complex{T},Int}
-    sync_state::Base.RefValue{Int}  # 0 = in sync, 1 = flat needs sync, -1 = unflat needs sync, 2 = none initialized
-    ufnnz::Vector{Int}  # Number of stored nonzeros in unflat and flat - to guard against tampering
+    # 0 = in sync, 1 = flat needs sync, -1 = unflat needs sync, 2 = none initialized
+    sync_state::Base.RefValue{Int}
+    # Number of stored nonzeros in unflat and flat - to guard against tampering
+    ufnnz::Vector{Int}
 end
 
 #region ## Constructors ##
@@ -1113,6 +1115,10 @@ Base.size(s::SparseMatrixView, i...) = size(s.mat, i...)
 minimal_callsafe_copy(s::SparseMatrixView) =
     SparseMatrixView(view(copy(parent(s.matview)), s.matview.indices...), copy(s.mat), s.ptrs)
 
+minimal_callsafe_copy(s::SparseMatrixView, aliasham) =
+    SparseMatrixView(view(call!_output(aliasham), s.matview.indices...), copy(s.mat), s.ptrs)
+
+
 #endregion
 
 #endregion
@@ -1222,11 +1228,14 @@ isspzeros(b::SparseMatrixCSC) = iszero(nnz(b))
 isspzeros(b::Tuple) = all(isspzeros, b)
 isspzeros(b) = false
 
-minimal_callsafe_copy(s::BlockSparseMatrix) = BlockSparseMatrix(copy(s.mat), minimal_callsafe_copy.(s.blocks), s.ptrs)
+minimal_callsafe_copy(s::BlockSparseMatrix) =
+    BlockSparseMatrix(copy(s.mat), minimal_callsafe_copy.(s.blocks), s.ptrs)
 
-minimal_callsafe_copy(s::BlockMatrix) = BlockMatrix(copy(s.mat), minimal_callsafe_copy.(s.blocks))
+minimal_callsafe_copy(s::BlockMatrix) =
+    BlockMatrix(copy(s.mat), minimal_callsafe_copy.(s.blocks))
 
-minimal_callsafe_copy(m::MatrixBlock) = MatrixBlock(m.block, m.rows, m.cols, m.coefficient, copy_ifnotmissing(m.denseblock))
+minimal_callsafe_copy(m::MatrixBlock) =
+    MatrixBlock(m.block, m.rows, m.cols, m.coefficient, copy_ifnotmissing(m.denseblock))
 
 #endregion
 #endregion
@@ -1264,8 +1273,8 @@ function update!(s::InverseGreenBlockSparse, ω)
     return update!(bsm)
 end
 
-minimal_callsafe_copy(s::InverseGreenBlockSparse) =
-    InverseGreenBlockSparse(minimal_callsafe_copy(s.mat), s.nonextrng, s.unitcinds,
+minimal_callsafe_copy(s::InverseGreenBlockSparse, parentham, contacts) =
+    InverseGreenBlockSparse(minimal_callsafe_copy(s.mat, parentham, contacts), s.nonextrng, s.unitcinds,
     s.unitcindsall, copy(s.source))
 
 #endregion
@@ -1795,6 +1804,27 @@ call!(s::WrappedExtendedSelfEnergySolver; params...) = s
 #endregion
 
 ############################################################################################
+# Green solvers - see solvers/greensolvers.jl
+#region
+
+# Generic system-independent directives for solvers, e.g. GS.Schur()
+abstract type AbstractGreenSolver end
+
+# Application to a given OpenHamiltonian, but still independent from (ω; params...)
+# It should support call!(::AppliedGreenSolver, ω; params...) -> GreenSolution
+abstract type AppliedGreenSolver end
+
+# Solver with fixed ω and params that can compute G[subcell, subcell´] or G[cell, cell´]
+# It should also be able to return contact G with G[]
+abstract type GreenSlicer{C<:Complex} end   # C is the eltype of the slice
+
+# fallback: slicers in general are already unaliased from parentham
+# SchurGreenSlicer is an exception, so it has an override in solvers/green/schur.jl
+minimal_callsafe_copy(s::GreenSlicer, parentham) = minimal_callsafe_copy(s)
+
+#endregion
+
+############################################################################################
 # SelfEnergy - see solvers/selfenergy.jl
 #   Wraps an AbstractSelfEnergySolver and a SiteSlice
 #     -It produces Σs(ω)::AbstractMatrix defined over a SiteSlice
@@ -1814,7 +1844,6 @@ struct SelfEnergy{T,E,L,S<:AbstractSelfEnergySolver}
 end
 
 #region ## Constructors ##
-
 
 SelfEnergy(solver::S, orbslice::OrbitalSliceGrouped{T,E,L}) where {T,E,L,S<:AbstractSelfEnergySolver} =
     SelfEnergy{T,E,L,S}(solver, orbslice)
@@ -1987,27 +2016,10 @@ Base.isempty(c::Contacts) = isempty(selfenergies(c))
 
 # Base.length(c::Contacts) = length(selfenergies(c)) # unused
 
-minimal_callsafe_copy(s::Contacts) =
-    Contacts(minimal_callsafe_copy.(s.selfenergies), s.orbitals, s.orbslice)
+minimal_callsafe_copy(c::Contacts) =
+    Contacts(minimal_callsafe_copy.(c.selfenergies), c.orbitals, c.orbslice)
 
 #endregion
-
-#endregion
-
-############################################################################################
-# Green solvers - see solvers/greensolvers.jl
-#region
-
-# Generic system-independent directives for solvers, e.g. GS.Schur()
-abstract type AbstractGreenSolver end
-
-# Application to a given OpenHamiltonian, but still independent from (ω; params...)
-# It should support call!(::AppliedGreenSolver, ω; params...) -> GreenSolution
-abstract type AppliedGreenSolver end
-
-# Solver with fixed ω and params that can compute G[subcell, subcell´] or G[cell, cell´]
-# It should also be able to return contact G with G[]
-abstract type GreenSlicer{C<:Complex} end   # C is the eltype of the slice
 
 #endregion
 
@@ -2176,11 +2188,19 @@ copy_lattice(g::GreenSolution) = GreenSolution(
 copy_lattice(g::GreenSlice) = GreenSlice(
     copy_lattice(g.parent), g.rows, g.cols)
 
-minimal_callsafe_copy(g::GreenFunction) =
-    GreenFunction(minimal_callsafe_copy(g.parent), minimal_callsafe_copy(g.solver), minimal_callsafe_copy(g.contacts))
+function minimal_callsafe_copy(g::GreenFunction)
+    parent´ = minimal_callsafe_copy(g.parent)
+    solver´ = minimal_callsafe_copy(g.solver, parent´)
+    contacts´ = minimal_callsafe_copy(g.contacts)
+    return GreenFunction(parent´, solver´, contacts´)
+end
 
-minimal_callsafe_copy(g::GreenSolution) =
-    GreenSolution(minimal_callsafe_copy(g.parent), minimal_callsafe_copy(g.slicer), g.contactΣs, g.contactorbs)
+function minimal_callsafe_copy(g::GreenSolution)
+    parentg´ = minimal_callsafe_copy(g.parent)
+    g´ = GreenSolution(parentg´,
+        minimal_callsafe_copy(g.slicer, hamiltonian(parentg´)), g.contactΣs, g.contactorbs)
+    return g´
+end
 
 minimal_callsafe_copy(g::GreenSlice) =
     GreenSlice(minimal_callsafe_copy(g.parent), g.rows, g.cols)

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -414,4 +414,11 @@ end
     gs = Quantica.call!(g, 0.4, q = 0.1)
     parent(g)(q = 2)
     @test_broken gs[cells = 0] == m
+    # Ensure that g.solver.invgreen alias of parent contacts is not broken by minimal_callsafe_copy
+    glead = LP.linear() |> @onsite((; o = 1) -> o) - hopping(1) |> greenfunction(GS.Schur(boundary = 0));
+    g = LP.linear() |> -hopping(1) |> supercell |> attach(glead) |> greenfunction;
+    g´ = Quantica.minimal_callsafe_copy(g);
+    @test g´(0, o = 0)[] == g(0, o = 0)[]
+    @test g´(0, o = 1)[] == g(0, o = 1)[]
+
 end

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -397,3 +397,21 @@ end
         @test iszero(diff)
     end
 end
+
+@testset "aliasing" begin
+    # Issue #267
+    g = LP.linear() |> hamiltonian(@hopping((; q = 1) -> q*I), orbitals = 2) |> greenfunction
+    g´ = Quantica.minimal_callsafe_copy(g)
+    @test g(0.2; q = 2)[cells = 1] == g´(0.2; q = 2)[cells = 1]
+    @test g´.solver.fsolver.h0 === g´.parent.h.harmonics[1].h
+    # The Schur slicer has uninitialized fields whose eventual value depends on the parent hamiltonian
+    # at call time, not creation time. This can produce bugs if Quantica.call!(g, ω; params...) is used.
+    # The exported g(ω; params...) syntax decouples the slicer's parent Hamiltonian, so it is safe.
+    g = LP.linear() |> hamiltonian(@onsite((; q = 1) -> q) + @hopping((; q = 1) -> q)) |> greenfunction
+    m = g(0.4, q = 0.1)[cells = 0]
+    gs = Quantica.call!(g, 0.4, q = 0.1)
+    @test gs[cells = 0] == m
+    gs = Quantica.call!(g, 0.4, q = 0.1)
+    parent(g)(q = 2)
+    @test_broken gs[cells = 0] == m
+end


### PR DESCRIPTION
Closes #267 

We use the approach described in that issue: redefine `minimal_callsafe_copy` methods throughout Quantica to restore aliasing relations between subparts of objects, particularly between `GreenSolvers` and any parent `ph::ParametricHamiltonian`.

We also fixed a silly bug that called `call!` on each `ph[hybrid(dn)]` indexing, so this might even improve performance a bit. I didn't profile any potential allocations regressions of the PR. The changes are subtle and hence a bit risky.