### PR TITLE
Make `view(gω::GreenSolution, contact_inds...)` a `SubArray` instead of an `OrbitalSliceArray`

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1558,6 +1558,12 @@ evaluated at fixed energy, parameters and positions. The matrix is a dense
 is flattened. Note that the resulting `m` can itself be indexed over collections of sites
 with `m[i, j]`, where `i, j` are `siteselector(; ss...)` or `ss::NamedTuple`.
 
+    view(gω, i::C, j::C == i)
+
+For any `gω::GreenSolution` and `C<:Union{Colon,Integer}`, obtain a view (of type
+`SubArray`, not `OrbitalSliceMatrix`) of the corresponding intra or inter-contact propagator
+`gω[i, j]` with minimal allocations.
+
 # Example
 ```jldoctest
 julia> g = LP.honeycomb() |> hamiltonian(@hopping((; t = 1) -> t)) |> supercell(region = RP.circle(10)) |> greenfunction(GS.SparseLU())

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1553,8 +1553,10 @@ retarded `g`.
     gs(ω; params...)
 
 For any `gω::GreenSolution` or `gs::GreenSlice`, build the Green function matrix fully
-evaluated at fixed energy, parameters and positions. The matrix is dense and has scalar
-elements, so that any orbital structure on each site is flattened.
+evaluated at fixed energy, parameters and positions. The matrix is a dense
+`m::OrbitalSliceMatrix` with scalar element type, so that any orbital structure on each site
+is flattened. Note that the resulting `m` can itself be indexed over collections of sites
+with `m[i, j]`, where `i, j` are `siteselector(; ss...)` or `ss::NamedTuple`.
 
 # Example
 ```jldoctest

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -97,15 +97,12 @@ Base.getindex(g::GreenFunction, kw::NamedTuple) = g[siteselector(; kw...)]
 Base.getindex(g::GreenSolution; kw...) = g[getindex(lattice(g); kw...)]
 Base.getindex(g::GreenSolution, kw::NamedTuple) = g[getindex(lattice(g); kw...)]
 
-# wrapped view for end user consumption
-Base.view(g::GreenSolution, i::Integer, j::Integer = i) =
-    OrbitalSliceMatrix(view(slicer(g), i, j), sites_to_orbs.((i,j), Ref(g)))
-Base.view(g::GreenSolution, i::Colon, j::Colon = i) =
-    OrbitalSliceMatrix(view(slicer(g), i, j), sites_to_orbs.((i,j), Ref(g)))
+# g[::Integer, ::Integer] and g[:, :] - intra and inter contacts
+Base.view(g::GreenSolution, i::CT, j::CT = i) where {CT<:Union{Integer,Colon}} = view(slicer(g), i, j)
 
 # fastpath for intra and inter-contact
-Base.getindex(g::GreenSolution, i::Integer, j::Integer = i) = copy(view(g, i, j))
-Base.getindex(g::GreenSolution, ::Colon, ::Colon = :) = copy(view(g, :, :))
+Base.getindex(g::GreenSolution, i::CT, j::CT = i)  where {CT<:Union{Integer,Colon}}  =
+    OrbitalSliceMatrix(copy(view(g, i, j)), sites_to_orbs.((i,j), Ref(g)))
 
 # conversion down to CellOrbitals. See sites_to_orbs in slices.jl
 Base.getindex(g::GreenSolution, i, j) = getindex(g, sites_to_orbs(i, g), sites_to_orbs(j, g))

--- a/src/solvers/green.jl
+++ b/src/solvers/green.jl
@@ -10,8 +10,9 @@
 #   To do this, it must implement contact slicing (unless it relies on TMatrixSlicer)
 #      - view(gs, ::Int, ::Int) -> g(ω; kw...) between specific contacts (has error fallback)
 #      - view(gs, ::Colon, ::Colon) -> g(ω; kw...) between all contacts (has error fallback)
+#      - Both of the above are of type `SubArray`
 #   It must also implement generic slicing, and minimal copying
-#      - gs[i::CellOrbitals, j::CellOrbitals] -> must return a Matrix for type stability
+#      - gs[i::CellOrbitals, j::CellOrbitals] -> must return a `Matrix` for type stability
 #      - minimal_callsafe_copy(gs, parentham, parentcontacts)
 #   The user-facing indexing API accepts:
 #      - i::Integer -> Sites of Contact number i

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -102,6 +102,12 @@ end
     g = central |> attach(glead[cells = 1], -hopping(1), region = r -> r[1] > 1.3 && -1.1 <= r[2] <= 1.1, transform = r -> r + SA[1.2,0]) |> greenfunction
     @test g isa GreenFunction
     @test_throws ArgumentError central |> attach(glead[cells = 1], -hopping(1), region = r -> r[1] > 2.3 && -1.1 <= r[2] <= 1.1, transform = r -> r + SA[1.2,0])
+
+    # cheap views
+    g = LP.linear() |> hopping(1) |> attach(@onsite((ω; p = 1) -> p), cells = 1) |> attach(@onsite((ω; p = 1) -> p), cells = 3) |> greenfunction
+    gs = g(0.2)
+    @test view(gs, 1, 2) isa SubArray
+    @test (@allocations view(gs, 1, 2)) == 1
 end
 
 @testset "GreenSolvers applicability" begin

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -107,7 +107,7 @@ end
     g = LP.linear() |> hopping(1) |> attach(@onsite((ω; p = 1) -> p), cells = 1) |> attach(@onsite((ω; p = 1) -> p), cells = 3) |> greenfunction
     gs = g(0.2)
     @test view(gs, 1, 2) isa SubArray
-    @test (@allocations view(gs, 1, 2)) == 1
+    @test (@allocations view(gs, 1, 2)) <= 2  # should be 1, but in some platforms/versions it could be 2
 end
 
 @testset "GreenSolvers applicability" begin


### PR DESCRIPTION
It's likely that when using `view` the intention is to minimize allocations and overhead. Since `OrbitalSliceArray` does have the overhead of allocating the slice axes, we should restrict that to `getindex`, and leave `view` as lightweight as possible.