### PR TITLE
`combine` of `ParametricHamiltonian`s

### DIFF
--- a/docs/src/tutorial/hamiltonians.md
+++ b/docs/src/tutorial/hamiltonians.md
@@ -221,3 +221,28 @@ julia> h2[()]
 As a consequence, `h` and `supercell(h)` represent exactly the same system, with the same observables, but with a different choice of unitcell.
 
 These two different behaviors make sense in different situations, so it is important to be aware of the order dependence of transformations. Similar considerations apply to `transform`, `translate` and `torus` when models are position dependent.
+
+## Combining Hamiltonians
+
+Multiple `h::AbstractHamiltonian`s (or multiple `l::Lattice`s) can be combined into one with `combine`.
+```julia
+julia> h1 = LP.linear(dim = 2) |> hopping(1); h2 = LP.linear(dim = 2, names = :B) |> hopping(1) |> translate(SA[0,1]) |> @onsite!((o; p=1) -> o+p);
+
+julia> combine(h1, h2; coupling = hopping(2))
+ParametricHamiltonian{Float64,2,1}: Parametric Hamiltonian on a 1D Lattice in 2D space
+  Bloch harmonics  : 3
+  Harmonic size    : 2 × 2
+  Orbitals         : [1, 1]
+  Element type     : scalar (ComplexF64)
+  Onsites          : 0
+  Hoppings         : 6
+  Coordination     : 3.0
+  Parameters       : [:p]
+```
+The `coupling` keyword, available when combining `h::AbstractHamiltonian`s, is a hopping model that is applied between each `h`. It can be constrained as usual with `hopselector`s and also be parametric. If either `coupling` or any of the combined `h` is parametric, the result of `combine` will be a `ParametricHamiltonian`, or a `Hamiltonian` otherwise.
+
+The combined objects must satisfy some conditions:
+
+- They must have the same Bravais vectors (modulo reorderings), which will be the inherited by the combined result.
+- They must have the same position type (the `T` in `AbstractHamiltonian{T}` and `Lattice{T}`)
+- They must have no repeated sublattice names among them (unless the combined object is non-parametric)

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -166,12 +166,10 @@ apply(m::ParametricModel, lat) = ParametricModel(apply.(terms(m), Ref(lat)))
 #region
 
 # Any means it could be wrapped in Intrablock or Interblock
-apply(m::AnyOnsiteModifier, h::Hamiltonian, shifts = missing) =
-    apply(parent(m), h, shifts, block(m, blockstructure(h)))
-apply(m::AnyHoppingModifier, h::Hamiltonian, shifts = missing) =
+apply(m::BlockModifier, h::Hamiltonian, shifts = missing) =
     apply(parent(m), h, shifts, block(m, blockstructure(h)))
 
-function apply(m::OnsiteModifier, h::Hamiltonian, shifts, oblock)
+function apply(m::OnsiteModifier, h::Hamiltonian, shifts = missing, oblock = missing)
     f = parametric_function(m)
     sel = selector(m)
     asel = apply(sel, lattice(h))
@@ -181,7 +179,7 @@ function apply(m::OnsiteModifier, h::Hamiltonian, shifts, oblock)
     return AppliedOnsiteModifier(sel, B, f, ptrs, spatial)
 end
 
-function apply(m::HoppingModifier, h::Hamiltonian, shifts, oblock)
+function apply(m::HoppingModifier, h::Hamiltonian, shifts = missing, oblock = missing)
     f = parametric_function(m)
     sel = selector(m)
     asel = apply(sel, lattice(h))

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -196,8 +196,10 @@ function IJVBuilder(lat::Lattice{T}, hams::AbstractHamiltonian...) where {T}
     orbs = vcat(norbitals.(hams)...)
     builder = IJVBuilderWithModifiers(lat, orbs)
     push_ijvharmonics!(builder, hams...)
-    unapplied_modifiers = tupleflatten(parent.(modifiers.(hams))...)
-    push!(builder, unapplied_modifiers...)
+    mss = modifiers.(hams)
+    bis = blockindices(hams)
+    unapplied_block_modifiers = ((ms, bi) -> intrablock.(parent.(ms), Ref(bi))).(mss, bis)
+    push!(builder, tupleflatten(unapplied_block_modifiers...)...)
     return builder
 end
 
@@ -261,7 +263,7 @@ harmonics(b::AbstractHamiltonianBuilder) = b.harmonics
 
 Base.length(b::AbstractHarmonicBuilder) = length(collector(b))
 
-Base.push!(b::IJVBuilderWithModifiers, ms::Modifier...) = push!(b.modifiers, ms...)
+Base.push!(b::IJVBuilderWithModifiers, ms::AnyModifier...) = push!(b.modifiers, ms...)
 
 Base.pop!(b::IJVBuilderWithModifiers) = pop!(b.modifiers)
 

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -185,16 +185,16 @@ end
 
 # with no modifiers
 function IJVBuilder(lat::Lattice{T}, hams::Hamiltonian...) where {T}
-    orbs = vcat(norbitals.(hams)...)
-    builder = IJVBuilder(lat, orbs)
+    bs = blockstructure(lat, hams...)
+    builder = IJVBuilder(lat, bs)
     push_ijvharmonics!(builder, hams...)
     return builder
 end
 
 # with some modifiers
 function IJVBuilder(lat::Lattice{T}, hams::AbstractHamiltonian...) where {T}
-    orbs = vcat(norbitals.(hams)...)
-    builder = IJVBuilderWithModifiers(lat, orbs)
+    bs = blockstructure(lat, hams...)
+    builder = IJVBuilderWithModifiers(lat, bs)
     push_ijvharmonics!(builder, hams...)
     mss = modifiers.(hams)
     bis = blockindices(hams)
@@ -211,17 +211,22 @@ push_ijvharmonics!(builder) = builder
 
 function push_ijvharmonics!(builder::IJVBuilder, hs::AbstractHamiltonian...)
     offset = 0
+    B = blocktype(builder)
     for h in hs
         for har in harmonics(h)
             ijv = builder[dcell(har)]
             hmat = unflat(matrix(har))
             I,J,V = findnz(hmat)
-            append!(ijv, (I .+ offset, J .+ offset, V))
+            V´ = maybe_mask_blocks(B, V)
+            append!(ijv, (I .+ offset, J .+ offset, V´))
         end
         offset += nsites(lattice(h))
     end
     return builder
 end
+
+maybe_mask_blocks(::Type{B}, V::Vector{B}) where {B} = V
+maybe_mask_blocks(::Type{B}, V::Vector) where {B} = mask_block.(B, V)
 
 empty_harmonic(b::CSCBuilder{<:Any,<:Any,L,B}, dn) where {L,B} =
     CSCHarmonic{L,B}(dn, CSC{B}(nsites(b.lat)))

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -415,6 +415,16 @@ Note that the `coupling` model will be applied to the combined lattice (which ma
 renamed sublattices to avoid name collissions). However, only hopping terms between
 different `hams` blocks will be applied.
 
+## Limitations
+
+Currently, `combine` only works with `Lattice{T}` `AbstractHamiltonians{T}` with the same
+`T`. Furthermore, if any of the `hams` is a `ParametricHamiltonian` or `coupling` is a
+`ParametricModel`, the sublattice names of all `hams` must be distinct. This ensures that
+parametric models, which get applied through `Modifiers` after construction of the
+`ParametricHamiltonian`, are not applied to the wrong sublattice, since sublattice names
+could be renamed by `combine` if they are not unique. Therefore, be sure to choose unique
+sublattice names upon construction for all the `hams` to be combined (see `lattice`).
+
 # Examples
 ```jldoctest
 julia> # Building Bernal-stacked bilayer graphene

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -93,7 +93,7 @@ unitcell(u::Unitcell{T,E}, names, postype::Type{S})  where {T,E,S<:SVector{E,T}}
 # combine lattices - combine sublats, rename if equal name
 #region
 
-function combine(lats::Lattice{<:Any,E,L}...) where {E,L}
+function combine(lats::Lattice{T,E,L}...) where {T,E,L}
     isapprox_modulo_shuffle(bravais_matrix.(lats)...) ||
         throw(ArgumentError("To combine lattices they must all share the same Bravais matrix. They read $(bravais_matrix.(lats))"))
     bravais´ = bravais(first(lats))
@@ -101,8 +101,9 @@ function combine(lats::Lattice{<:Any,E,L}...) where {E,L}
     return Lattice(bravais´, unitcell´)
 end
 
+# without <:Any here, this method overwrites the one above
 combine(lats::Lattice{<:Any}...) =
-    argerror("Tried to combine lattices with different dimension or embedding dimension")
+    argerror("Tried to combine lattices with different type or different dimension or embedding dimension")
 
 function combine(ucells::Unitcell...)
     names´ = vcat(sublatnames.(ucells)...)

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -90,7 +90,7 @@ unitcell(u::Unitcell{T,E}, names, postype::Type{S})  where {T,E,S<:SVector{E,T}}
 # end
 
 ############################################################################################
-# combine lattices - combine sublats if equal name
+# combine lattices - combine sublats, rename if equal name
 #region
 
 function combine(lats::Lattice{<:Any,E,L}...) where {E,L}

--- a/src/models.jl
+++ b/src/models.jl
@@ -176,10 +176,13 @@ interblock(m::AbstractModel, hams::AbstractHamiltonian...) =
     interblock(m, blockindices(hams)...)
 
 interblock(m::AbstractModel, inds...) = isempty(intersect(inds...)) ?
-    InterblockModel(hopping(m), inds) :
-    InterblockModel(m, inds)                 # if blocks overlap, don't exclude onsite terms
+    Interblock(hopping(m), inds) :
+    Interblock(m, inds)                 # if blocks overlap, don't exclude onsite terms
 
-intrablock(m::AbstractModel, inds) = IntrablockModel(m, inds)
+intrablock(m::AbstractModel, inds) = Intrablock(m, inds)
+
+interblock(m::AbstractModifier, inds) = Interblock(m, inds)
+intrablock(m::AbstractModifier, inds) = Intrablock(m, inds)
 
 function blockindices(hams::NTuple{N,Any}) where {N}
     offset = 0
@@ -191,5 +194,9 @@ function blockindices(hams::NTuple{N,Any}) where {N}
     end
     return inds
 end
+
+block(m::Intrablock, b::OrbitalBlockStructure) = flatrange(b, block(m))
+block(m::Interblock, b::OrbitalBlockStructure) = flatrange.(Ref(b), block(m))
+block(::Union{AbstractModel,AbstractModifier}, b...) = missing
 
 #endregion

--- a/src/sanitizers.jl
+++ b/src/sanitizers.jl
@@ -7,7 +7,7 @@ sanitize_Vector_of_Symbols(names) = Symbol[convert(Symbol, name) for name in nam
 
 sanitize_orbitals(o::Val) = o
 sanitize_orbitals(o::Int) = Val(o)
-sanitize_orbitals(o) = allequal(o) ? Val(first(o)) : o
+sanitize_orbitals(o) = allequal(o) ? sanitize_orbitals(first(o)) : o
 
 sanitize_Val(o::Val) = o
 sanitize_Val(o) = Val(o)

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -156,6 +156,9 @@ checkstored(mat, i, j) = i in view(rowvals(mat), nzrange(mat, j)) ||
 #   converts input to a specific block type B (with or without size check)
 #region
 
+# in case the first argument is a value, not a type
+@inline mask_block(::B, val) where {B} = mask_block(B, val)
+
 @inline mask_block(::Type{B}, val::UniformScaling, size = (N, N)) where {T,N,B<:MatrixElementNonscalarType{T,N}} =
     mask_block(B, sanitize_SMatrix(SMatrix{N,N,T}, SMatrix{N,N}(val), size))
 
@@ -183,7 +186,7 @@ end
     return SMatrixView(SMatrix{N,N,T}(s))
 end
 
-mask_block(t, val) = argerror("Unexpected block size")
+mask_block(t::Type, val) = argerror("Unexpected block size")
 
 size_or_1x1(::Number) = (1, 1)
 size_or_1x1(val) = size(val)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -35,7 +35,7 @@ end
 
 @noinline checkmatrixsize(::UniformScaling, s) = nothing
 @noinline checkmatrixsize(val, s) = (size(val, 1), size(val, 2)) == s ||
-    throw(ArgumentError("Expected an block or matrix of size $s, got size $((size(val, 1), size(val, 2)))"))
+    throw(ArgumentError("Expected a block or matrix of size $s, got size $((size(val, 1), size(val, 2)))"))
 
 @noinline function_not_defined(name) = argerror("Function $name not defined for the requested types")
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -837,8 +837,7 @@ end
 
 const AnyAbstractModifier = Union{AbstractModifier,Interblock{<:AbstractModifier},Intrablock{<:AbstractModifier}}
 const AnyModifier = Union{Modifier,Interblock{<:Modifier},Intrablock{<:Modifier}}
-const AnyOnsiteModifier = Union{OnsiteModifier,Interblock{<:OnsiteModifier},Intrablock{<:OnsiteModifier}}
-const AnyHoppingModifier = Union{HoppingModifier,Interblock{<:HoppingModifier},Intrablock{<:HoppingModifier}}
+const BlockModifier = Union{Interblock{<:AbstractModifier},Intrablock{<:AbstractModifier}}
 
 Base.parent(m::Union{Interblock,Intrablock}) = m.parent
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -875,6 +875,7 @@ OrbitalBlockStructure{B}(hsize::Int) where {B} = OrbitalBlockStructure{B}(Val(1)
 blocktype(::Type{T}, m::Val{1}) where {T} = Complex{T}
 blocktype(::Type{T}, m::Val{N}) where {T,N} = SMatrix{N,N,Complex{T},N*N}
 blocktype(T::Type, distinct_norbs) = maybe_SMatrixView(blocktype(T, val_maximum(distinct_norbs)))
+
 maybe_SMatrixView(C::Type{<:Complex}) = C
 maybe_SMatrixView(S::Type{<:SMatrix}) = SMatrixView(S)
 
@@ -1413,6 +1414,20 @@ end
 
 # Unless params are given, it returns the Hamiltonian with defaults parameters
 default_hamiltonian(h::AbstractHamiltonian; params...) = h(; params...)
+
+# type-stable computation of common blocktype (for e.g. combine)
+blocktype(h::AbstractHamiltonian, hs::AbstractHamiltonian...) =
+    blocktype(promote_type(typeof.((h, hs...))...))
+blocktype(::Type{<:AbstractHamiltonian{<:Any,<:Any,<:Any,B}}) where {B} = B
+
+# lat must be the result of combining the lattices of h, hs...
+function blockstructure(lat::Lattice{T}, h::AbstractHamiltonian{T}, hs::AbstractHamiltonian{T}...) where {T}
+    B = blocktype(h, hs...)
+    orbitals = sanitize_orbitals(vcat(norbitals.((h, hs...))...))
+    subsizes = sublatlengths(lat)
+    return OrbitalBlockStructure{B}(orbitals, subsizes)
+end
+
 
 ## Hamiltonian
 

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -110,11 +110,11 @@ end
     @test length.(sites.(Ref(cells), 1:5)) == [14, 14, 14, 14, 2]
     @test_throws ArgumentError combine(LatticePresets.honeycomb(), LatticePresets.square())
     @test_throws ArgumentError combine(LatticePresets.honeycomb(), LatticePresets.linear())
-    lat1 = transform(LatticePresets.honeycomb(type = Float32), r -> SA[r[2], -r[1]]) |> supercell((-1,1), (1,1))
+    lat1 = transform(LatticePresets.honeycomb(), r -> SA[r[2], -r[1]]) |> supercell((-1,1), (1,1))
     lat2 = combine(lat0, lat1)
     @test lat2 isa typeof(lat0)
     @test allunique(Quantica.sublatnames(lat2))
-    lat1 = transform(LatticePresets.honeycomb(type = Float32), r -> SA[r[2], -r[1]]) |> supercell((-3,3), (1,1))
+    lat1 = transform(LatticePresets.honeycomb(), r -> SA[r[2], -r[1]]) |> supercell((-3,3), (1,1))
     @test_throws ArgumentError combine(lat0, lat1)
 end
 


### PR DESCRIPTION
Closes #276 

`combine` only had real support for non-parametric `Hamiltonian`s. The reason is that parameters are implemented through modifiers that act on a selection of sites. When you combine two `ParametricHamiltonian`s, their modifiers would act on the two combined pieces, not on the original piece. With non-parametric `Hamiltonian`s this is not a problem, since all matrix elements are fixed after construction.

To support combining `ParametricHamiltonian`s we therefore need to generalize `Modifier`s to act on subblocks. Here we extend the `Intrablock` and `Interblock` machinery to act on both `AbstractModel`s and `Modifier`s. We also introduce some `promote_type` machinery to enable more precise inference of the type of the combined `AbstractHamiltonian`. We finally also restrict `combine` to `Lattice{T}` and `AbstractHamiltonian{T}` with the same  position type `T`, since supporting the general promotion-upon-combine seemed unpleasant.