### PR TITLE
Release v1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Quantica"
 uuid = "ae5ea0c6-3f5e-46a2-bc28-a7c4c7a4773c"
 authors = ["Pablo San-Jose"]
-version = "1.1"
+version = "1.1.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Quantica"
 uuid = "ae5ea0c6-3f5e-46a2-bc28-a7c4c7a4773c"
 authors = ["Pablo San-Jose"]
-version = "1.0.1"
+version = "1.1"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
@@ -34,16 +34,16 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 QuanticaMakieExt = "Makie"
 
 [compat]
-ArnoldiMethod = "0.2"
+ArnoldiMethod = "0.2, 0.3, 0.4"
 Arpack = "0.5"
 Compat = "4"
-Dictionaries = "0.3.26"
+Dictionaries = "0.3.26, 0.4"
 ExprTools = "^0.1"
 FrankenTuples = "0.1"
 FunctionWrappers = "1.1.3, 1.2, 1.0"
 GeometryBasics = "0.4"
 IntervalTrees = "1"
-KrylovKit = "0.6"
+KrylovKit = "0.6, 0.7"
 LinearMaps = "3"
 Makie = "0.20, 1.0"
 NearestNeighbors = "0.4"


### PR DESCRIPTION
PRs from #226 to #282

## Changes since v1.0.1

### New features

- `current(h::AbstractHamiltonian; direction = 1)` returns the current `Operator` along a given `direction` (#227)
- `OrbitalSliceArray`s and `CellSites`: indexing has been improved (#234, #245, #271, #277, #280)
- `GreenSolvers.Spectrum` (#240)
- `densitymatrix` observable (#241)
- `omegamap` option in `josephson` observable, to allow parameters to act as frequency (#247)
- Non-spatial models. These allow, in particular, to implement self-consistent mean field Hamiltonians (#248)
- Support for Wannier90 imports (#261, #264)
- `attach` now allows a `transform` keyword in its most general method (#263)
- Partial evaluation of `g::GreenFunction`s with `g(; params)` (#270)
- `combine` now works also with `ParametricHamiltonian`s and `ParametricModel`s as couplings (#278)

### Fixes and improvements

- Faster bands when using multithreaded julia (#226)
- 32bit support for GreenSolvers (#238)
- Plotting improvements (#249, #251, #255, #258, #272, #273)
- Bugfixes in `GreenSolvers.Bands` (#253, #259)
- Bugfix when using a function to constrain `cells` or `dcells` in a selector (#254)
- Fix to avoid an unnecessary performance drop when computing a `spectrum` in newer Julia versions (#260)
- Bugfixes to subtle aliasing problems (#269)
- Generalize macros to parse e.g. `@onsite(o -> 2o, sublats = :A)`, not only `@onsite(o -> 2o; sublats = :A)` (#275)

### Breaking changes

- rename `wrap` to `torus` due to a future name collision with `Base` (#237)