### PR TITLE
Reduce `min_squared_overlap` in `bands` below 0.5

### DIFF
--- a/src/bands.jl
+++ b/src/bands.jl
@@ -377,7 +377,7 @@ end
 # count singular values. The min_squared_overlap is arbitrary, and is fixed heuristically to
 # a high enough value to connect in the coarsest base lattices
 function connection_rank(proj)
-    min_squared_overlap = 0.5
+    min_squared_overlap = 0.499
     rankf = sum(abs2, proj) # = tr(proj'proj)
     fastrank = ifelse(rankf > min_squared_overlap, 1, 0)  # For rank=1 proj: upon doubt, connect
     if iszero(fastrank) || size(proj, 1) == 1 || size(proj, 2) == 1

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -49,6 +49,11 @@ using Random
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1))
     b = bands(h, subdiv(0, 2pi, 8), subdiv(0, 2pi, 8); showprogress = false, defects = ((2pi/3, 4pi/3), (4pi/3, 2pi/3)), patches = 10)
     @test nvertices(b) == 140
+
+    # knit min_squared_overlap should be < 0.5
+    h = LP.square() |> hamiltonian(onsite(3*I) -hopping(I) + hopping((r, dr) -> 0.1*(im*dr[1]*SA[0 -im; im 0] - im*dr[2]*SA[0 1; 1 0])), orbitals = 2)
+    b = bands(h, subdiv(-π, π, 19), subdiv(-π, π, 19))
+    @test nsimplices(b) == 1312
 end
 
 @testset "functional bandstructures" begin


### PR DESCRIPTION
Otherwise some unlucky simplices with `overlap^2 == 0.5 - machine_eps` get missed. The necessary reduction below 0.5 is in theory just some small quantity ~eps, but we use 0.499 as knitting too optimistically is better than the opposite.