### PR TITLE
Ensure `reverse!` flips harmonics

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -342,7 +342,8 @@ supercell
 """
     reverse(lat_or_h::Union{Lattice,AbstractHamiltonian})
 
-Build a new lattice or hamiltonian with the orientation of all Bravais vectors reversed.
+Build a new lattice or hamiltonian with the orientation of all Bravais vectors and harmonics
+reversed.
 
 # See also
     `reverse!`, `transform`
@@ -352,7 +353,7 @@ Base.reverse
 """
     reverse!(lat_or_h::Union{Lattice,AbstractHamiltonian})
 
-In-place version of `reverse`, inverts all Bravais vectors of `lat_or_h`.
+In-place version of `reverse`, inverts all Bravais vectors and harmonics of `lat_or_h`.
 
 # See also
     `reverse`, `transform`
@@ -1503,11 +1504,11 @@ Add a self-energy `Σ(ω) = h₋₁⋅g1D(ω)[surface]⋅h₁` corresponding to 
 couplings, and `g1D` is the lead `GreenFunction`. The `g1D(ω)` is taken at the `suface`
 unitcell, either adjacent to the `boundary` on its positive side (if `reverse = false`) or
 on its negative side (if `reverse = true`). Note that `reverse` only flips the direction we
-extend the lattice to form the lead, but does not flip the unit cell (use `transform` for
-that). The positions of the selected `sites` in `h` must match, modulo an arbitrary
-displacement, those of the left or right unit cell surface of the lead (i.e. sites coupled
-to the adjacent unit cells), after applying `transform` to the latter. If they don't match,
-use the `attach` syntax below.
+extend the lattice to form the lead, but does not flip the unit cell (may use `transform`
+for that) or any contacts in the lead. The positions of the selected `sites` in `h` must
+match, modulo an arbitrary displacement, those of the left or right unit cell surface of the
+lead (i.e. sites coupled to the adjacent unit cells), after applying `transform` to the
+latter. If they don't match, use the `attach` syntax below.
 
 Advanced: If the `g1D` does not have any self-energies, the produced self-energy is in fact
 an `ExtendedSelfEnergy`, which is numerically more stable than a naive implementation of

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -45,13 +45,31 @@ translate(l::Lattice, δr) = translate!(copy(l), δr)
 # Lattice reverse - flip all Bravais vectors
 #region
 
-Base.reverse!(lat::Lattice) = (matrix(bravais(lat)) .*= -1; lat)
-
 Base.reverse(lat::Lattice) = reverse!(copy(lat))
 
-Base.reverse!(h::AbstractHamiltonian) = (reverse!(lattice(h)); h)
+Base.reverse!(lat::Lattice) = (matrix(bravais(lat)) .*= -1; lat)
 
 Base.reverse(h::AbstractHamiltonian) = reverse!(copy(h))
+
+function Base.reverse!(h::AbstractHamiltonian)
+    reverse!(lattice(h))
+    flip_harmonics!(h)
+    return h
+end
+
+function flip_harmonics!(h::Hamiltonian)
+    hars = harmonics(h)
+    for (i, har) in enumerate(hars)
+        hars[i] = Harmonic(-dcell(har), matrix(har))
+    end
+    return h
+end
+
+function flip_harmonics!(h::AbstractHamiltonian)
+    flip_harmonics!(parent(h))
+    flip_harmonics!(hamiltonian(h))
+    return h
+end
 
 #end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1486,6 +1486,9 @@ Base.copy(h::Hamiltonian) = Hamiltonian(
 copy_lattice(h::Hamiltonian) = Hamiltonian(
     copy(lattice(h)), blockstructure(h), harmonics(h), bloch(h))
 
+copy_harmonics_shallow(h::Hamiltonian) = Hamiltonian(
+    lattice(h), blockstructure(h), copy(harmonics(h)), bloch(h))
+
 function LinearAlgebra.ishermitian(h::Hamiltonian)
     for hh in h.harmonics
         isassigned(h, -hh.dn) || return false
@@ -1555,6 +1558,9 @@ LinearAlgebra.ishermitian(h::ParametricHamiltonian) =
 
 copy_lattice(p::ParametricHamiltonian) = ParametricHamiltonian(
     copy_lattice(p.hparent), p.h, p.modifiers, p.allptrs, p.allparams)
+
+copy_harmonics_shallow(p::ParametricHamiltonian) = ParametricHamiltonian(
+    copy_harmonics_shallow(p.hparent), copy_harmonics_shallow(p.h), p.modifiers, p.allptrs, p.allparams)
 
 #endregion
 #endregion

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -443,5 +443,12 @@ end
     g´ = Quantica.minimal_callsafe_copy(g);
     @test g´(0, o = 0)[] == g(0, o = 0)[]
     @test g´(0, o = 1)[] == g(0, o = 1)[]
-
+    # two leads from the same g
+    glead = LP.honeycomb() |> onsite(4) - hopping(1) |> supercell(4,2) |> supercell((0,-1))|> greenfunction(GS.Schur(boundary = 0));
+    g = LP.honeycomb() |> onsite(4) - hopping(1) |> supercell(4,5) |> supercell |>
+       attach(glead, region = r -> SA[-√3/2,1/2]' * r > 3.5, reverse = true) |>
+       attach(glead, region = r -> SA[-√3/2,1/2]' * r < 0, reverse = false) |> greenfunction;
+    @test g.contacts.selfenergies[2].solver.hlead[(0,)] === g.contacts.selfenergies[1].solver.hlead[(0,)]
+    @test g.contacts.selfenergies[2].solver.hlead[(1,)] === g.contacts.selfenergies[1].solver.hlead[(-1,)]
+    @test g.contacts.selfenergies[2].solver.hlead[(-1,)] === g.contacts.selfenergies[1].solver.hlead[(1,)]
 end

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -1,5 +1,5 @@
 using Quantica: Hamiltonian, ParametricHamiltonian, BarebonesOperator, OrbitalSliceMatrix, SparseMatrixCSC,
-      sites, nsites, nonsites, nhoppings, coordination, flat, hybrid, transform!, nnz, nonzeros
+      sites, nsites, nonsites, nhoppings, coordination, flat, hybrid, transform!, nnz, nonzeros, dcell, harmonics
 
 @testset "basic hamiltonians" begin
     presets = (LatticePresets.linear, LatticePresets.square, LatticePresets.triangular, LatticePresets.honeycomb,
@@ -402,6 +402,7 @@ end
     @test sites(lattice(h´)) == [SA[0,0], SA[0,1]]
     h´´ = reverse(h´)
     @test bravais_matrix(lattice(h´´)) == - bravais_matrix(lattice(h´))
+    @test all(dcell(har´´) == -dcell(har´) for (har´´, har´) in zip(harmonics(h´´), harmonics(h´)))
     @test reverse!(h´´) === h´´
     @test bravais_matrix(lattice(h´´)) == bravais_matrix(lattice(h´))
 end


### PR DESCRIPTION
When doing `reverse!` of an `h::AbstractHamiltonian` we just flip the lattice Bravais vectors currently. However it is also necessary to flip the `dcell` of each harmonic. This PR does just that. It also ensures that upon use of `reverse!` in Schur solvers we do the appropriate shallow copy of the Harmonics vector in `h` (shallow = does not copy harmonic matrices, only vector of them) before reversing them. This only affects visulatization, since all the solver needs are the matrices, that remain untouched.

Example
```julia
julia> glead = LP.honeycomb() |> hopping(1) |> supercell((1, -1)) |> greenfunction(GS.Schur(boundary = 0));

julia> g = LP.honeycomb() |> hopping(1) |> supercell((4, -4)) |> supercell |>
              attach(glead, region = r -> r[1] < 0.1 && r[2] > 0.1, reverse = true) |> 
              attach(glead, region = r -> r[1] >= 3.1 && r[2] < 1, reverse = false) |> greenfunction;

julia> qplot(g)
```

Before:
![Screenshot 2024-05-03 at 11 28 57](https://github.com/pablosanjose/Quantica.jl/assets/4310809/c6a15524-7322-4003-bda5-b40467645fdd)

This PR:
![Screenshot 2024-05-03 at 11 30 10](https://github.com/pablosanjose/Quantica.jl/assets/4310809/2253bfef-c365-4960-b456-532ea7c37a41)

