### PR TITLE
add DensityMatrixSchurSolver

### DIFF
--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -589,7 +589,7 @@ end
 
 broaden_bounding_box(mm::Tuple) = mm
 
-boundary_bounding_box(::Val{0}) = (SVector{0,Int}(), SVector{0,Int}())
+boundary_bounding_box(::Val{L}) where {L} = (zero(SVector{L,Int}), zero(SVector{L,Int}))
 
 function boundary_bounding_box(::Val{L}, (dir, cell), bs...) where {L}
     cell´ = isfinite(cell) ? cell + 1 : 0

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1830,6 +1830,7 @@ The generic integration algorithm allows for the following `opts` (see also `jos
 
 Currently, the following GreenSolvers implement dedicated densitymatrix algorithms:
 
+- `GS.Schur`: based on numerical integration over Bloch phase. Boundaries are not currently supported. No `opts`.
 - `GS.Spectrum`: based on summation occupation-weigthed eigenvectors. No `opts`.
 - `GS.KPM`: based on the Chebyshev expansion of the Fermi function. Currently only works for zero temperature and only supports `nothing` contacts (see `attach`). No `opts`.
 

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -99,11 +99,11 @@ end
 
 function (d::DensityMatrixSpectrumSolver)(mu, kBT; params...)
     vi = d.psirows
-    vj´ = d.psicols' .* fermi.(d.es .- mu, kBT)
+    vj´ = d.psicols' .* fermi.(d.es .- mu, inv(kBT))
     return vi * vj´
 end
 
-# if the orbindices cover all the unit cell, use matrices instead of
+# if the orbindices cover all the unit cell, use matrices instead of views
 _maybe_view(m, oi) = length(oi) == size(m, 1) ? m : view(m, oi, :)
 
 #endregion

--- a/src/types.jl
+++ b/src/types.jl
@@ -1442,6 +1442,8 @@ function blockstructure(lat::Lattice{T}, h::AbstractHamiltonian{T}, hs::Abstract
     return OrbitalBlockStructure{B}(orbitals, subsizes)
 end
 
+similar_Matrix(h::AbstractHamiltonian{T}) where {T} =
+    Matrix{Complex{T}}(undef, flatsize(h), flatsize(h))
 
 ## Hamiltonian
 

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -408,6 +408,29 @@ end
     # test fermi at zero temperature
     g = LP.linear() |> hopping(1) |> supercell(3) |> supercell |> greenfunction(GS.Spectrum())
     @test ρ = diag(densitymatrix(g[])()) ≈ [0.5, 0.5, 0.5]
+
+    # test DensityMatrixSchurSolver
+    g = LP.honeycomb() |> hamiltonian(hopping(I) + @onsite((; w=0) -> SA[w 1; 1 -w], sublats = :A), orbitals = (2,1)) |> supercell((1,-1), region = r->-2<r[2]<2) |> greenfunction(GS.Schur());
+    ρ0 = densitymatrix(g[cells = (SA[2],SA[4]), sublats = :A], (-4, 4))
+    ρ = densitymatrix(g[cells = (SA[2],SA[4]), sublats = :A])
+    ρ0sol = ρ(0.2, 0.3)
+    ρsol = ρ(0.2, 0.3)
+    @test maximum(abs, ρ0sol - ρsol) < 1e-7
+    @test typeof(ρ0sol) == typeof(ρsol)
+    ρ0sol = ρ()
+    ρsol = ρ()
+    @test maximum(abs, ρ0sol - ρsol) < 1e-7
+    @test typeof(ρ0sol) == typeof(ρsol)
+    ρ = densitymatrix(g[sites(:)])
+    ρ0 = densitymatrix(g[sites(:)])
+    ρ0sol = ρ(0.2, 0.3)
+    ρsol = ρ(0.2, 0.3)
+    @test maximum(abs, ρ0sol - ρsol) < 1e-7
+    @test typeof(ρ0sol) == typeof(ρsol)
+    ρ0sol = ρ()
+    ρsol = ρ()
+    @test maximum(abs, ρ0sol - ρsol) < 1e-7
+    @test typeof(ρ0sol) == typeof(ρsol)
 end
 
 @testset "mean-field models" begin


### PR DESCRIPTION
Adds a new dedicated `densitymatrix` solver for `GreenSolvers.Schur` that is quite a bit faster than the fallback.
It relies on numerical integration over Bloch phase
$$ρ_{dn} = (1/2π) \int_{-\pi}^\pi d ϕ f(H(ϕ)-µI)e^{i dn \phi}$$
where the Fermi function `f` of the Bloch Hamiltonian is computed via exact diagonalization at each Bloch phase ϕ. A crucial trick for performance is to divide the integration interval [-π,π] into segments separated by Fermi points (because in those, f changes abruptly). This is achieved with `Quantica.schur_eigvals` which doesn't require a full Schur decomposition, just `eigvals!(A, B)` of the AB pencil.

Demo:
```
julia> glead = LP.honeycomb() |> hopping(1)+@onsite((; w=0) -> w) |> supercell((1, -1), region = r->-4<r[2]<4) |> greenfunction(GS.Schur());

julia> ρ = densitymatrix(glead[]);  # new solver

julia> ρ0 = densitymatrix(glead[], (-3,3));  # fallback solver

julia> @btime ρ();
  5.980 ms (5272 allocations: 8.64 MiB)

julia> @btime ρ0();
  108.306 ms (138586 allocations: 172.20 MiB)

julia> maximum(abs, ρ() - ρ0())
3.3203146215798895e-7

```

Caveat: currently only GreenFunctions without boundaries are implemented, since I don't yet know how to generalize the algorithm to include them.