### PR TITLE
EigenSolvers as extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -58,11 +58,12 @@ StaticArrays = "0.12.3, 0.13, 1.0"
 julia = "^1.9"
 
 [extras]
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ArnoldiMethod", "FFTW", "Arpack", "CairoMakie"]
+test = ["Test", "LinearMaps", "ArnoldiMethod", "KrylovKit", "Arpack", "CairoMakie"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,6 @@ authors = ["Pablo San-Jose"]
 version = "1.1.0"
 
 [deps]
-ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
-Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
@@ -13,9 +11,7 @@ ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 FrankenTuples = "7e584817-dab4-53a9-9a51-4037a36b0ad0"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 IntervalTrees = "524e6230-43b7-53ae-be76-1e9e4d08d11b"
-KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
@@ -29,9 +25,17 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 [weakdeps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
+ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 
 [extensions]
 QuanticaMakieExt = "Makie"
+QuanticaLinearMapsExt = "LinearMaps"
+QuanticaArnoldiMethodExt = "ArnoldiMethod"
+QuanticaKrylovKitExt = "KrylovKit"
+QuanticaArpackExt = "Arpack"
 
 [compat]
 ArnoldiMethod = "0.2, 0.3, 0.4"

--- a/ext/QuanticaArnoldiMethodExt.jl
+++ b/ext/QuanticaArnoldiMethodExt.jl
@@ -1,0 +1,12 @@
+module QuanticaArnoldiMethodExt
+
+using ArnoldiMethod
+using Quantica
+
+function Quantica.get_eigen(solver::ES.ArnoldiMethod, mat)
+    pschur, _ = ArnoldiMethod.partialschur(mat; solver.kwargs...)
+    ε, Ψ = ArnoldiMethod.partialeigen(pschur)
+    return ε, Ψ
+end
+
+end # module

--- a/ext/QuanticaArnoldiMethodExt.jl
+++ b/ext/QuanticaArnoldiMethodExt.jl
@@ -2,6 +2,7 @@ module QuanticaArnoldiMethodExt
 
 using ArnoldiMethod
 using Quantica
+import Quantica: get_eigen
 
 function Quantica.get_eigen(solver::ES.ArnoldiMethod, mat)
     pschur, _ = ArnoldiMethod.partialschur(mat; solver.kwargs...)

--- a/ext/QuanticaArpackExt.jl
+++ b/ext/QuanticaArpackExt.jl
@@ -2,6 +2,7 @@ module QuanticaArpackExt
 
 using Arpack
 using Quantica
+import Quantica: get_eigen
 
 function Quantica.get_eigen(solver::ES.ArnoldiMethod, mat)
     ε, Ψ, _ = Arpack.eigs(mat; solver.kwargs...)

--- a/ext/QuanticaArpackExt.jl
+++ b/ext/QuanticaArpackExt.jl
@@ -1,0 +1,11 @@
+module QuanticaArpackExt
+
+using Arpack
+using Quantica
+
+function Quantica.get_eigen(solver::ES.ArnoldiMethod, mat)
+    ε, Ψ, _ = Arpack.eigs(mat; solver.kwargs...)
+    return ε, Ψ
+end
+
+end # module

--- a/ext/QuanticaArpackExt.jl
+++ b/ext/QuanticaArpackExt.jl
@@ -4,7 +4,7 @@ using Arpack
 using Quantica
 import Quantica: get_eigen
 
-function Quantica.get_eigen(solver::ES.ArnoldiMethod, mat)
+function Quantica.get_eigen(solver::ES.Arpack, mat)
     ε, Ψ, _ = Arpack.eigs(mat; solver.kwargs...)
     return ε, Ψ
 end

--- a/ext/QuanticaKrylovKitExt.jl
+++ b/ext/QuanticaKrylovKitExt.jl
@@ -2,6 +2,7 @@ module QuanticaKrylovKitExt
 
 using KrylovKit
 using Quantica
+import Quantica: get_eigen
 
 function Quantica.get_eigen(solver::ES.KrylovKit, mat)
     ε, Ψ, _ = KrylovKit.eigsolve(mat, solver.params...; solver.kwargs...)

--- a/ext/QuanticaKrylovKitExt.jl
+++ b/ext/QuanticaKrylovKitExt.jl
@@ -1,0 +1,11 @@
+module QuanticaKrylovKitExt
+
+using KrylovKit
+using Quantica
+
+function Quantica.get_eigen(solver::ES.KrylovKit, mat)
+    ε, Ψ, _ = KrylovKit.eigsolve(mat, solver.params...; solver.kwargs...)
+    return ε, Ψ
+end
+
+end # module

--- a/ext/QuanticaLinearMapsExt.jl
+++ b/ext/QuanticaLinearMapsExt.jl
@@ -1,0 +1,21 @@
+module QuanticaLinearMapsExt
+
+using LinearMaps
+using LinearAlgebra
+using SparseArrays
+using Quantica
+
+function Quantica.get_eigen(solver::ES.ShiftInvert, mat::AbstractSparseMatrix{T}) where {T<:Number}
+    mat´ = mat - I * solver.origin
+    F = lu(mat´)
+    lmap = LinearMap{T}((x, y) -> ldiv!(x, F, y), size(mat)...;
+        ismutating = true, ishermitian = false)
+    ε, Ψ = solver.eigensolver(lmap)
+    @. ε = 1 / ε + solver.origin
+    return ε, Ψ
+end
+
+Quantica.get_eigen(::ES.ShiftInvert, mat) =
+    Quantica.argerror("ShiftInvert requires a sparse matrix input, but received a matrix of type $(typeof(mat)).")
+
+end # module

--- a/ext/QuanticaLinearMapsExt.jl
+++ b/ext/QuanticaLinearMapsExt.jl
@@ -4,6 +4,7 @@ using LinearMaps
 using LinearAlgebra
 using SparseArrays
 using Quantica
+import Quantica: get_eigen
 
 function Quantica.get_eigen(solver::ES.ShiftInvert, mat::AbstractSparseMatrix{T}) where {T<:Number}
     mat´ = mat - I * solver.origin

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -94,4 +94,4 @@ function qplotdefaults end
 qplot(args...; kw...) =
     argerror("No plotting backend found or unexpected argument. Forgot to do e.g. `using GLMakie`?")
 
-end
+end # module

--- a/src/solvers/eigen.jl
+++ b/src/solvers/eigen.jl
@@ -9,7 +9,7 @@ module EigenSolvers
 using FunctionWrappers: FunctionWrapper
 using SparseArrays: SparseMatrixCSC, AbstractSparseMatrix
 using Quantica: Eigen, I, lu, ldiv!
-using Quantica: Quantica, AbstractEigenSolver, ensureloaded, SVector, SMatrix,
+using Quantica: Quantica, AbstractEigenSolver, SVector, SMatrix,
                 sanitize_eigen, call!_output
 
 #endregion

--- a/src/solvers/green.jl
+++ b/src/solvers/green.jl
@@ -28,7 +28,7 @@
 
 module GreenSolvers
 
-using Quantica: Quantica, AbstractGreenSolver, ensureloaded, I
+using Quantica: Quantica, AbstractGreenSolver, I
 
 struct SparseLU <:AbstractGreenSolver end
 
@@ -46,31 +46,8 @@ struct KPM{B<:Union{Missing,NTuple{2}},A} <: AbstractGreenSolver
     padfactor::Float64  # for automatically computed bandrange
 end
 
-function KPM(; order = 100, bandrange = missing, padfactor = 1.01, kernel = I)
-    bandrange === missing && ensureloaded(:Arpack)
-    return KPM(order, bandrange, kernel, padfactor)
-end
-
-# Used in kpm.jl
-function bandrange_arpack(h::AbstractMatrix{T}) where {T}
-    R = real(T)
-    ϵL, _ = Quantica.Arpack.eigs(h, nev=1, tol=1e-4, which = :LR);
-    ϵR, _ = Quantica.Arpack.eigs(h, nev=1, tol=1e-4, which = :SR);
-    ϵmax = R(real(ϵL[1]))
-    ϵmin = R(real(ϵR[1]))
-    return (ϵmin, ϵmax)
-end
-
-## Alternative bandrange, requires ensureloaded(:ArnoldiMethod) in KPM constructor
-# function bandrange_arnoldi(h::AbstractMatrix{T}) where {T}
-#     # ensureloaded(:ArnoldiMethod)
-#     R = real(T)
-#     decompl, _ = Quantica.ArnoldiMethod.partialschur(h, nev=1, tol=1e-4, which = Main.ArnoldiMethod.LR());
-#     decomps, _ = Quantica.ArnoldiMethod.partialschur(h, nev=1, tol=1e-4, which = Main.ArnoldiMethod.SR());
-#     ϵmax = R(real(decompl.eigenvalues[1]))
-#     ϵmin = R(real(decomps.eigenvalues[1]))
-#     return (ϵmin, ϵmax)
-# end
+KPM(; order = 100, bandrange = missing, padfactor = 1.01, kernel = I) =
+    KPM(order, bandrange, kernel, padfactor)
 
 struct Spectrum{K} <:AbstractGreenSolver
     spectrumkw::K

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -165,11 +165,21 @@ band_ceter_halfwidth(_, (emin, emax), padfactor) = 0.5 * (emin + emax), 0.5 * (e
 
 function band_ceter_halfwidth(h, ::Missing, padfactor)
     @warn "Computing spectrum bounds... Consider using the `bandrange` option for faster performance."
-    # (ϵmin, ϵmax) = GS.bandrange_arnoldi(h)
-    (emin, emax) = GS.bandrange_arpack(h)
+    (emin, emax) = bandrange(h)  # requires an extension
     @warn  "Computed real bandrange = ($emin, $emax)"
     bandCH = 0.5 * (emin + emax), 0.5 * (emax - emin) * padfactor
     return bandCH
+end
+
+function bandrange(h::AbstractMatrix{T}) where {T}
+    R = real(T)
+    # ϵL, _ = get_eigen(ES.Arpack(nev=1, tol=1e-4, which = :LR), h)
+    # ϵR, _ = get_eigen(ES.Arpack(nev=1, tol=1e-4, which = :SR), h)
+    ϵL, _ = get_eigen(ES.ArnoldiMethod(nev=1, tol=1e-4, which = :LR), h)
+    ϵR, _ = get_eigen(ES.ArnoldiMethod(nev=1, tol=1e-4, which = :SR), h)
+    ϵmax = R(real(ϵL[1]))
+    ϵmin = R(real(ϵR[1]))
+    return (ϵmin, ϵmax)
 end
 
 function contact_basis(h::AbstractHamiltonian{T}, contacts) where {T}

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -227,19 +227,3 @@ function merged_mul!(C::SparseMatrixCSC{<:Number}, bs::OrbitalBlockStructure{B},
 end
 
 #endregion
-
-############################################################################################
-# Dynamic package loader
-#   This is in global Quantica scope to avoid name collisions
-#   We also `import` instead of `using` to avoid collisions between different backends
-#region
-
-function ensureloaded(package::Symbol)
-    if !isdefined(Quantica, package)
-        @warn("Required package $package not loaded. Loading...")
-        eval(:(import $package))
-    end
-    return nothing
-end
-
-#endregion

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -1,5 +1,14 @@
 using Quantica: nsubbands, nvertices, nedges, nsimplices
 using Random
+
+@testset "extensions not loaded" begin
+    solver = ES.ShiftInvert(ES.ArnoldiMethod(), 0.0)
+    h = HP.graphene() |> supercell(10)
+    @test_throws ArgumentError spectrum(h, (0,0); solver)
+    solver = ES.Arpack(nev = 2)
+    @test_throws ArgumentError spectrum(h, (0,0); solver)
+end
+
 using LinearMaps, ArnoldiMethod, KrylovKit, Arpack
 
 @testset "basic bandstructures" begin

--- a/test/test_bandstructure.jl
+++ b/test/test_bandstructure.jl
@@ -1,5 +1,6 @@
 using Quantica: nsubbands, nvertices, nedges, nsimplices
 using Random
+using LinearMaps, ArnoldiMethod, KrylovKit, Arpack
 
 @testset "basic bandstructures" begin
     h = LatticePresets.honeycomb() |> hamiltonian(hopping(-1))

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -1,6 +1,8 @@
 using Quantica: GreenFunction, GreenSlice, GreenSolution, zerocell, CellOrbitals, ncontacts,
     solver
 
+using ArnoldiMethod  # for KPM bandrange
+
 function testgreen(h, s; kw...)
     ω = 0.2
     g = greenfunction(h, s)


### PR DESCRIPTION
Closes #297

We introduce extensions for LinearMaps, ArnoldiMethod, KrylovKit and Arpack.

This has revealed yet another issue with FunctionWrappers.jl, similar to #235, but not quite the same. When attempting to call `spectrum(h; solver = ...)` with an unloaded extension for the solver, it would error as expected. Then, after loading the relevant package, calling `spectrum` again would yield a weird error such as
```
julia> spectrum(h, (0,), solver = ES.ShiftInvert(ES.ArnoldiMethod(nev = 4), 0))
ERROR: TypeError: in cfunction, expected Union{}, got a value of type LinearAlgebra.Eigen{ComplexF64, ComplexF64, Matrix{ComplexF64}, Vector{ComplexF64}}
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/FunctionWrappers/Q5cBx/src/FunctionWrappers.jl:137 [inlined]
 [2] do_ccall
   @ ~/.julia/packages/FunctionWrappers/Q5cBx/src/FunctionWrappers.jl:125 [inlined]
 [3] FunctionWrapper
   @ ~/.julia/packages/FunctionWrappers/Q5cBx/src/FunctionWrappers.jl:144 [inlined]
 [4] AppliedEigenSolver
   @ ~/.julia/dev/Quantica/src/types.jl:1716 [inlined]
 [5] spectrum(h::Quantica.ParametricHamiltonian{Float64, 1, 1, ComplexF64, Tuple{…}}, φs::Tuple{Int64}; solver::Quantica.EigenSolvers.ShiftInvert{Int64, Quantica.EigenSolvers.ArnoldiMethod{…}}, transform::Missing, kw::@Kwargs{})
   @ Quantica ~/.julia/dev/Quantica/src/bands.jl:11
 [6] top-level scope
   @ REPL[5]:1
```

This likely stems from FunctionWrappers' issues with the world age system, and is, interestingly, fixed by the same approach as #235. However this impacts also aarch64 (macos) and Julia 1.11, unlike #235, so it seems to be more general.

We have implemented a cheaper fix, trying for the moment to avoid excising FunctionWrappers altogether (which, admittedly, improves compile and runtime performance in Quantica). It consists of always running the wrapped eigensolver with a `dryrun=true` option to make it almost free, but force it to compile.