### PR TITLE
Serializer/AppliedSerializer refactor

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -165,7 +165,6 @@ apply(m::ParametricModel, lat) = ParametricModel(apply.(terms(m), Ref(lat)))
 #   shifts is useful for supercell, where we want to keep the r, dr of original lat
 #region
 
-# Any means it could be wrapped in Intrablock or Interblock
 apply(m::BlockModifier, h::Hamiltonian, shifts = missing) =
     apply(parent(m), h, shifts, block(m, blockstructure(h)))
 
@@ -265,6 +264,87 @@ push_pointer!(ptrs::Vector{T}, tup::T, _...) where {T<:Tuple} = push!(ptrs, tup)
 
 apply_shift(::Missing, r, _) = r
 apply_shift(shifts, r, i) = r - shifts[i]
+
+#endregion
+
+############################################################################################
+# apply Serializers
+#   construct pointer Dictionaries of the form
+#   [dn => [(ptr, ptr´, serialrng)...]...] or [dn => [(ptr, serialrng)...]...]
+#   depending on whether enc/dec is a tuple of functions (onsite/hopping) or a function
+#   ptr, ptr´ are pointers to nonzeros of h[unflat(dn)] and h[unflat(-dn)] respectively
+#   serialrng is the index range inside the serialized vector corresponding to the pointer
+#region
+
+# we support shifts, for supercell, but not oblock, for BlockModifiers
+function apply(s::Serializer, h::AbstractHamiltonian, shifts = missing)
+    ptrs = serializer_pointers(h, s.encoder, s.selectors, shifts)
+    len = update_serial_ranges!(ptrs, h, s)
+    return AppliedSerializer(s, h, ptrs, len)
+end
+
+## serializer_pointers
+
+serializer_pointers(h::ParametricHamiltonian, args...) =
+    serializer_pointers(hamiltonian(h), args...)
+
+function serializer_pointers(h::Hamiltonian{<:Any,<:Any,L}, encoder, selectors, shifts) where {L}
+    E = serializer_pointer_type(encoder)
+    skip_reverse = encoder isa Tuple
+    d = Dictionary{SVector{L,Int},Vector{E}}()
+    for har in harmonics(h)
+        dn = dcell(har)
+        if skip_reverse && haskey(d, -dn)
+            ptrs = E[]
+        else
+            ptrs = push_and_merge_pointers!(E[], h, har, shifts, selectors...)
+        end
+        insert!(d, dn, ptrs)
+    end
+    return d
+end
+
+serializer_pointer_type(::Function) = Tuple{Int,UnitRange{Int}}
+serializer_pointer_type(::Tuple{Function,Function}) = Tuple{Int,Int,UnitRange{Int}}
+
+function push_and_merge_pointers!(ptrs, h, har, shifts, sel::Selector, selectors...)
+    asel = apply(sel, lattice(h))
+    push_pointers!(ptrs, h, har, asel, shifts)
+    return push_and_merge_pointers!(ptrs, h, har, shifts, selectors...)
+end
+
+push_and_merge_pointers!(ptrs, h, har, shifts) = unique!(sort!(ptrs))
+
+# gets called by push_pointers!, see Modifier section above
+function push_pointer!(ptrs::Vector{Tuple{Int,Int,UnitRange{Int}}}, (p, _...), h, har, (row, col))
+    dn = dcell(har)
+    if row == col && iszero(dn)
+        p´ = p
+    elseif row > col && iszero(dn)
+        return ptrs     # we don't want duplicates
+    else
+        mat´ = h[unflat(-dn)]
+        p´ = sparse_pointer(mat´, (col, row)) # adjoint element
+    end
+     # we leave the serial range empty (initialized later), as it depends on the encoder
+    push!(ptrs, (p, p´, 1:0))
+    return ptrs
+end
+
+push_pointer!(ptrs::Vector{Tuple{Int,UnitRange{Int}}}, (p, _...), _...) = push!(ptrs, (p, 1:0))
+
+## update_serial_ranges!
+
+function update_serial_ranges!(ptrs, h, s::Serializer)
+    enc = encoder(s)
+    offset = 0
+    for (har, ps) in zip(harmonics(h), ptrs), (i, p) in enumerate(ps)
+        len = length(serialize_core(h, har, p, enc))
+        ps[i] = (Base.front(p)..., offset+1:offset+len)
+        offset += len
+    end
+    return offset   # we return the total length of the serialized vector
+end
 
 #endregion
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -278,7 +278,7 @@ apply_shift(shifts, r, i) = r - shifts[i]
 
 # we support shifts, for supercell, but not oblock, for BlockModifiers
 function apply(s::Serializer, h::AbstractHamiltonian, shifts = missing)
-    ptrs = serializer_pointers(h, s.encoder, s.selectors, shifts)
+    ptrs = serializer_pointers(h, encoder(s), selectors(s), shifts)
     len = update_serial_ranges!(ptrs, h, s)
     return AppliedSerializer(s, h, ptrs, len)
 end

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -178,6 +178,8 @@ parametric(h::Hamiltonian, m::AnyAbstractModifier, ms::AnyAbstractModifier...) =
 parametric(p::ParametricHamiltonian, ms::AnyAbstractModifier...) =
     parametric!(copy(p), ms...)
 
+parametric!(p::ParametricHamiltonian) = p
+
 # This should not be exported, because it doesn't modify p in place (because of modifiers)
 function parametric!(p::ParametricHamiltonian, ms::AnyModifier...)
     ams = apply.(ms, Ref(parent(p)))

--- a/src/serializer.jl
+++ b/src/serializer.jl
@@ -6,8 +6,8 @@
 
 ## serializer_pointers
 
-serializer_pointers(h::ParametricHamiltonian, selectors...) =
-    serializer_pointers(hamiltonian(h), selectors...)
+serializer_pointers(h::ParametricHamiltonian, encoder, selectors...) =
+    serializer_pointers(hamiltonian(h), encoder, selectors...)
 
 function serializer_pointers(h::Hamiltonian{<:Any,<:Any,L}, encoder, selectors...) where {L}
     E = serializer_pointer_type(encoder)

--- a/src/serializer.jl
+++ b/src/serializer.jl
@@ -1,78 +1,15 @@
 
 ############################################################################################
-# Serializer
+# AppliedSerializer
 #   support for serialization of Hamiltonians and ParametricHamiltonians
 #region
 
-## serializer_pointers
-
-serializer_pointers(h::ParametricHamiltonian, encoder, selectors...) =
-    serializer_pointers(hamiltonian(h), encoder, selectors...)
-
-function serializer_pointers(h::Hamiltonian{<:Any,<:Any,L}, encoder, selectors...) where {L}
-    E = serializer_pointer_type(encoder)
-    skip_reverse = encoder isa Tuple
-    d = Dictionary{SVector{L,Int},Vector{E}}()
-    for har in harmonics(h)
-        dn = dcell(har)
-        if skip_reverse && haskey(d, -dn)
-            ptrs = E[]
-        else
-            ptrs = push_and_merge_pointers!(E[], h, har, selectors...)
-        end
-        insert!(d, dn, ptrs)
-    end
-    return d
-end
-
-serializer_pointer_type(::Function) = Tuple{Int,UnitRange{Int}}
-serializer_pointer_type(::Tuple{Function,Function}) = Tuple{Int,Int,UnitRange{Int}}
-
-function push_and_merge_pointers!(ptrs, h, har, sel::Selector, selectors...)
-    asel = apply(sel, lattice(h))
-    push_pointers!(ptrs, h, har, asel)
-    return push_and_merge_pointers!(ptrs, h, har, selectors...)
-end
-
-push_and_merge_pointers!(ptrs, h, har) = unique!(sort!(ptrs))
-
-# gets called by push_pointers! in apply.jl
-function push_pointer!(ptrs::Vector{Tuple{Int,Int,UnitRange{Int}}}, (p, _...), h, har, (row, col))
-    dn = dcell(har)
-    if row == col && iszero(dn)
-        p´ = p
-    elseif row > col && iszero(dn)
-        return ptrs     # we don't want duplicates
-    else
-        mat´ = h[unflat(-dn)]
-        p´ = sparse_pointer(mat´, (col, row)) # adjoint element
-    end
-     # we leave the serial range empty (initialized later), as it depends on the encoder
-    push!(ptrs, (p, p´, 1:0))
-    return ptrs
-end
-
-push_pointer!(ptrs::Vector{Tuple{Int,UnitRange{Int}}}, (p, _...), _...) = push!(ptrs, (p, 1:0))
-
-## update_serial_ranges!
-
-function update_serial_ranges!(s::Serializer)
-    h = hamiltonian(s)
-    enc = encoder(s)
-    offset = 0
-    for (har, ptrs) in zip(harmonics(h), pointers(s)), (i, p) in enumerate(ptrs)
-        len = length(serialize_core(h, har, p, enc))
-        ptrs[i] = (Base.front(p)..., offset+1:offset+len)
-        offset += len
-    end
-    return Serializer(s, offset)
-end
-
 ## serialize and serialize!
 
-function serialize!(v, s::Serializer; kw...)
+function serialize!(v, s::AppliedSerializer; kw...)
     @boundscheck check_serializer_length(s, v)
-    h = call!(s.h; kw...)
+    h0 = parent_hamiltonian(s)
+    h = call!(h0; kw...)
     enc = encoder(s)
     i = 0
     for (har, ptrs) in zip(harmonics(h), pointers(s)), p in ptrs
@@ -84,7 +21,7 @@ function serialize!(v, s::Serializer; kw...)
     return v
 end
 
-serialize(s::Serializer{T}; kw...) where {T} =
+serialize(s::AppliedSerializer{T}; kw...) where {T} =
     serialize!(Vector{T}(undef, length(s)), s; kw...)
 
 # encoder::Function
@@ -119,13 +56,13 @@ check_serializer_length(s, v) = length(v) == length(s) ||
 
 ## deserialize!
 
-deserialize(s::Serializer, v; kw...) = deserialize!(s(; kw...), v)
+deserialize(s::AppliedSerializer, v; kw...) = deserialize!(s(; kw...), v)
 
-deserialize!(s::Serializer, v; kw...) = deserialize!(call!(s; kw...), v)
+deserialize!(s::AppliedSerializer, v; kw...) = deserialize!(call!(s; kw...), v)
 
-function deserialize!(s::Serializer{<:Any,<:Hamiltonian}, v)
+function deserialize!(s::AppliedSerializer{<:Any,<:Hamiltonian}, v)
     @boundscheck check_serializer_length(s, v)
-    h = hamiltonian(s)
+    h = parent_hamiltonian(s)
     dec = decoder(s)
     for (har, ptrs) in zip(harmonics(h), pointers(s))
         isempty(ptrs) && continue
@@ -181,8 +118,8 @@ end
 
 ## check
 
-function check(s::Serializer{T}; params...) where {T}
-    h = hamiltonian(s)
+function check(s::AppliedSerializer{T}; params...) where {T}
+    h = parent_hamiltonian(s)
     h(; params...) == deserialize(s, serialize(s; params...); params...) ||
         argerror("decoder/encoder pair do not seem to be correct inverse of each other")
     return nothing

--- a/src/show.jl
+++ b/src/show.jl
@@ -177,6 +177,7 @@ Base.summary(::ParametricHoppingTerm{N}) where {N} = "ParametricHoppingTerm{Para
 Base.summary(::OnsiteModifier{N}) where {N} = "OnsiteModifier{ParametricFunction{$N}}:"
 Base.summary(::HoppingModifier{N}) where {N} = "HoppingModifier{ParametricFunction{$N}}:"
 
+
 display_argument_type(t) = is_spatial(t) ? "spatial" : "non-spatial"
 
 #endregion
@@ -555,19 +556,35 @@ Base.summary(::IJVBuilder{T,E,L}) where {T,E,L} =
 # Serializer
 #region
 
-function Base.show(io::IO, s::Serializer{T}) where {T}
+function Base.show(io::IO, s::Serializer)
     i = get(io, :indent, "")
     ioindent = IOContext(io, :indent => i * "  ")
     print(io, i, summary(s), "\n",
-"$i  Object            : $(nameof(typeof(hamiltonian(s))))
-$i  Output eltype     : $T
+"$i  Stream parameter  : :$(only(parameters(s)))
+$i  Output eltype     : $(eltype(s))
+$i  Encoder/Decoder   : $(display_encdec(encoder(s)))")
+end
+
+function Base.show(io::IO, s::AppliedSerializer)
+    i = get(io, :indent, "")
+    ioindent = IOContext(io, :indent => i * "  ")
+    print(io, i, summary(s), "\n",
+"$i  Object            : $(nameof(typeof(parent_hamiltonian(s))))
+$i  Object parameters : $(display_parameters(s))
+$i  Stream parameter  : :$(only(parameters(s)))
+$i  Output eltype     : $(eltype(s))
 $i  Encoder/Decoder   : $(display_encdec(encoder(s)))
 $i  Length            : $(length(s))")
 end
 
-Base.summary(::Serializer{T}) where {T} =
-    "Serializer{$T} : encoder/decoder of matrix elements into a collection of scalars"
+Base.summary(::Serializer) =
+    "Serializer : translation rules used to build an AppliedSerializer"
+Base.summary(::AppliedSerializer) =
+    "AppliedSerializer : translator between a selection of of matrix elements of an AbstractHamiltonian and a collection of scalars"
 
 display_encdec(::Function) = "Single"
 display_encdec(::Tuple) = "(Onsite, Hopping pairs)"
+
+display_parameters(s::AppliedSerializer{<:Any,<:Hamiltonian}) = "none"
+display_parameters(s::AppliedSerializer{<:Any,<:ParametricHamiltonian}) = string(parameters(parent_hamiltonian(s)))
 #endregion

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -61,9 +61,6 @@ end
 copy_ifnotmissing(::Missing) = missing
 copy_ifnotmissing(d) = copy(d)
 
-merge_parameters!(p, m, ms...) = merge_parameters!(append!(p, parameters(m)), ms...)
-merge_parameters!(p) = unique!(sort!(p))
-
 typename(::T) where {T} = nameof(T)
 
 chopsmall(x::T, atol = sqrt(eps(real(T)))) where {T<:Real} =

--- a/src/types.jl
+++ b/src/types.jl
@@ -1437,7 +1437,12 @@ call!(s::Serializer; kw...) = Serializer(s.type, call!(s.h; kw...), s.selectors,
 
 (s::Serializer)(; kw...) = Serializer(s.type, s.h(; kw...), s.selectors, s.ptrs, s.encoder, s.decoder, s.len)
 
-(s::Serializer)(name::Symbol) = parametric!(hamiltonian(s), SerializerModifier(name, s))
+function (s::Serializer)(name::Symbol)
+    s´ = parametric(s)
+    return parametric!(hamiltonian(s´), SerializerModifier(name, s´))
+end
+
+parametric(s::Serializer) = Serializer(s.type, parametric(s.h), s.selectors, s.ptrs, s.encoder, s.decoder, s.len)
 
 hamiltonian(s::Serializer) = s.h
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -758,14 +758,16 @@ end
 #region
 
 abstract type AbstractModifier end
+abstract type Modifier <: AbstractModifier end
+abstract type AppliedModifier <: AbstractModifier end
 
-struct OnsiteModifier{N,S<:SiteSelector,F<:ParametricFunction{N}} <: AbstractModifier
+struct OnsiteModifier{N,S<:SiteSelector,F<:ParametricFunction{N}} <: Modifier
     f::F
     selector::S
     spatial::Bool
 end
 
-struct AppliedOnsiteModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:SiteSelector,P<:CellSitePos} <: AbstractModifier
+struct AppliedOnsiteModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:SiteSelector,P<:CellSitePos} <: AppliedModifier
     parentselector::S        # unapplied selector, needed to grow a ParametricHamiltonian
     blocktype::Type{B}  # These are needed to cast the modification to the sublat block type
     f::F
@@ -774,13 +776,13 @@ struct AppliedOnsiteModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:SiteSele
     spatial::Bool   # If true, f is a function of position r. Otherwise it takes a single CellSite
 end
 
-struct HoppingModifier{N,S<:HopSelector,F<:ParametricFunction{N}} <: AbstractModifier
+struct HoppingModifier{N,S<:HopSelector,F<:ParametricFunction{N}} <: Modifier
     f::F
     selector::S
     spatial::Bool  # If true, f is a function of positions r, dr. Otherwise it takes two CellSite's
 end
 
-struct AppliedHoppingModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:HopSelector,P<:CellSitePos} <: AbstractModifier
+struct AppliedHoppingModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:HopSelector,P<:CellSitePos} <: AppliedModifier
     parentselector::S        # unapplied selector, needed to grow a ParametricHamiltonian
     blocktype::Type{B}  # These are needed to cast the modification to the sublat block type
     f::F
@@ -788,9 +790,6 @@ struct AppliedHoppingModifier{B,N,R<:SVector,F<:ParametricFunction{N},S<:HopSele
     # [[(ptr, r, dr, si, sj, (norbs, norbs´)), ...], ...] for each selected hop on each harmonic
     spatial::Bool  # If true, f is a function of positions r, dr. Otherwise it takes two CellSite's
 end
-
-const Modifier = Union{OnsiteModifier,HoppingModifier}
-const AppliedModifier = Union{AppliedOnsiteModifier,AppliedHoppingModifier}
 
 #region ## Constructors ##
 
@@ -1371,13 +1370,98 @@ Base.parent(u::HybridInds) = u.inds
 #endregion
 
 ############################################################################################
-# Hamiltonian  -  see hamiltonian.jl for methods
+# AbstractHamiltonian type
 #region
 
 abstract type AbstractHamiltonian{T,E,L,B} end
 
 const AbstractHamiltonian0D{T,E,B} = AbstractHamiltonian{T,E,0,B}
 const AbstractHamiltonian1D{T,E,B} = AbstractHamiltonian{T,E,1,B}
+
+#endregion
+
+############################################################################################
+# Serializer  -  see serializer.jl
+#   A Serializer is used to contruct an iterator that encodes Hamiltonian matrix elements in
+#   a way that can be turned into a Vector and back into a Hamiltonian
+#   encoder = s -> vec and its inverse decoder = vec -> s translate between s::B and some
+#   iterable, typically some AbstractVector. B<:SMatrixView is translated to its parent.
+#   Both can also be tuples (s->vec, (s, s´)->vec) and viceversa if the translation
+#   of hoppings requires both the hopping s and its conjugate s´.
+#region
+
+struct Serializer{T,H<:AbstractHamiltonian,P<:Dictionary,S,E,D}
+    type::Type{T}
+    h::H
+    selectors::S    # unapplied selectors, needed to rebuild ptrs if h changes (e.g. supercell)
+    ptrs::P         # [dn => [(ptr, ptr´, serialrng)...]...]or [dn => [(ptr, serialrng)...]...]
+                    # depending on encoder, (Function, Function) or Function.
+    encoder::E
+    decoder::D
+    len::Int
+end
+
+struct SerializerModifier{S<:Serializer} <: AppliedModifier
+    paramname::Symbol
+    s::S
+end
+
+#region ## Constructors ##
+
+serializer(T, h; kw...) = serializer(T, h, siteselector(), hopselector(); kw...)
+
+function serializer(T::Type, h::H, sel::Selector, selectors...; encoder = identity, decoder = identity) where {H<:AbstractHamiltonian}
+    check_encoder_decoder(encoder, decoder)
+    ptrs = serializer_pointers(h, encoder, sel, selectors...)
+    s = Serializer(T, h, selectors, ptrs, encoder, decoder, 0)
+    s´ = update_serial_ranges!(s)
+    return s´
+end
+
+serializer(h::AbstractHamiltonian{T}, args...; kw...) where {T} =
+    serializer(Complex{T}, h, siteselector(), hopselector(); kw...)
+
+
+Serializer(s::Serializer, len) = Serializer(s.type, s.h, s.selectors, s.ptrs, s.encoder, s.decoder, len)
+
+check_encoder_decoder(encoder::Function, decoder::Function) = nothing
+check_encoder_decoder(encoder::Tuple{Function,Function}, decoder::Tuple{Function,Function}) =
+    nothing
+check_encoder_decoder(_, _) = argerror("encoder and decoder must be both functions or both tuples of functions")
+
+#endregion
+
+#region ## API ##
+
+call!(s::Serializer; kw...) = Serializer(s.type, call!(s.h; kw...), s.selectors, s.ptrs, s.encoder, s.decoder, s.len)
+
+(s::Serializer)(; kw...) = Serializer(s.type, s.h(; kw...), s.selectors, s.ptrs, s.encoder, s.decoder, s.len)
+
+(s::Serializer)(name::Symbol) = parametric!(hamiltonian(s), SerializerModifier(name, s))
+
+hamiltonian(s::Serializer) = s.h
+
+pointers(s::Serializer) = s.ptrs
+
+encoder(s::Serializer) = s.encoder
+
+decoder(s::Serializer) = s.decoder
+
+selectors(s::Serializer) = s.selectors
+
+Base.length(s::Serializer) = s.len
+
+serializer(sm::SerializerModifier) = sm.s
+
+parameters(sm::SerializerModifier) = (sm.paramname,)
+
+#endregion
+
+#endregion
+
+############################################################################################
+# Hamiltonian  -  see hamiltonian.jl for methods
+#region
 
 struct Hamiltonian{T,E,L,B} <: AbstractHamiltonian{T,E,L,B}
     lattice::Lattice{T,E,L}
@@ -1587,7 +1671,6 @@ struct Mesh{V,S} <: AbstractMesh{V,S}    # S-1 is the manifold dimension
     simps::Vector{NTuple{S,Int}}         # list of simplices, each a group of S neighboring
                                          # vertex indices
 end
-
 
 #region ## Constructors ##
 
@@ -2324,6 +2407,7 @@ end
 SparseArrays.nnz(h::BarebonesOperator) = sum(har -> nnz(matrix(har)), harmonics(h))
 
 #endregion
+#endregion
 
 ############################################################################################
 # OrbitalSliceArray: array type over orbital slice - see specialmatrices.jl
@@ -2345,71 +2429,5 @@ OrbitalSliceMatrix(m::AbstractMatrix, axes) = OrbitalSliceArray(m, axes)
 orbaxes(a::OrbitalSliceArray) = a.orbaxes
 
 Base.parent(a::OrbitalSliceArray) = a.parent
-
-#endregion
-
-
-############################################################################################
-# Serializer  -  see serializer.jl
-#   A Serializer is used to contruct an iterator that encodes Hamiltonian matrix elements in
-#   a way that can be turned into a Vector and back into a Hamiltonian
-#   encoder = s -> vec and its inverse decoder = vec -> s translate between s::B and some
-#   iterable, typically some AbstractVector. B<:SMatrixView is translated to its parent.
-#   Both can also be tuples (s->vec, (s, s´)->vec) and viceversa if the translation
-#   of hoppings requires both the hopping s and its conjugate s´.
-#region
-
-struct Serializer{T,H<:AbstractHamiltonian,P<:Dictionary,E,D}
-    type::Type{T}
-    h::H
-    ptrs::P     # [dn => [(ptr, ptr´, serialrng)...]...]or [dn => [(ptr, serialrng)...]...]
-                # depending on encoder, (Function, Function) or Function.
-    encoder::E
-    decoder::D
-    len::Int
-end
-
-#region ## Constructors ##
-
-serializer(T, h; kw...) = serializer(T, h, siteselector(), hopselector(); kw...)
-
-function serializer(T::Type, h::H, sel::Selector, selectors...; encoder = identity, decoder = identity) where {H<:AbstractHamiltonian}
-    check_encoder_decoder(encoder, decoder)
-    ptrs = serializer_pointers(h, encoder, sel, selectors...)
-    s = Serializer(T, h, ptrs, encoder, decoder, 0)
-    s´ = update_serial_ranges!(s)
-    return s´
-end
-
-serializer(h::AbstractHamiltonian{T}, args...; kw...) where {T} =
-    serializer(Complex{T}, h, siteselector(), hopselector(); kw...)
-
-
-Serializer(s::Serializer, len) = Serializer(s.type, s.h, s.ptrs, s.encoder, s.decoder, len)
-
-check_encoder_decoder(encoder::Function, decoder::Function) = nothing
-check_encoder_decoder(encoder::Tuple{Function,Function}, decoder::Tuple{Function,Function}) =
-    nothing
-check_encoder_decoder(_, _) = argerror("encoder and decoder must be both functions or both tuples of functions")
-
-#endregion
-
-#region ## API ##
-
-call!(s::Serializer; kw...) = Serializer(s.type, call!(s.h; kw...), s.ptrs, s.encoder, s.decoder, s.len)
-
-(s::Serializer)(; kw...) = Serializer(s.type, s.h(; kw...), s.ptrs, s.encoder, s.decoder, s.len)
-
-hamiltonian(s::Serializer) = s.h
-
-pointers(s::Serializer) = s.ptrs
-
-encoder(s::Serializer) = s.encoder
-
-decoder(s::Serializer) = s.decoder
-
-Base.length(s::Serializer) = s.len
-
-#endregion
 
 #endregion

--- a/src/types.jl
+++ b/src/types.jl
@@ -1448,10 +1448,9 @@ pointers(s::AppliedSerializer) = s.ptrs
 Base.length(s::AppliedSerializer) = s.len
 
 Base.eltype(s::AppliedSerializer) = eltype(s.parent)
+Base.eltype(::Serializer{T}) where {T} = T
 
 Base.parent(s::AppliedSerializer) = s.parent
-
-serializer(sm::AppliedSerializer) = sm.parent
 
 selectors(s::Serializer) = s.selectors
 selectors(s::AppliedSerializer) = selectors(s.parent)
@@ -1465,7 +1464,6 @@ encoder(s::AppliedSerializer) = encoder(s.parent)
 decoder(s::Serializer) = s.decoder
 decoder(s::AppliedSerializer) = decoder(s.parent)
 
-Base.eltype(::Serializer{T}) where {T} = T
 
 #endregion
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -588,7 +588,8 @@ end
     @test all((hss[(0,)], hss[(-1,)], hss[(1)]) .== (SA[0 2; 1 0], SA[0 0; 3 0], SA[0 4; 0 0]))
 
     # Supercell transform
-    hs = h1 |> serializer(ComplexF64, siteselector(), parameter = :onsite)
+    hs = LP.linear() |> hopping((r, dr) -> im*dr[1]) - @onsite((r; U = 2) -> U) |>
+         serializer(ComplexF64, siteselector(), parameter = :onsite)
     @test hs(onsite = SA[1], U = 3)[()] == SA[1;;]
     hs´ = supercell(hs, 2)
     @test hs´(onsite = SA[10,20], U = 3)[()] == SA[10 -im; im 20]

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -40,6 +40,9 @@
         @test nothing === show(stdout, sites(SA[0], :))
     end
     h = first(hs)
+    @test nothing === show(stdout, serializer(h))
+    @test nothing === show(stdout, serializer(Float64))
+    @test nothing === show(stdout, serializer(Float64, decoder = (identity, v -> (v, v)), encoder = (identity, (s1, s2)->s1)))
     g = greenfunction(supercell(h) |> attach(@onsite(ω -> im*I)) |> attach(nothing))
     @test nothing === show(stdout, josephson(g[1], 2))
     @test nothing === show(stdout, densitymatrix(g[1], 2))
@@ -53,4 +56,5 @@
     w = EP.wannier90("wannier_test_tb.dat");
     @test nothing === show(stdout, w)
     @test nothing === show(stdout, position(w))
+
 end


### PR DESCRIPTION
This makes `Serializer <: Modifier` and `AppliedSerializer <: AppliedModifier`, thus extending the functionality of `@onsite!` and `@hopping!`. 

In particular we can now do the following
- Define a `Serializer` decoupled from an `AbstractHamiltonian`, e.g. `s = serializer(Float64, selectors...; parameter = :stream, decoder = ..., encoder = ...)`
- Apply it to a given `h::AbstractHamiltonian` to obtain an `as::AppliedSerializer`, e.g. `as = serializer(Float64, h, selectors...; kw...)`
- Use `s` instead as a `Modifier`, e.g `ph = h |> s`, where `ph` is now a `ParametricHamiltonian` with a new parameter named `:stream` (name chosen when defining `s`) that accepts serialized vectors, and overwrites the chosen matrix elements.
- Turn an `as::AppliedSerializer` into a `ph´::ParametricHamiltonian` by doing `ph´ = hamiltonian(as)`. This `ph´` is the same as `Quantica.parent_hamiltonian(as)` but with `as` as an extra parametric modifier, and parameter name `stream`.