### PR TITLE
Relink serializers upon ParametricHamiltonian copy

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1647,8 +1647,11 @@ blocktype(h::ParametricHamiltonian) = blocktype(parent(h))
 
 lattice(h::ParametricHamiltonian) = lattice(hamiltonian(h))
 
-minimal_callsafe_copy(p::ParametricHamiltonian) = ParametricHamiltonian(
-    p.hparent, minimal_callsafe_copy(p.h), p.modifiers, p.allptrs, p.allparams)
+function minimal_callsafe_copy(p::ParametricHamiltonian)
+    h´ = minimal_callsafe_copy(p.h)
+    modifiers´ = maybe_relink_serializer.(p.modifiers, Ref(h´))
+    return ParametricHamiltonian(p.hparent, h´, modifiers´, p.allptrs, p.allparams)
+end
 
 Base.parent(h::ParametricHamiltonian) = h.hparent
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -569,6 +569,8 @@ end
     @test hs isa ParametricHamiltonian
     @test hamiltonian(h1) == hamiltonian(hs)
     @test hs.modifiers[2].h === hs.h
+    hs´ = Quantica.minimal_callsafe_copy(hs)
+    @test hs´.modifiers[2].h === hs´.h
 
     # Serializer call
     s = serializer(h1)


### PR DESCRIPTION
We forgot to relink AppliedSerializer modifiers when doing`minimal_callsafe_copy(h::ParametricHamiltonian)`, which would make e.g. `bands` to ignore these modifiers.