### PR TITLE
Bug fixes in parametric and/or multiorbital `combine`

### DIFF
--- a/src/builders.jl
+++ b/src/builders.jl
@@ -204,6 +204,11 @@ function IJVBuilder(lat::Lattice{T}, hams::AbstractHamiltonian...) where {T}
 end
 
 (::Type{IJVBuilderWithModifiers})(lat, orbitals) = IJVBuilder(lat, orbitals, Any[])
+# add modifiers to existing builder
+(::Type{IJVBuilderWithModifiers})(b::IJVBuilder) =
+    IJVBuilder(b.lat, b.blockstruct, b.harmonics, b.kdtrees, Any[])
+# only if it doesn't already have modifiers!
+(::Type{IJVBuilderWithModifiers})(b::IJVBuilderWithModifiers) = b
 
 push_ijvharmonics!(builder, ::OrbitalBlockStructure) = builder
 push_ijvharmonics!(builder, hars::Vector{<:IJVHarmonic}) = copy!(builder.harmonics, hars)

--- a/src/models.jl
+++ b/src/models.jl
@@ -195,8 +195,4 @@ function blockindices(hams::NTuple{N,Any}) where {N}
     return inds
 end
 
-block(m::Intrablock, b::OrbitalBlockStructure) = flatrange(b, block(m))
-block(m::Interblock, b::OrbitalBlockStructure) = flatrange.(Ref(b), block(m))
-block(::Union{AbstractModel,AbstractModifier}, b...) = missing
-
 #endregion

--- a/src/types.jl
+++ b/src/types.jl
@@ -847,12 +847,12 @@ Base.parent(m::AppliedHoppingModifier) = HoppingModifier(m.f, m.parentselector, 
 
 struct Interblock{M<:Union{AbstractModel,AbstractModifier},N}
     parent::M
-    block::NTuple{N,UnitRange{Int}}  # May be two or more ranges
+    block::NTuple{N,UnitRange{Int}}  # May be two or more ranges of site indices
 end
 
 struct Intrablock{M<:Union{AbstractModel,AbstractModifier}}
     parent::M
-    block::UnitRange{Int}
+    block::UnitRange{Int}            # A single range of site indices
 end
 
 const AnyAbstractModifier = Union{AbstractModifier,Interblock{<:AbstractModifier},Intrablock{<:AbstractModifier}}


### PR DESCRIPTION
#278 had some bugs. Notably, when combining two AbstractHamiltonians with a parametric coupling, the coupling modifiers lost their block filters, so they became applied everywhere, unlike the base coupling model, which was only applied in the coupling block. Also, the block indices were converted to orbital space, while they were assumed to be site indices when applying them to a given Hamiltonian. 

All this lead to a host of issues when using combine with parametric couplings, but even with non parametric coupling between multiorbital systems. 