### PR TITLE
Add `Quantica.integrand` for `josephson` currents

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2094,7 +2094,7 @@ josephson
 """
     Quantica.integrand(J::Josephson, kBT = 0)
 
-Returns the integrand `j::JosephsonDensity` whose integral over frequency yields the
+Return the integrand `j::JosephsonDensity` whose integral over frequency yields the
 Josephson current `J(kBT)`. To evaluate the `j` for a given `ω` and parameters, use `j(ω;
 params...)`, or `call!(j, ω; params...)` for its mutating (non-allocating) version.
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2092,6 +2092,16 @@ julia> J(0.0)
 josephson
 
 """
+    Quantica.integrand(J::Josephson, kBT = 0)
+
+Returns the integrand `j::JosephsonDensity` whose integral over frequency yields the
+Josephson current `J(kBT)`. To evaluate the `j` for a given `ω` and parameters, use `j(ω;
+params...)`, or `call!(j, ω; params...)` for its mutating (non-allocating) version.
+
+"""
+integrand
+
+"""
     OrbitalSliceArray <: AbstractArray
 
 A type of `AbstractArray` defined over a set of orbitals (see also `orbaxes`). It wraps a
@@ -2366,7 +2376,7 @@ true
 deserialize!
 
 """
-    gaps(h::Hamiltonian1D{T}, µ = 0; atol = eps(T))
+    Quantica.gaps(h::Hamiltonian1D{T}, µ = 0; atol = eps(T))
 
 Compute the energy gaps of a 1D Hamiltonian `h` at chemical potential `µ`. The result is a
 `Vector{T}` of the local minima of the `|ϵ(ϕ) - µ|`, where `ϵ(ϕ)` is the energy band closest
@@ -2396,8 +2406,8 @@ julia> Quantica.gaps(h(U=2))
 gaps
 
 """
-    decay_lengths(g::GreenFunctionSchurLead, µ = 0; reverse = false)
-    decay_lengths(h::AbstractHamiltonian1D, µ = 0; reverse = false)
+    Quantica.decay_lengths(g::GreenFunctionSchurLead, µ = 0; reverse = false)
+    Quantica.decay_lengths(h::AbstractHamiltonian1D, µ = 0; reverse = false)
 
 Compute the decay lengths of evanescent modes of a 1D `AbstractHamiltonian` `h` or a 1D
 `GreenFunction` `g` using the `GS.Schur` solver. The modes decaying towards positive

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -348,6 +348,8 @@ function testjosephson(g0)
     J2 = josephson(g0[2], 4; phases = subdiv(0, pi, 10))
     @test all(>=(0), Quantica.chopsmall.(J1()))
     @test all(((j1, j2) -> ≈(j1, j2, atol = 0.000001)).(J1(), J2()))
+    j = Quantica.integrand(J1)
+    @test Quantica.call!(j, 0.2+0.3im) isa Vector
 end
 
 @testset "greenfunction observables" begin


### PR DESCRIPTION
Provides an unexported method `j = integrand(J::Josephson, kBT = 0.0)` to obtain the function whose integral over `ω` yields the Josephson current `J(kBT)`, where `J = josephson(...)`. The integrand can be called with `Quantica.call!(j, ω; params...)` (mutating) of `j(ω; params...)` (allocating)