### PR TITLE
Bring in deprecated `permute!!` and `permutecols!!`

### DIFF
--- a/src/sanitizers.jl
+++ b/src/sanitizers.jl
@@ -169,8 +169,8 @@ function sorteigs!(ϵ::AbstractVector, ψ::AbstractMatrix)
     p = Vector{Int}(undef, length(ϵ))
     p´ = similar(p)
     sortperm!(p, ϵ, by = real, alg = Base.DEFAULT_UNSTABLE)
-    Base.permute!!(ϵ, copy!(p´, p))
-    Base.permutecols!!(ψ, copy!(p´, p))
+    permute!!(ϵ, copy!(p´, p))
+    permutecols!!(ψ, copy!(p´, p))
     return ϵ, ψ
 end
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -108,6 +108,60 @@ lengths_to_offsets(v::NTuple{<:Any,Integer}) = (0, cumsum(v)...)
 lengths_to_offsets(v) = prepend!(cumsum(v), 0)
 lengths_to_offsets(f::Function, v) = prepend!(accumulate((i,j) -> i + f(j), v; init = 0), 0)
 
+# Taken from Base julia, now deprecated there
+function permute!!(a, p::AbstractVector{<:Integer})
+    Base.require_one_based_indexing(a, p)
+    count = 0
+    start = 0
+    while count < length(a)
+        ptr = start = findnext(!iszero, p, start+1)::Int
+        temp = a[start]
+        next = p[start]
+        count += 1
+        while next != start
+            a[ptr] = a[next]
+            p[ptr] = 0
+            ptr = next
+            next = p[next]
+            count += 1
+        end
+        a[ptr] = temp
+        p[ptr] = 0
+    end
+    a
+end
+
+# like permute!! applied to each row of a, in-place in a (overwriting p).
+function permutecols!!(a::AbstractMatrix, p::AbstractVector{<:Integer})
+    Base.require_one_based_indexing(a, p)
+    count = 0
+    start = 0
+    while count < length(p)
+        ptr = start = findnext(!iszero, p, start+1)::Int
+        next = p[start]
+        count += 1
+        while next != start
+            swapcols!(a, ptr, next)
+            p[ptr] = 0
+            ptr = next
+            next = p[next]
+            count += 1
+        end
+        p[ptr] = 0
+    end
+    a
+end
+
+function swapcols!(a::AbstractMatrix, i, j)
+    i == j && return
+    cols = axes(a,2)
+    @boundscheck i in cols || throw(BoundsError(a, (:,i)))
+    @boundscheck j in cols || throw(BoundsError(a, (:,j)))
+    for k in axes(a,1)
+        @inbounds a[k,i],a[k,j] = a[k,j],a[k,i]
+    end
+end
+
 #endregion
 
 ############################################################################################


### PR DESCRIPTION
These functions are now deprecated in 1.11. We have brought them into Quantica.