### PR TITLE
ZeroField

### DIFF
--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -33,7 +33,7 @@ export sublat, bravais_matrix, lattice, sites, supercell, hamiltonian,
        conductance, josephson, ldos, current, transmission, densitymatrix,
        OrbitalSliceArray, OrbitalSliceVector, OrbitalSliceMatrix, orbaxes, siteindexdict,
        serializer, serialize, serialize!, deserialize!, deserialize,
-       meanfield
+       meanfield, zerofield
 
 export LatticePresets, LP, RegionPresets, RP, HamiltonianPresets, HP, ExternalPresets, EP
 export EigenSolvers, ES, GreenSolvers, GS

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2602,6 +2602,12 @@ interaction potentials, and `ρ` is the density matrix evaluated at specific che
 potential and temperature. Also `ν = ifelse(nambu, 0.5, 1.0)`, and `v_F(0) = v_H(0) = U`,
 where `U` is the onsite interaction.
 
+    zerofield
+
+An sigleton of type `ZeroField` that represents a zero-values field. It has the property
+that it returns zero no matter how it is indexed (`zerofield[inds...] = 0.0 * I`), so it is
+useful as a default value in a non-spatial model involving mean fields.
+
 ## Keywords
 
 - `potential`: charge-charge potential to use for both Hartree and Fock. Can be a number or a function of position. Default: `1
@@ -2625,26 +2631,34 @@ e.g. `ϕ[sites(2:3), sites(1)]`, see `OrbitalSliceArray` for details.
 # Examples
 
 ```jldoctest
-julia> g = HP.graphene(orbitals = 2, a0 = 1) |> supercell((1,-1)) |> greenfunction;
+julia> model = hopping(I) - @onsite((i; phi = zerofield) --> phi[i]);
 
-julia> M = meanfield(g; selector = (; range = 1), charge = I)
+julia> g = LP.honeycomb() |> hamiltonian(model, orbitals = 2) |> supercell((1,-1)) |> greenfunction;
+
+julia> M = meanfield(g; selector = (; range = 1), charge = I, potential = 0.05)
 MeanField{SMatrix{2, 2, ComplexF64, 4}} : builder of Hartree-Fock mean fields
   Charge type      : 2 × 2 blocks (ComplexF64)
   Hartree pairs    : 14
   Mean field pairs : 28
 
-julia> phi = M(0.2, 0.3);
+julia> phi0 = M(0.2, 0.3);
 
-julia> phi[sites(1), sites(2)] |> Quantica.chopsmall
+julia> phi0[sites(1), sites(2)] |> Quantica.chopsmall
 2×2 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
- 0.00239416+0.0im             ⋅
-            ⋅      0.00239416+0.0im
+ 0.00109527+0.0im             ⋅
+            ⋅      0.00109527+0.0im
 
-julia> phi[sites(1)] |> Quantica.chopsmall
+julia> phi0[sites(1)] |> Quantica.chopsmall
 2×2 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
- 5.53838+0.0im          ⋅
-         ⋅      5.53838+0.0im
+ 0.296672+0.0im           ⋅
+          ⋅      0.296672+0.0im
 
+julia> phi1 = M(0.2, 0.3; phi = phi0);
+
+julia> phi1[sites(1), sites(2)] |> Quantica.chopsmall
+2×2 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
+ 0.00307712+0.0im             ⋅
+            ⋅      0.00307712+0.0im
 ```
 """
 meanfield

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2602,12 +2602,6 @@ interaction potentials, and `ρ` is the density matrix evaluated at specific che
 potential and temperature. Also `ν = ifelse(nambu, 0.5, 1.0)`, and `v_F(0) = v_H(0) = U`,
 where `U` is the onsite interaction.
 
-    zerofield
-
-An sigleton of type `ZeroField` that represents a zero-values field. It has the property
-that it returns zero no matter how it is indexed (`zerofield[inds...] = 0.0 * I`), so it is
-useful as a default value in a non-spatial model involving mean fields.
-
 ## Keywords
 
 - `potential`: charge-charge potential to use for both Hartree and Fock. Can be a number or a function of position. Default: `1
@@ -2631,7 +2625,7 @@ e.g. `ϕ[sites(2:3), sites(1)]`, see `OrbitalSliceArray` for details.
 # Examples
 
 ```jldoctest
-julia> model = hopping(I) - @onsite((i; phi = zerofield) --> phi[i]);
+julia> model = hopping(I) - @onsite((i; phi = zerofield) --> phi[i]);  # see zerofield docstring
 
 julia> g = LP.honeycomb() |> hamiltonian(model, orbitals = 2) |> supercell((1,-1)) |> greenfunction;
 
@@ -2660,5 +2654,22 @@ julia> phi1[sites(1), sites(2)] |> Quantica.chopsmall
  0.00307712+0.0im             ⋅
             ⋅      0.00307712+0.0im
 ```
+
+# See also
+    `zerofield`, `densitymatrix`, `OrbitalSliceMatrix`
 """
 meanfield
+
+"""
+        zerofield
+
+An sigleton of type `ZeroField` that represents a zero-valued field. It has the property
+that it returns zero no matter how it is indexed (`zerofield[inds...] = 0.0 * I`), so it is
+useful as a default value in a non-spatial model involving mean fields. See `meanfield` for
+a usage example.
+
+# See also
+    `meanfield`
+
+"""
+zerofield

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -549,9 +549,6 @@ Base.getindex(a::OrbitalSliceMatrix, i::C, j::C = i) where {B,C<:CellSitePos{<:A
 Base.checkbounds(::Type{Bool}, a::OrbitalSliceMatrix, i::CellSitePos, j::CellSitePos) =
     checkbounds(Bool, first(orbaxes(a)), i) && checkbounds(Bool, last(orbaxes(a)), j)
 
-# it also returns 0I if the matrix is missing (useful for meanfield models)
-Base.getindex(::Missing, ::CellSitePos, ::CellSitePos...) = 0I
-
 function Base.view(a::OrbitalSliceMatrix, i::AnyCellSites, j::AnyCellSites = i)
     rowslice, colslice = orbaxes(a)
     i´, j´ = apply(i, lattice(rowslice)), apply(j, lattice(colslice))

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -69,6 +69,7 @@ chopsmall(x::C, atol = sqrt(eps(real(C)))) where {C<:Complex} =
     chopsmall(real(x), atol) + im*chopsmall(imag(x), atol)
 chopsmall(xs, atol) = chopsmall.(xs, Ref(atol))
 chopsmall(xs) = chopsmall.(xs)
+chopsmall(xs::UniformScaling, atol...) = I * chopsmall(xs.λ, atol...)
 
 # Flattens matrix of Matrix{<:Number} into a matrix of Number's
 function mortar(ms::AbstractMatrix{M}) where {C<:Number,M<:Matrix{C}}

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -158,7 +158,7 @@ end
     @test_throws ArgumentError h()
 
     # out of bounds indexing
-    h = LP.linear() |>  @hopping((i,j; phi = missing) --> phi[i, j]);
+    h = LP.linear() |>  @hopping((i,j; phi = zerofield) --> phi[i, j]);
     ϕ = h[cells = 0]
     @test h(phi = ϕ) isa Hamiltonian
 end


### PR DESCRIPTION
We change `missing` as the default value for missing mean field arrays (i.e. the seed non-interacting case) by the singleton `zerofield = ZeroField()`. It has the property that it returns `0.0 I` no matter how it is indexed. This is conceptually cleaner than overloading `Base.getindex(::Missing, ::CellSitePos, ::CellSitePos...)` as we did before.

We also add some numerical stabilization to the mean field machinery to make the default behaviour more predictable.