### PR TITLE
Revert "Bugfix: ensure full dealiasing of lattices in attach"

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1623,14 +1623,6 @@ Base.copy(h::Hamiltonian) = Hamiltonian(
 copy_lattice(h::Hamiltonian) = Hamiltonian(
     copy(lattice(h)), blockstructure(h), harmonics(h), bloch(h))
 
-function copy_lattice(h1::Hamiltonian, h2::Hamiltonian)
-    @assert lattice(h1) === lattice(h2)
-    lat´ = copy(lattice(h1))
-    h1´ = Hamiltonian(lat´, blockstructure(h1), harmonics(h1), bloch(h1))
-    h2´ = Hamiltonian(lat´, blockstructure(h2), harmonics(h2), bloch(h2))
-    return h1´, h2´
-end
-
 copy_harmonics_shallow(h::Hamiltonian) = Hamiltonian(
     lattice(h), blockstructure(h), copy(harmonics(h)), bloch(h))
 
@@ -1705,7 +1697,7 @@ LinearAlgebra.ishermitian(h::ParametricHamiltonian) =
     argerror("`ishermitian(::ParametricHamiltonian)` not supported, as the result can depend on the values of parameters.")
 
 copy_lattice(p::ParametricHamiltonian) = ParametricHamiltonian(
-    copy_lattice(p.hparent, p.h)..., p.modifiers, p.allptrs, p.allparams)
+    copy_lattice(p.hparent), p.h, p.modifiers, p.allptrs, p.allparams)
 
 copy_harmonics_shallow(p::ParametricHamiltonian) = ParametricHamiltonian(
     copy_harmonics_shallow(p.hparent), copy_harmonics_shallow(p.h), p.modifiers, p.allptrs, p.allparams)

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -561,13 +561,6 @@ end
     @test g.contacts.selfenergies[2].solver.hlead[(0,)] === g.contacts.selfenergies[1].solver.hlead[(0,)]
     @test g.contacts.selfenergies[2].solver.hlead[(1,)] === g.contacts.selfenergies[1].solver.hlead[(-1,)]
     @test g.contacts.selfenergies[2].solver.hlead[(-1,)] === g.contacts.selfenergies[1].solver.hlead[(1,)]
-
-    # ensure full dealiasing of lattices in attach
-    model = hopping(SA[1 0; 0 -1]) + @onsite((; µ = 0) -> SA[-µ 0; 0 µ])
-    h = LP.linear() |> hamiltonian(model, orbitals = 2)
-    glead = h |> greenfunction(GS.Schur(boundary = 0))
-    g = h |> attach(glead, cells = 1) |> greenfunction(GS.Schur(boundary = 0));
-    @test sites(lattice(h)) == [SA[0.0]]
 end
 
 @testset "meanfield" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -421,7 +421,7 @@ end
     @test h((1,2)) == h3((1,2))
     h = LP.square() |> @hopping((; t=1) -> t) |> supercell((2,0), (0, 1))
     h´ = h |> transform(r -> SA[r[2], r[1]])
-    @test sites(lattice(h´)) == sites(h´.h.lattice) == sites(lattice(parent(h´)))
+    @test sites(lattice(h´)) == sites(h´.h.lattice) != sites(lattice(parent(h´)))
     @test sites(lattice(h´)) == [SA[0,0], SA[0,1]]
     h´´ = reverse(h´)
     @test bravais_matrix(lattice(h´´)) == - bravais_matrix(lattice(h´))


### PR DESCRIPTION
Reverts pablosanjose/Quantica.jl#319

The fix here was wrong. It made `copy_lattice(ph::ParametricHamiltonian)` copy the lattices of the parent and the embedded `Hamiltonian`, instead of only the parent one. In fact, the right fix is to copy only the embedded Hamiltonian because `transform` and `translate` modify `lattice(ph)` only, not the parent one, which must remain untouched. As a result the two lattices need not coincide in general.