### PR TITLE
Symmetry enforcement in meanfield

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ makedocs(;
         canonical="https://pablosanjose.github.io/Quantica.jl",
         assets=["assets/custom.css"],
         size_threshold_ignore = [
-            api.md
+            "api.md"
         ]
     ),
     pages=[

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,9 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://pablosanjose.github.io/Quantica.jl",
         assets=["assets/custom.css"],
+        size_threshold_ignore = [
+            api.md
+        ]
     ),
     pages=[
         "Home" => "index.md",

--- a/docs/src/advanced/meanfield.md
+++ b/docs/src/advanced/meanfield.md
@@ -77,7 +77,7 @@ julia> using SIAMFANLEquations
 julia> h = LP.linear() |> supercell(4) |> onsite(r->r[1]) - hopping(1) + @onsite((i; phi = zerofield) --> phi[i]);
 
 julia> M = meanfield(greenfunction(h); onsite = 1, selector = (; range = 0), fock = nothing)
-MeanField{ComplexF64} : builder of Hartree-Fock mean fields
+MeanField{ComplexF64} : builder of Hartree-Fock-Bogoliubov mean fields
   Charge type      : scalar (ComplexF64)
   Hartree pairs    : 4
   Mean field pairs : 4

--- a/docs/src/advanced/meanfield.md
+++ b/docs/src/advanced/meanfield.md
@@ -50,6 +50,9 @@ Then, the self-consistent Hamiltonian is given by `h(; Φ = Φ_sol, params...)`.
 
 The key problem is to actually find the fixed point of the `M` function. The naive iteration above is not optimal, and often does not converge. To do a better job we should use a dedicated fixed-point solver.
 
+!!! note "Superconducting systems"
+    Superconducting (Nambu) Hamiltonians obey the same equations for the Hartree and Fock mean fields, with a proper definition of `Q`, and an extra `1/2` coefficient in the Hartree trace, see the `meanfield` doctring.
+
 ## Using an external fixed-point solver
 
 We now show how to approach such a fixed-point problem. We will employ an external library to solve generic fixed-point problems, and show how to make it work with Quantica `MeanField` objects efficiently. Many generic fixed-point solver backends exist. Here we use the SIAMFANLEquations.jl package. It provides a simple utility `aasol(f, x0)` that computes the solution of `f(x) = x` with initial condition `x0` using Anderson acceleration. This is an example of how it works to compute the fixed point of function `f(x) = 1 + atan(x)`

--- a/docs/src/advanced/meanfield.md
+++ b/docs/src/advanced/meanfield.md
@@ -81,6 +81,7 @@ MeanField{ComplexF64} : builder of Hartree-Fock mean fields
   Charge type      : scalar (ComplexF64)
   Hartree pairs    : 4
   Mean field pairs : 4
+  Nambu            : false
 
 julia> Φ0 = M(0.0, 0.0);
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -716,7 +716,7 @@ julia> h[sites(1), sites(2)]
  1.0+0.0im  0.0+0.0im
 
 julia> ph = h |> @hopping!((t; p = 3) -> p*t); ph[region = RP.square(1)]
-4×4 OrbitalSliceMatrix{ComplexF64,SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}:
+4×4 OrbitalSliceMatrix{ComplexF64,SparseMatrixCSC}:
  0.0+0.0im  0.0+0.0im  0.0+0.0im  3.0+0.0im
  0.0+0.0im  0.0+0.0im  3.0+0.0im  0.0+0.0im
  0.0+0.0im  3.0+0.0im  0.0+0.0im  0.0+0.0im
@@ -1684,7 +1684,7 @@ julia> gω[ss] == gs(0.1; t = 2)
 true
 
 julia> summary(gω[ss])
-"14×14 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}"
+"14×14 OrbitalSliceMatrix{ComplexF64,Array}"
 ```
 
 # See also
@@ -2302,7 +2302,7 @@ used e.g. to index another `OrbitalSliceArray` or to inspect the indices of each
 julia> g = HP.graphene(orbitals = 2) |> supercell((1,-1)) |> greenfunction;
 
 julia> d = ldos(g[cells = SA[0]])(2); summary(d)
-"8-element OrbitalSliceVector{Float64,Vector{Float64}}"
+"8-element OrbitalSliceVector{Float64,Array}"
 
 julia> a = only(orbaxes(d))
 OrbitalSliceGrouped{Float64,2,1} : collection of subcells of orbitals (grouped by sites) for a 1D lattice in 2D space
@@ -2632,8 +2632,11 @@ mean field, see above
 
     M(µ = 0, kBT = 0; params...)    # where M::MeanField
 
-Build an `Φ::OrbitalSliceMatrix` that can be indexed at different sites or pairs of sites,
-e.g. `ϕ[sites(2:3), sites(1)]`, see `OrbitalSliceArray` for details.
+Build an `Φ::CompressedOrbitalMatrix`, which is a special form of `OrbitalSliceMatrix` that
+can be indexed at pairs of individual sites, e.g. `ϕ[sites(2), sites(1)]` to return an
+`SMatrix`. This type of matrix is less flexible than `OrbitalSliceMatrix` but is fully
+static, and can encode symmetries. Its features are implementation details and are bound to
+change. The returned `Φ` is just meant to be used in non-spatial models, see Examples below.
 
 # Examples
 
@@ -2652,25 +2655,25 @@ MeanField{SMatrix{2, 2, ComplexF64, 4}} : builder of Hartree-Fock mean fields
 julia> phi0 = M(0.2, 0.3);
 
 julia> phi0[sites(1), sites(2)] |> Quantica.chopsmall
-2×2 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
- 0.00109527+0.0im             ⋅
-            ⋅      0.00109527+0.0im
+2×2 SMatrix{2, 2, ComplexF64, 4} with indices SOneTo(2)×SOneTo(2):
+ 0.00109527+0.0im         0.0+0.0im
+        0.0+0.0im  0.00109527+0.0im
 
 julia> phi0[sites(1)] |> Quantica.chopsmall
-2×2 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
- 0.296672+0.0im           ⋅
-          ⋅      0.296672+0.0im
+2×2 SMatrix{2, 2, ComplexF64, 4} with indices SOneTo(2)×SOneTo(2):
+ 0.296672+0.0im       0.0+0.0im
+      0.0+0.0im  0.296672+0.0im
 
 julia> phi1 = M(0.2, 0.3; phi = phi0);
 
 julia> phi1[sites(1), sites(2)] |> Quantica.chopsmall
-2×2 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 2 stored entries:
- 0.00307712+0.0im             ⋅
-            ⋅      0.00307712+0.0im
+2×2 SMatrix{2, 2, ComplexF64, 4} with indices SOneTo(2)×SOneTo(2):
+ 0.00307712+0.0im         0.0+0.0im
+        0.0+0.0im  0.00307712+0.0im
 ```
 
 # See also
-    `zerofield`, `densitymatrix`, `OrbitalSliceMatrix`
+    `zerofield`, `densitymatrix`
 """
 meanfield
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2599,10 +2599,10 @@ decay_lengths
 """
     meanfield(g::GreenFunction, args...; kw...)
 
-Build a `M::MeanField` object that can be used to compute the Hartree-Fock mean field `Φ`
-between selected sites interacting through a given charge-charge potential. The density
-matrix used to build the mean field is obtained with `densitymatrix(g[pair_selection],
-args...; kw...)`, see `densitymatrix` for details.
+Build a `M::MeanField` object that can be used to compute the Hartree-Fock-Bogoliubov mean
+field `Φ` between selected sites interacting through a given charge-charge potential. The
+density matrix used to build the mean field is obtained with
+`densitymatrix(g[pair_selection], args...; kw...)`, see `densitymatrix` for details.
 
 The mean field between site `i` and `j` is defined as `Φᵢⱼ = δᵢⱼ hartreeᵢ + fockᵢⱼ`, where
 
@@ -2646,7 +2646,7 @@ julia> model = hopping(I) - @onsite((i; phi = zerofield) --> phi[i]);  # see zer
 julia> g = LP.honeycomb() |> hamiltonian(model, orbitals = 2) |> supercell((1,-1)) |> greenfunction;
 
 julia> M = meanfield(g; selector = (; range = 1), charge = I, potential = 0.05)
-MeanField{SMatrix{2, 2, ComplexF64, 4}} : builder of Hartree-Fock mean fields
+MeanField{SMatrix{2, 2, ComplexF64, 4}} : builder of Hartree-Fock-Bogoliubov mean fields
   Charge type      : 2 × 2 blocks (ComplexF64)
   Hartree pairs    : 14
   Mean field pairs : 28

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2464,6 +2464,10 @@ where `h = Quantica.parent_hamiltonian(as)` is the `AbstractHamiltonian` used to
 Return an `Array` of the same eltype as `m` that contains all the stored matrix elements of
 `m`. See `deserialize` for the inverse operation.
 
+    serialize(T::Type, m::OrbitalSliceArray)
+
+Reinterpret `serialize(m)` as a collection with eltype `T`
+
 ## See also
     `serializer`, `serialize!`, `deserialize`, `deserialize!`
 
@@ -2492,7 +2496,8 @@ serialize(s)` restored (i.e. overwritten). See `serialize` for details.
 
 Reconstruct an `OrbitalSliceArray` with the same structure as `m` but with the matrix
 elements enconded in `v`. This `v` is typically the result of a `serialize` call to a
-another similar `m`, but the only requirement is that is has the correct size.
+another similar `m`, but the only requirement is that is has the correct size. If `v` has
+the wrong eltype, it will be reintepreted to match the eltype of `m`.
 
 ## See also
     `serializer`, `serialize`, `serialize!`, `deserialize!`
@@ -2611,12 +2616,13 @@ where `U` is the onsite interaction.
 
 ## Keywords
 
-- `potential`: charge-charge potential to use for both Hartree and Fock. Can be a number or a function of position. Default: `1
+- `potential`: charge-charge potential to use for both Hartree and Fock. Can be a number or a function of position. Default: `1`
 - `hartree`: charge-charge potential `v_H` for the Hartree mean field. Can be a number or a function of position. Overrides `potential`. Default: `potential`
 - `fock`: charge-charge potential `v_F` for the Fock mean field. Can be a number, a function of position or `nothing`. In the latter case all Fock terms (even onsite) will be dropped. Default: `hartree`
 - `onsite`: charge-charge onsite potential. Overrides both Hartree and Fock potentials for onsite interactions. Default: `hartree(0)`
 - `charge`: a number (in single-orbital systems) or a matrix (in multi-orbital systems) representing the charge operator on each site. Default: `I`
 - `nambu::Bool`: specifies whether the model is defined in Nambu space. In such case, `charge` should also be in Nambu space, typically `SA[1 0; 0 -1]` or similar. Default: `false`
+- `namburotation::Bool`: if `nambu == true` and spinful systems, specifies whether the spinor basis is `[c↑, c↓, c↓⁺, -c↑⁺]` (`namburotation = true`) or `[c↑, c↓, c↑⁺, c↓⁺]` (`namburotation = false`). Default: `false`
 - `selector::NamedTuple`: a collection of `hopselector` directives that defines the pairs of sites (`pair_selection` above) that interact through the charge-charge potential. Default: `(; range = 0)` (i.e. onsite)
 
 Any additional keywords `kw` are passed to the `densitymatrix` function used to compute the
@@ -2641,6 +2647,7 @@ MeanField{SMatrix{2, 2, ComplexF64, 4}} : builder of Hartree-Fock mean fields
   Charge type      : 2 × 2 blocks (ComplexF64)
   Hartree pairs    : 14
   Mean field pairs : 28
+  Nambu            : false
 
 julia> phi0 = M(0.2, 0.3);
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1595,13 +1595,20 @@ Build a `gs::GreenSlice` between sites specified by `src` and `dst`, which can t
 the forms above. Therefore, all the previous single-index slice forms correspond to a
 diagonal block `g[i, i]`.
 
-    g[diagonal(i, kernel = missing)]
+    g[diagonal(i; kernel = missing)]
 
-If `kernel = missing`, efficiently construct `diag(g[i, i])`. If `kernel` is a matrix,
-return `tr(g[site, site] * kernel)` over each site encoded in `i`. Note that if there are
-several orbitals per site, these will have different length (i.e. number of orbitals vs
-number of sites). See also `diagonal`.
+Build a diagonal `gs::GreenSlice` over sites specified by `i`. If `kernel = missing` the
+diagonal entries are `g[o, o]` for orbitals `o` in sites encoded in `i`. If `kernel` is a
+matrix, the diagonal elements are `tr(g[site, site] * kernel)` over each site `i`. Note that
+if there are several orbitals per site, `g[site, site]` may have different sizes (i.e.
+number of orbitals vs number of sites). Upon evaluating `gs(ω)`, the result is a `Diagonal`
+matrix wrapped in an `OrbitalSliceMatrix`, and spans full unit cells.See also `diagonal`.
 
+    g[sitepairs(; kernel = missing, hops...)]
+
+Like the above but for a selection of site pairs selected by `hopselector(; hops...)`. Upon
+evaluating `gs(ω)`, the result is a `SparseMatrixCSC` wrapped in an `OrbitalSliceMatrix`,
+and spans full unit cells. See also `sitepairs`.
 
     g(ω; params...)
 
@@ -1725,7 +1732,7 @@ If `kernel = Q` (a matrix) instead of `missing`, each diagonal block for multior
 For a `gω::GreenSolution`, `gω[diagonal(sel)] = diag(gω[sel, sel])`, although where possible
 the former computation is done more efficiently internally.
 
-    diagonal(kernel = missing, sites...)
+    diagonal(; kernel = missing, sites...)
 
 Equivalent to `diagonal(siteselector(; sites...); kernel)`
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2543,13 +2543,14 @@ true
 deserialize!
 
 """
-    Quantica.gaps(h::Hamiltonian1D{T}, µ = 0; atol = eps(T))
+    Quantica.gaps(h::Hamiltonian1D{T}, µ = 0; atol = eps(T), kw...)
 
 Compute the energy gaps of a 1D Hamiltonian `h` at chemical potential `µ`. The result is a
 `Vector{T}` of the local minima of the `|ϵ(ϕ) - µ|`, where `ϵ(ϕ)` is the energy band closest
 to `µ` and `ϕ ∈ [-π,π]` is the Bloch phase. The `atol` parameter is the absolute tolerance
 used to determine the local minima versus `ϕ`, which are computed using the `Schur` solver
-for 1D Hamiltonians.
+for 1D Hamiltonians. The keywords `kw` are passed to the ArnoldiMethod `partialschur!`
+eigensolver (`kw = (; nev = 1)` by default).
 
 The `LinearMaps` and `ArnoldiMethod` packages must be loaded to enable this functionality.
 
@@ -2567,10 +2568,21 @@ julia> Quantica.gaps(h(U=2))
 ```
 
 # See also:
-    `Quantica.decay_lengths`
+    `Quantica.gap`, `Quantica.decay_lengths`
 
 """
 gaps
+
+"""
+    Quantica.gap(h::Hamiltonian1D{T}, µ = 0; atol = eps(T), kw...)
+
+Compute the minimal gap around `µ`, see `Quantica.gaps`
+
+# See also:
+    `Quantica.gaps`, `Quantica.decay_lengths`
+
+"""
+gap
 
 """
     Quantica.decay_lengths(g::GreenFunctionSchurLead, µ = 0; reverse = false)

--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -7,12 +7,15 @@
 #   we precompute v_H^{ik} = \sum_n v_H(r_{i0} - r_{kn}), exploiting ρ translation symmetry
 #region
 
-struct MeanField{B,T,S<:SparseMatrixCSC,H<:DensityMatrix,F<:DensityMatrix}
+struct MeanField{B,T,C<:CompressedOrbitalMatrix,S<:SparseMatrixCSC,H<:DensityMatrix,F<:DensityMatrix}
+    output::C
     potHartree::S
     potFock::S
     rhoHartree::H
     rhoFock::F
     charge::B
+    nambu::Bool
+    is_nambu_rotated::Bool
     rowcol_ranges::NTuple{2,Vector{UnitRange{Int}}}
     onsite_tmp::Vector{Complex{T}}
 end
@@ -23,18 +26,18 @@ struct ZeroField end
 
 function meanfield(g::GreenFunction{T,E}, args...;
     potential = Returns(1), hartree = potential, fock = hartree,
-    onsite = missing, charge = I, nambu::Bool = false,
+    onsite = missing, charge = I, nambu::Bool = false, namburotation = missing,
     selector::NamedTuple = (; range = 0), kw...) where {T,E}
 
     Vh = sanitize_potential(hartree)
     Vf = sanitize_potential(fock)
-    Q = sanitize_charge(charge, blocktype(hamiltonian(g)))
+    is_nambu_rotated´ = sanitize_nambu_rotated(namburotation, nambu)
+    Q = sanitize_charge(charge, blocktype(hamiltonian(g)), nambu, is_nambu_rotated´)
     U = onsite === missing ? T(Vh(zero(SVector{E,T}))) : T(onsite)
     Uf = fock === nothing ? zero(U) : U
 
     isempty(boundaries(g)) || argerror("meanfield does not currently support systems with boundaries")
     isfinite(U) || argerror("Onsite potential must be finite, consider setting `onsite`")
-    nambu && (!is_square(charge) || iseven(size(charge, 1))) && argerror("Invalid charge matrix for Nambu space")
 
     gsHartree = g[diagonal(; cells = 0, kernel = Q)]
     rhoHartree = densitymatrix(gsHartree, args...; kw...)
@@ -48,7 +51,6 @@ function meanfield(g::GreenFunction{T,E}, args...;
         lat |> hopping((r, dr) -> iszero(dr) ? U : Vh(dr); selector..., includeonsite = true)
 
     potHartree = sum(unflat, harmonics(hHartree))
-    nambu && (nonzeros(potHartree) .*= T(1/2)) # to compensate for the factor 2 from nambu trace
 
     oaxes = orbaxes(call!_output(gsFock))
     rowcol_ranges = collect.(orbranges.(oaxes))
@@ -62,7 +64,13 @@ function meanfield(g::GreenFunction{T,E}, args...;
     check_cell_order(hFock_slice, rhoFock)
     potFock = parent(hFock_slice)
 
-    return MeanField(potHartree, potFock, rhoHartree, rhoFock, Q, rowcol_ranges, onsite_tmp)
+    encoder, decoder = nambu ? NambuEncoderDecoder(is_nambu_rotated´) : (identity, identity)
+    S = typeof(encoder(zero(Q)))
+    output = call!_output(g[sitepairs(; selector..., includeonsite = true, kernel = Q)])
+    sparse_enc = similar(output, S)
+    output = CompressedOrbitalMatrix(sparse_enc; encoder, decoder, hermitian = true)
+
+    return MeanField(output, potHartree, potFock, rhoHartree, rhoFock, Q, nambu, is_nambu_rotated´, rowcol_ranges, onsite_tmp)
 end
 
 sanitize_potential(x::Number) = Returns(x)
@@ -70,8 +78,54 @@ sanitize_potential(x::Function) = x
 sanitize_potential(x::Nothing) = Returns(0)
 sanitize_potential(_) = argerror("Invalid potential: use a number or a function of position")
 
-sanitize_charge(B, t) = sanitize_block(t, B)
-sanitize_charge(B, ::Type{<:SMatrixView}) = argerror("meanfield does not currently support systems with heterogeneous orbitals")
+sanitize_nambu_rotated(is_nambu_rotated, nambu) =
+    nambu ? sanitize_nambu_rotated(is_nambu_rotated) : false
+sanitize_nambu_rotated(::Missing) =
+    argerror("Must specify `namburotation` (true or false)")
+sanitize_nambu_rotated(is_nambu_rotated::Bool) = is_nambu_rotated
+
+function sanitize_charge(charge, B, nambu, is_rotated)
+    Q = sanitize_charge(charge, B)
+    nambu && check_nambu(Q, is_rotated)
+    return Q
+end
+
+sanitize_charge(charge, B) = sanitize_block(B, charge)
+sanitize_charge(charge, ::Type{<:SMatrixView}) =
+    argerror("meanfield does not currently support systems with heterogeneous orbitals")
+
+check_nambu(Q::S, is_rotated) where {S<:Union{SMatrix{2,2},SMatrix{4,4}}} =
+    nambu_redundants(Q) ≈ nambu_adjoint_significants(Q, is_rotated) ||
+    argerror("Matrix $Q does not satisfy Nambu symmetry")
+check_nambu(::SMatrix{N,N}, is_rotated) where {N} =
+    argerror("Quantica currently only understand 2×2 and 4×4 Nambu spaces, got $N×$N")
+check_nambu(Q, is_rotated) = argerror("$Q does not satisfy Nambu symmetry")
+
+nambu_significants(mat::SMatrix{4,4}) = mat[:, SA[1,2]]
+nambu_significants(mat::SMatrix{2,2}) = mat[:, 1]
+nambu_redundants(mat::SMatrix{4,4}) = mat[:, SA[3,4]]
+nambu_redundants(mat::SMatrix{2,2}) = mat[:, 2]
+
+nambu_adjoint_significants(mat::SMatrix{N,N}, is_rotated) where {N} =
+    nambu_adjoint_significants(nambu_significants(mat), is_rotated)
+
+function nambu_adjoint_significants(lmat::SVector{2}, _)
+    return -SA[0 1; 1 0] * conj(lmat)
+end
+
+function nambu_adjoint_significants(lmat::SMatrix{4,2}, is_rotated)
+    if is_rotated
+        return -SA[0 0 0 -1; 0 0 1 0; 0 1 0 0; -1 0 0 0] * lmat * SA[0 -1; 1 0]
+    else
+        return -SA[0 0 1 0; 0 0 0 1; 1 0 0 0; 0 1 0 0] * lmat
+    end
+end
+
+function NambuEncoderDecoder(is_nambu_rotated)
+    encoder = nambu_significants
+    decoder = smat -> [smat nambu_adjoint_significants(smat, is_nambu_rotated)]
+    return encoder, decoder
+end
 
 function check_cell_order(hFock_slice, rhoFock)
     opot = first(orbaxes(hFock_slice))
@@ -90,35 +144,45 @@ hartree_matrix(m::MeanField) = m.potHartree
 
 fock_matrix(m::MeanField) = parent(m.potFock)
 
-function (m::MeanField{B})(args...; chopsmall = true, params...) where {B}
+isnambu(m::MeanField) = m.nambu
+
+is_nambu_rotated(m::MeanField) = m.is_nambu_rotated
+
+(m::MeanField)(args...; kw...) = copy(call!(m, args...; kw...))
+
+function call!(m::MeanField{B}, args...; chopsmall = true, params...) where {B}
     Q, hartree_pot, fock_pot = m.charge, m.onsite_tmp, m.potFock
     rowrngs, colrngs = m.rowcol_ranges
     trρQ = m.rhoHartree(args...; params...)
     mul!(hartree_pot, m.potHartree, diag(parent(trρQ)))
-    meanfield = m.rhoFock(args...; params...)
+    ρFock = m.rhoFock(args...; params...)
+    meanfield = m.output
     mf_parent = parent(meanfield)
+    fill!(mf_parent, zero(eltype(mf_parent)))
     if chopsmall
-        hartree_pot .= Quantica.chopsmall.(hartree_pot)
-        nonzeros(mf_parent) .= Quantica.chopsmall.(nonzeros(mf_parent))
+        hartree_pot .= Quantica.chopsmall.(hartree_pot)  # this is a Vector
+        nzs = nonzeros(parent(ρFock))
+        nzs .= Quantica.chopsmall.(nzs)
     end
     rows, cols, nzs = rowvals(fock_pot), axes(fock_pot, 2), nonzeros(fock_pot)
     for col in cols
-        viiQ = hartree_pot[col] * Q
+        # 1/2 to compensate for the factor 2 from nambu trace
+        viiQ = ifelse(m.nambu, 0.5*hartree_pot[col], hartree_pot[col]) * Q
         for ptr in nzrange(fock_pot, col)
             row = rows[ptr]
+            row > col && ishermitian(meanfield) && continue   # skip upper triangle
             vij = nzs[ptr]
-            ρij = view(mf_parent, rowrngs[row], colrngs[col])
+            ρij = view(ρFock, rowrngs[row], colrngs[col])
             vQρijQ = vij * Q * sanitize_block(B, ρij) * Q
             if row == col
-                ρij .= viiQ - vQρijQ
+                mf_parent[row, col] = encoder(meanfield)(viiQ - vQρijQ)
             else
-                ρij .= -vQρijQ
+                mf_parent[row, col] = encoder(meanfield)(-vQρijQ)
             end
         end
     end
     return meanfield
 end
-
 
 ## ZeroField
 

--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -48,9 +48,9 @@ function meanfield(g::GreenFunction{T,E}, args...;
 
     lat = lattice(hamiltonian(g))
     # The sparse structure of hFock will be inherited by the evaluated mean field. Need onsite.
-    hFock = lat |> hopping((r, dr) -> iszero(dr) ? Uf : Vf(dr); selector..., includeonsite = true)
+    hFock = lat |> hopping((r, dr) -> iszero(dr) ? Uf : T(Vf(dr)); selector..., includeonsite = true)
     hHartree = (Uf == U && Vh === Vf) ? hFock :
-        lat |> hopping((r, dr) -> iszero(dr) ? U : Vh(dr); selector..., includeonsite = true)
+        lat |> hopping((r, dr) -> iszero(dr) ? U : T(Vh(dr)); selector..., includeonsite = true)
 
     potHartree = sum(unflat, harmonics(hHartree))
 
@@ -75,10 +75,10 @@ function meanfield(g::GreenFunction{T,E}, args...;
     return MeanField(output, potHartree, potFock, rhoHartree, rhoFock, Q, nambu, is_nambu_rotated´, rowcol_ranges, onsite_tmp)
 end
 
-sanitize_potential(x::Number) = Returns(x)
+sanitize_potential(x::Real) = Returns(x)
 sanitize_potential(x::Function) = x
 sanitize_potential(x::Nothing) = Returns(0)
-sanitize_potential(_) = argerror("Invalid potential: use a number or a function of position")
+sanitize_potential(_) = argerror("Invalid potential: use a real number or a function of position")
 
 sanitize_nambu_rotated(is_nambu_rotated, nambu, ::Type{<:SMatrix{2,2}}) = false
 sanitize_nambu_rotated(is_nambu_rotated, nambu, ::Type{<:SMatrix{4,4}}) =

--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -170,7 +170,7 @@ function call!(m::MeanField{B}, args...; chopsmall = true, params...) where {B}
         viiQ = ifelse(m.nambu, 0.5*hartree_pot[col], hartree_pot[col]) * Q
         for ptr in nzrange(fock_pot, col)
             row = rows[ptr]
-            row > col && ishermitian(meanfield) && continue   # skip upper triangle
+            row < col && ishermitian(meanfield) && continue   # skip upper triangle
             vij = nzs[ptr]
             ρij = view(ρFock, rowrngs[row], colrngs[col])
             vQρijQ = vij * Q * sanitize_block(B, ρij) * Q

--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -33,6 +33,7 @@ function meanfield(g::GreenFunction{T,E}, args...;
     Vf = sanitize_potential(fock)
     U = onsite === missing ? T(Vh(zero(SVector{E,T}))) : T(onsite)
     Uf = onsite === missing ? T(Vf(zero(SVector{E,T}))) : T(onsite)
+    Uf = fock === nothing ? zero(Uf) : Uf
     B = blocktype(hamiltonian(g))
     is_nambu_rotated´ = sanitize_nambu_rotated(namburotation, nambu, B)
     Q = sanitize_charge(charge, B, nambu, is_nambu_rotated´)

--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -194,6 +194,7 @@ function call!(m::MeanField{B}, args...; chopsmall = true, params...) where {B}
     return meanfield
 end
 
+check_zero_mu(_) = nothing
 check_zero_mu(m, µ, _...) = !m.nambu || iszero(µ) ||
     argerror("Tried to evaluate a Nambu mean field at a nonzero µ = $µ")
 

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -163,7 +163,7 @@ function call!(I::Integrator; params...)
     end
     result, err = quadgk!(fx!, serialize(I.result), I.points...; I.quadgk_opts...)
     # note: post-processing is not element-wise & can be in-place
-    result´ = deserialize(I.result, I.post(result))
+    result´ = unsafe_deserialize(I.result, I.post(result))
     return result´
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -540,19 +540,14 @@ Base.summary(::CurrentDensitySlice{T}) where {T} =
 #endregion
 
 ############################################################################################
-# OrbitalSliceMatrix
+# AbstractOrbitalArray
 #region
 
 # For simplified printing of the array typename
 
-function Base.showarg(io::IO, ::OrbitalSliceMatrix{T,M}, toplevel) where {T,M}
+function Base.showarg(io::IO, ::A, toplevel) where {T,M,A<:AbstractOrbitalArray{T,M}}
     toplevel || print(io, "::")
-    print(io,  "OrbitalSliceMatrix{$T,$M}")
-end
-
-function Base.showarg(io::IO, ::OrbitalSliceVector{T,M}, toplevel) where {T,M}
-    toplevel || print(io, "::")
-    print(io,  "OrbitalSliceVector{$T,$M}")
+    print(io,  "$(nameof(A)){$T,$M}")
 end
 
 #endregion
@@ -619,7 +614,7 @@ display_parameters(s::AppliedSerializer{<:Any,<:ParametricHamiltonian}) = string
 
 
 ############################################################################################
-# MeanField and EvaluatedMeanField
+# MeanField
 #region
 
 function Base.show(io::IO, s::MeanField{Q}) where {Q}
@@ -628,10 +623,13 @@ function Base.show(io::IO, s::MeanField{Q}) where {Q}
     print(io, i, summary(s), "\n",
 "$i  Charge type      : $(displaytype(Q))
 $i  Hartree pairs    : $(nnz(hartree_matrix(s)))
-$i  Mean field pairs : $(nnz(fock_matrix(s)))")
+$i  Mean field pairs : $(nnz(fock_matrix(s)))
+$i  Nambu            : $(nambustring(s))")
 end
 
 Base.summary(::MeanField{Q}) where {Q} =
     "MeanField{$Q} : builder of Hartree-Fock mean fields"
+
+nambustring(s) = isnambu(s) ? "true $(is_nambu_rotated(s) ? "(rotated basis)" : "")" : "false"
 
 #endregion

--- a/src/show.jl
+++ b/src/show.jl
@@ -632,7 +632,7 @@ $i  Nambu            : $(nambustring(s))")
 end
 
 Base.summary(::MeanField{Q}) where {Q} =
-    "MeanField{$Q} : builder of Hartree-Fock mean fields"
+    "MeanField{$Q} : builder of Hartree-Fock-Bogoliubov mean fields"
 
 nambustring(s) = isnambu(s) ? "true $(is_nambu_rotated(s) ? "(rotated basis)" : "")" : "false"
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -545,10 +545,14 @@ Base.summary(::CurrentDensitySlice{T}) where {T} =
 
 # For simplified printing of the array typename
 
-function Base.showarg(io::IO, ::A, toplevel) where {T,M,A<:AbstractOrbitalArray{T,M}}
+function Base.showarg(io::IO, ::A, toplevel) where {T,M,A<:AbstractOrbitalArray{T,<:Any,M}}
     toplevel || print(io, "::")
-    print(io,  "$(nameof(A)){$T,$M}")
+    print(io,  "$(nameof(A)){$T,$(nameof(M))}")
 end
+
+Base.nameof(::Type{<:OrbitalSliceMatrix}) = "OrbitalSliceMatrix"
+Base.nameof(::Type{<:OrbitalSliceVector}) = "OrbitalSliceVector"
+Base.nameof(::Type{<:CompressedOrbitalMatrix}) = "CompressedOrbitalMatrix"
 
 #endregion
 

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -83,8 +83,8 @@ function nearest_cell_harmonics(h)
     is_nearest ||
         argerror("Too many or too few harmonics. Perhaps try `supercell` to ensure strictly nearest-cell harmonics.")
     hm, h0, hp = h[hybrid(-1)], h[hybrid(0)], h[hybrid(1)]
-    flat(hm) == flat(hp)' ||
-        argerror("The Hamiltonian should have h[1] == h[-1]' to use the Schur solver")
+    flat(hm) ≈ flat(hp)' ||
+        argerror("The Hamiltonian should have h[1] ≈ h[-1]' to use the Schur solver")
     return hm, h0, hp
 end
 
@@ -696,7 +696,7 @@ function (s::DensityMatrixSchurSolver)(µ, kBT; params...)
     xs = sort!(ϕs ./ (2π))
     pushfirst!(xs, -0.5)
     push!(xs, 0.5)
-    xs = unique!(xs)
+    xs = [mean(view(xs, rng)) for rng in approxruns(xs)]  # elliminate approximate duplicates
     result = call!_output(s.gs)
     integrand!(x) = fermi_h!(result, s, 2π * x, µ, inv(kBT); params...)
     fx! = (y, x) -> (y .= integrand!(x))

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -492,69 +492,72 @@ checkcontactindices(allcontactinds, hdim) = maximum(allcontactinds) <= hdim ||
 #endregion
 
 ############################################################################################
-## OrbitalSliceArray
+## AbstractOrbitalArray
 #region
 
 # AbstractArray interface
-Base.size(a::OrbitalSliceArray) = size(parent(a))
-Base.iterate(a::OrbitalSliceArray, i...) = iterate(parent(a), i...)
-Base.length(a::OrbitalSliceArray) = length(parent(a))
-Base.IndexStyle(::Type{T}) where {M,T<:OrbitalSliceArray{<:Any,<:Any,M}} = IndexStyle(M)
-Base.similar(a::OrbitalSliceArray) = OrbitalSliceArray(similar(parent(a)), orbaxes(a))
-Base.similar(a::OrbitalSliceArray, t::Type) = OrbitalSliceArray(similar(parent(a), t), orbaxes(a))
-# doesn't make sense to keep orbaxes in similar with different dimensions.
-Base.similar(a::OrbitalSliceArray, dims::Tuple) = similar(parent(a), dims)
-Base.copy(a::OrbitalSliceArray) = OrbitalSliceArray(copy(parent(a)), orbaxes(a))
-Base.@propagate_inbounds Base.getindex(a::OrbitalSliceArray, i::Int) =
+Base.size(a::AbstractOrbitalArray) = size(parent(a))
+Base.iterate(a::AbstractOrbitalArray, i...) = iterate(parent(a), i...)
+Base.length(a::AbstractOrbitalArray) = length(parent(a))
+Base.IndexStyle(::Type{T}) where {M,T<:AbstractOrbitalArray{<:Any,<:Any,M}} = IndexStyle(M)
+Base.similar(a::AbstractOrbitalArray) = similar(a, similar(parent(a)), orbaxes(a))
+Base.similar(a::AbstractOrbitalArray, t::Type) = similar(a, similar(parent(a), t), orbaxes(a))
+# doesn't make sense to keep orbaxes in similar with different dimensions, return parent
+Base.similar(a::AbstractOrbitalArray, dims::Tuple) = similar(parent(a), dims)
+Base.copy(a::AbstractOrbitalArray) = similar(a, copy(parent(a)), orbaxes(a))
+Base.@propagate_inbounds Base.getindex(a::AbstractOrbitalArray, i::Int) =
     getindex(parent(a), i)
-Base.@propagate_inbounds Base.getindex(a::OrbitalSliceArray, I::Vararg{Int, N}) where {N} =
+Base.@propagate_inbounds Base.getindex(a::AbstractOrbitalArray, I::Vararg{Int, N}) where {N} =
     getindex(parent(a), I...)
-Base.@propagate_inbounds Base.setindex!(a::OrbitalSliceArray, v, i::Int) = setindex!(parent(a), v, i)
-Base.@propagate_inbounds Base.setindex!(a::OrbitalSliceArray, v, I::Vararg{Int, N}) where {N} = setindex!(parent(a), v, I...)
+Base.@propagate_inbounds Base.setindex!(a::AbstractOrbitalArray, v, i::Int) = setindex!(parent(a), v, i)
+Base.@propagate_inbounds Base.setindex!(a::AbstractOrbitalArray, v, I::Vararg{Int, N}) where {N} = setindex!(parent(a), v, I...)
 
-Base.:*(x::Number, a::OrbitalSliceArray) = OrbitalSliceArray(parent(a) * x, orbaxes(a))
-Base.:*(a::OrbitalSliceArray, x::Number) = x * a
+Base.:*(x::Number, a::AbstractOrbitalArray) = similar(a, parent(a) * x, orbaxes(a))
+Base.:*(a::AbstractOrbitalArray, x::Number) = x * a
 
-Base.:+(a::OrbitalSliceArray, b::OrbitalSliceArray) = parent(a) + parent(b)
+Base.:+(a::AbstractOrbitalArray, b::AbstractOrbitalArray) = parent(a) + parent(b)
 
-Base.:-(a::OrbitalSliceArray, b::OrbitalSliceArray) = parent(a) - parent(b)
+Base.:-(a::AbstractOrbitalArray, b::AbstractOrbitalArray) = parent(a) - parent(b)
 
 # Additional indexing over sites
-Base.getindex(a::OrbitalSliceMatrix; sites...) = getindex(a, siteselector(; sites...))
-Base.getindex(a::OrbitalSliceMatrix, i::NamedTuple, j::NamedTuple = i) =
+Base.getindex(a::AbstractOrbitalMatrix; sites...) = getindex(a, siteselector(; sites...))
+Base.getindex(a::AbstractOrbitalMatrix, i::NamedTuple, j::NamedTuple = i) =
     getindex(a, siteselector(i), siteselector(j))
-Base.getindex(a::OrbitalSliceMatrix, i::NamedTuple, j::SiteSelector) =
+Base.getindex(a::AbstractOrbitalMatrix, i::NamedTuple, j::SiteSelector) =
     getindex(a, siteselector(i), j)
-Base.getindex(a::OrbitalSliceMatrix, i::SiteSelector, j::NamedTuple) =
+Base.getindex(a::AbstractOrbitalMatrix, i::SiteSelector, j::NamedTuple) =
     getindex(a, i, siteselector(j))
 
-# SiteSelector: return a new OrbitalSliceMatrix
-function Base.getindex(a::OrbitalSliceMatrix, i::SiteSelector, j::SiteSelector = i)
+# SiteSelector: return a new AbstractOrbitalMatrix
+function Base.getindex(a::AbstractOrbitalMatrix, i::SiteSelector, j::SiteSelector = i)
     rowslice, colslice = orbaxes(a)
     rowslice´, colslice´ = rowslice[i], colslice[j]
     rows = collect(indexcollection(rowslice, rowslice´))
     cols = i === j && rowslice === colslice ? rows : indexcollection(colslice, colslice´)
     m = parent(a)[rows, cols]
-    return OrbitalSliceMatrix(m, (rowslice´, colslice´))
+    return similar(a, m, (rowslice´, colslice´))
 end
 
 # CellSites: return an unwrapped Matrix
-Base.getindex(a::OrbitalSliceMatrix, i::AnyCellSites, j::AnyCellSites = i) =
+Base.getindex(a::AbstractOrbitalMatrix, i::AnyCellSites, j::AnyCellSites = i) =
     copy(view(a, i, j))
 
 # CellSitePos: return an unwrapped SMatrix or a scalar, even if out of bounds
-Base.getindex(a::OrbitalSliceMatrix, i::C, j::C = i) where {B,C<:CellSitePos{<:Any,<:Any,<:Any,B}} =
+Base.getindex(a::AbstractOrbitalMatrix, i::C, j::C = i) where {B,C<:CellSitePos{<:Any,<:Any,<:Any,B}} =
     checkbounds(Bool, a, i, j) ? sanitize_block(B, view(a, i, j)) : zero(B)
 
-Base.checkbounds(::Type{Bool}, a::OrbitalSliceMatrix, i::CellSitePos, j::CellSitePos) =
+Base.checkbounds(::Type{Bool}, a::AbstractOrbitalMatrix, i::CellSitePos, j::CellSitePos) =
     checkbounds(Bool, first(orbaxes(a)), i) && checkbounds(Bool, last(orbaxes(a)), j)
 
-function Base.view(a::OrbitalSliceMatrix, i::AnyCellSites, j::AnyCellSites = i)
+Base.view(a::AbstractOrbitalMatrix, i::AnyCellSites, j::AnyCellSites = i) =
+    view(parent(a), indexcollection(a, i, j)...)
+
+function indexcollection(a::AbstractOrbitalMatrix, i::AnyCellSites, j::AnyCellSites = i)
     rowslice, colslice = orbaxes(a)
-    i´, j´ = apply(i, lattice(rowslice)), apply(j, lattice(colslice))
-    rows = indexcollection(rowslice, i´)
-    cols = j === i && rowslice === colslice ? rows : indexcollection(colslice, j´)
-    return view(parent(a), rows, cols)
+    isdiag = j === i && rowslice === colslice
+    rows = indexcollection(rowslice, apply(i, lattice(rowslice)))
+    cols = isdiag ? rows : indexcollection(colslice, apply(j, lattice(colslice)))
+    return rows, cols
 end
 
 # Minimal getindex for OrbitalSliceVector
@@ -562,64 +565,64 @@ Base.getindex(a::OrbitalSliceVector, i::AnyCellSites) = copy(view(a, i))
 Base.getindex(a::OrbitalSliceVector, i::C) where {B,C<:CellSitePos{<:Any,<:Any,<:Any,B}} =
     sanitize_block(B, view(a, i))
 
-function Base.view(a::OrbitalSliceVector, i::AnyCellSites)
+Base.view(a::OrbitalSliceVector, i::AnyCellSites) = view(parent(a), indexcollection(a, i))
+
+function indexcollection(a::OrbitalSliceVector, i::AnyCellSites)
     rowslice = only(orbaxes(a))
-    i´ = apply(i, lattice(rowslice))
-    rows = indexcollection(rowslice, i´)
-    return view(parent(a), rows)
+    rows = indexcollection(rowslice, apply(i, lattice(rowslice)))
+    return rows
 end
 
 LinearAlgebra.diag(a::OrbitalSliceMatrix) =
     OrbitalSliceVector(diag(parent(a)), (first(orbaxes(a)),))
 
-LinearAlgebra.norm(a::OrbitalSliceMatrix) = norm(parent(a))
+LinearAlgebra.norm(a::AbstractOrbitalMatrix) = norm(parent(a))
+
+## CompressedOrbitalMatrix
+
+# decoding access
+Base.view(a::CompressedOrbitalMatrix, i::AnyCellSites, j::AnyCellSites = i) =
+    getindex_scalar(a, only.(indexcollection(a, i, j)))
+
+@inline function getindex_scalar(a::CompressedOrbitalMatrix, (i,j)::NTuple{2,Integer})
+    dec = decoder(a)
+    if ishermitian(a)
+        if i < j
+            return dec(parent(a)[j, i])'
+        elseif i == j
+            d = dec(parent(a)[i, j])
+            return 0.5 * (d + d')
+        else
+            return dec(parent(a)[i, j])
+        end
+    end
+    return dec(parent(a)[i, j])
+end
 
 ## broadcasting
 
 # following the manual: https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array
 # disabled for now, since it seems to cause issues with OrbitalSliceMatrix{<:SparseMatrixCSC}
 
-# Broadcast.BroadcastStyle(::Type{O}) where {O<:OrbitalSliceArray} = Broadcast.ArrayStyle{O}()
+# Broadcast.BroadcastStyle(::Type{O}) where {O<:AbstractOrbitalArray} = Broadcast.ArrayStyle{O}()
 
 # Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{O}}, ::Type{ElType}) where {ElType,O<:OrbitalSliceMatrix{<:Any,<:Array}} =
-#     OrbitalSliceArray(similar(Array{ElType}, axes(bc)), orbaxes(find_osa(bc)))
+#     AbstractOrbitalArray(similar(Array{ElType}, axes(bc)), orbaxes(find_osa(bc)))
 # Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{O}}, ::Type{ElType}) where {ElType,O<:OrbitalSliceMatrix{<:Any,<:SparseMatrixCSC}} =
-#     OrbitalSliceArray(similar(parent(find_osa(bc)), ElType), orbaxes(find_osa(bc)))
+#     AbstractOrbitalArray(similar(parent(find_osa(bc)), ElType), orbaxes(find_osa(bc)))
 
 # find_osa(bc::Base.Broadcast.Broadcasted) = find_osa(bc.args)
 # find_osa(args::Tuple) = find_osa(find_osa(args[1]), Base.tail(args))
 # find_osa(x) = x
 # find_osa(::Tuple{}) = nothing
-# find_osa(a::OrbitalSliceArray, rest) = a
+# find_osa(a::AbstractOrbitalArray, rest) = a
 # find_osa(::Any, rest) = find_osa(rest)
 
 # taken from https://github.com/JuliaArrays/OffsetArrays.jl/blob/756e839563c88faa4ebe4ff971286747863aaff0/src/OffsetArrays.jl#L469
 
-Base.dataids(A::OrbitalSliceArray) = Base.dataids(parent(A))
-Broadcast.broadcast_unalias(dest::OrbitalSliceArray, src::OrbitalSliceArray) =
+Base.dataids(A::AbstractOrbitalArray) = Base.dataids(parent(A))
+Broadcast.broadcast_unalias(dest::AbstractOrbitalArray, src::AbstractOrbitalArray) =
     parent(dest) === parent(src) ? src : Broadcast.unalias(dest, src)
-
-# ## conversion: If i contains an OrbitalSliceGrouped, wrap it in an OrbitalSliceArray. Otherwise, no-op
-
-# maybe_OrbitalSliceArray(i) = x -> maybe_OrbitalSliceArray(x, i)
-
-# maybe_OrbitalSliceArray(x::AbstractMatrix, i) = maybe_OrbitalSliceMatrix(x, i)
-
-# maybe_OrbitalSliceMatrix(x::Diagonal, i::OrbitalSliceGrouped) =
-#     maybe_OrbitalSliceMatrix(x, (i, i))
-# maybe_OrbitalSliceMatrix(x, (i, j)::Tuple{OrbitalSliceGrouped,OrbitalSliceGrouped}) =
-#     OrbitalSliceMatrix(x, (i, j))
-# maybe_OrbitalSliceMatrix(x, i) = x
-
-## currently unsused
-# maybe_OrbitalSliceArray(x::AbstractVector, i) = maybe_OrbitalSliceVector(x, i)
-# maybe_OrbitalSliceVector(x, i::DiagIndices{Missing,<:OrbitalSliceGrouped}) =
-#     maybe_OrbitalSliceVector(x, parent(i))
-# maybe_OrbitalSliceVector(x, i::DiagIndices{<:Any,<:OrbitalSliceGrouped}) =
-#     maybe_OrbitalSliceVector(x, scalarize(parent(i)))
-# maybe_OrbitalSliceVector(x, i::OrbitalSliceGrouped) = OrbitalSliceVector(x, (i,))
-# maybe_OrbitalSliceVector(x, i) = x
-
 
 #endregion
 

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -586,6 +586,7 @@ Base.view(a::CompressedOrbitalMatrix, i::AnyCellSites, j::AnyCellSites = i) =
 
 @inline function getindex_scalar(a::CompressedOrbitalMatrix, (i,j)::NTuple{2,Integer})
     dec = decoder(a)
+    # Only lower-triangle is stored in the hermitian case
     if ishermitian(a)
         if i < j
             return dec(parent(a)[j, i])'

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -600,6 +600,26 @@ Base.view(a::CompressedOrbitalMatrix{C}, i::AnyCellSites, j::AnyCellSites = i) w
     return dec(parent(a)[i, j])
 end
 
+## checkbounds
+
+# checkbounds axis
+checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i, axis) =
+    checkbounds(Bool, axes(a, axis), i)
+
+# checkbounds orbaxis
+checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i::CellIndices, axis) =
+    checkbounds_axis_or_orbaxis(orbaxes(a, axis), i)
+
+function checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i::CellIndices)
+    dict = cellsdict(a)
+    c = cell(i, a)
+    if haskey(dict, c)
+        return siteindex(i) in keys(orbgroups(dict[c]))
+    else
+        return false
+    end
+end
+
 ## broadcasting
 
 # following the manual: https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -582,22 +582,32 @@ LinearAlgebra.norm(a::AbstractOrbitalMatrix) = norm(parent(a))
 
 # decoding access
 Base.view(a::CompressedOrbitalMatrix{C}, i::AnyCellSites, j::AnyCellSites = i) where {C} =
-    checkbounds(Bool, a, i, j) ? getindex_scalar(a, only.(indexcollection(a, i, j))) : zero(decoder(a)(zero(C)))
+    checkbounds(Bool, a, i, j) ? getindex_decode(a, i, j) : zero(decoder(a)(zero(C)))
 
-@inline function getindex_scalar(a::CompressedOrbitalMatrix{C}, (i,j)::NTuple{2,Integer}) where {C}
-    dec = decoder(a)
+@inline function getindex_decode(a::CompressedOrbitalMatrix, ci, cj)
+    i, j = only.(indexcollection(a, ci, cj))
     # Only lower-triangle is stored in the hermitian case
     if ishermitian(a)
-        if i < j
-            return dec(parent(a)[j, i])'
-        elseif i == j
-            d = dec(parent(a)[i, j])
-            return 0.5 * (d + d')
-        else
-            return dec(parent(a)[i, j])
-        end
+        # we find the indices for a[sites(-ni, j), sites(0, i)],
+        # the conjugate of a[sites(ni, i), sites(0, j)],
+        ci´, cj´ = sites(-cell(ci), siteindex(cj)), sites(cell(cj), siteindex(ci))
+        i´, j´ = only.(indexcollection(a, ci´, cj´))
+        val = getindex_decode_hermitian(a, i, j)
+        val´ = getindex_decode_hermitian(a, i´, j´)'
+        return 0.5 * (val + val´)
     end
     return dec(parent(a)[i, j])
+end
+
+function getindex_decode_hermitian(a::CompressedOrbitalMatrix, i, j)
+    dec = decoder(a)
+    if i < j
+        return dec(parent(a)[j, i])'
+    elseif i == j
+        return dec(parent(a)[i, j])
+    else
+        return dec(parent(a)[i, j])
+    end
 end
 
 ## checkbounds

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -608,9 +608,9 @@ checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i, axis) =
 
 # checkbounds orbaxis
 checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i::CellIndices, axis) =
-    checkbounds_axis_or_orbaxis(orbaxes(a, axis), i)
+    checkbounds_orbaxis(orbaxes(a, axis), i)
 
-function checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i::CellIndices)
+function checkbounds_orbaxis(a::LatticeSlice, i::CellIndices)
     dict = cellsdict(a)
     c = cell(i, a)
     if haskey(dict, c)

--- a/src/types.jl
+++ b/src/types.jl
@@ -2247,8 +2247,8 @@ GreenSlice(parent::GreenFunction{T}, rows::GreenIndices, cols::GreenIndices, ::T
     GreenSlice(parent, rows, cols, similar_slice(C, orbindices(rows), orbindices(cols)))
 
 function GreenSlice(parent, rows, cols, type...)
-    if rows isa DiagIndices || cols isa DiagIndices
-        rows === cols || argerror("Diagonal indices should be identical for rows and columns")
+    if rows isa SparseIndices || cols isa SparseIndices
+        rows === cols || argerror("Sparse indices should be identical for rows and columns")
     end
     rows´ = greenindices(rows, parent)
     cols´ = cols === rows ? rows´ : greenindices(cols, parent)
@@ -2511,13 +2511,27 @@ SparseArrays.nnz(h::BarebonesOperator) = sum(har -> nnz(matrix(har)), harmonics(
 #   if missing, the dimension does not span orbitals but something else
 #region
 
-struct OrbitalSliceArray{C,N,M<:AbstractArray{C,N},A<:NTuple{N,Union{OrbitalSliceGrouped,Missing}}} <: AbstractArray{C,N}
+abstract type AbstractOrbitalArray{C,N,M} <: AbstractArray{C,N} end
+
+const AbstractOrbitalVector{C,M} = AbstractOrbitalArray{C,1,M}
+const AbstractOrbitalMatrix{C,M} = AbstractOrbitalArray{C,2,M}
+
+struct OrbitalSliceArray{C,N,M<:AbstractArray{C,N},A<:NTuple{N,Union{OrbitalSliceGrouped,Missing}}} <: AbstractOrbitalArray{C,N,M}
     parent::M
     orbaxes::A
 end
 
 const OrbitalSliceVector{C,V,A} = OrbitalSliceArray{C,1,V,A}
 const OrbitalSliceMatrix{C,M,A} = OrbitalSliceArray{C,2,M,A}
+
+struct CompressedOrbitalMatrix{C<:Union{Number,SArray},M,O<:OrbitalSliceMatrix{C,M},E,D} <: AbstractOrbitalMatrix{C,M}
+    omat::O
+    hermitian::Bool
+    encoder::E
+    decoder::D
+end
+
+#region ## Contructors ##
 
 OrbitalSliceVector(v::AbstractVector, axes) = OrbitalSliceArray(v, axes)
 OrbitalSliceMatrix(m::AbstractMatrix, axes) = OrbitalSliceArray(m, axes)
@@ -2537,8 +2551,27 @@ function OrbitalSliceMatrix{C}(::UndefInitializer, oi::SparseIndices{<:Hamiltoni
     return OrbitalSliceArray(mat, (i, j))
 end
 
+CompressedOrbitalMatrix(o::OrbitalSliceMatrix; hermitian = false, encoder = identity, decoder = identity) =
+    CompressedOrbitalMatrix(o, hermitian, encoder, decoder)
+
+Base.similar(::OrbitalSliceArray, mat, orbaxes) = OrbitalSliceArray(mat, orbaxes)
+Base.similar(a::CompressedOrbitalMatrix, mat, orbaxes) =
+    CompressedOrbitalMatrix(similar(a.omat, mat, orbaxes), a.hermitian, a.encoder, a.decoder)
+
+#endregion
+#region ## API ##
+
 orbaxes(a::OrbitalSliceArray) = a.orbaxes
+orbaxes(a::CompressedOrbitalMatrix) = orbaxes(a.omat)
 
 Base.parent(a::OrbitalSliceArray) = a.parent
+Base.parent(a::CompressedOrbitalMatrix) = parent(a.omat)
 
+encoder(a::CompressedOrbitalMatrix) = a.encoder
+
+decoder(a::CompressedOrbitalMatrix) = a.decoder
+
+LinearAlgebra.ishermitian(a::CompressedOrbitalMatrix) = a.hermitian
+
+#endregion
 #endregion

--- a/src/types.jl
+++ b/src/types.jl
@@ -546,24 +546,6 @@ boundingbox(l::LatticeSlice) = boundingbox(keys(cellsdict(l)))
 pos(s::CellSitePos) = s.type.r
 ind(s::CellSitePos) = s.inds
 
-# checkbounds axis
-checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i, axis) =
-    checkbounds(Bool, axes(a, axis), i)
-
-# checkbounds orbaxis
-checkbounds_axis_or_orbaxis(a::AbstractOrbitalMatrix, i::CellIndices, axis) =
-    checkbounds_axis_or_orbaxis(orbaxes(a, axis), i)
-
-function checkbounds_axis_or_orbaxis(a::OrbitalSliceGrouped, i::CellIndices)
-    dict = cellsdict(a)
-    c = cell(i, a)
-    if haskey(dict, c)
-        return siteindex(i) in keys(orbgroups(dict[c]))
-    else
-        return false
-    end
-end
-
 # iterators
 
 sites(l::LatticeSlice) =

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -601,7 +601,6 @@ end
     @test_throws ArgumentError meanfield(g)
     g = LP.honeycomb() |> hamiltonian(hopping(I), orbitals = (2,1)) |> greenfunction
     @test_throws ArgumentError meanfield(g)
-
 end
 
 @testset begin "OrbitalSliceArray serialization"


### PR DESCRIPTION
This stores the output of calling a `MeanField` object in a new subtype of `OrbitalSliceMatrix`, called `CompressedOrbitalMatrix`, that keeps only an encoding of the original matrix. This allows to enforce hermiticity, Nambu structure and other symmetries by construction.

We also include an extension of serialize/deserialize to reinterpret as a given eltype, for compatibility with more fixed-point solvers.