### PR TITLE
Taking integration paths seriously

### DIFF
--- a/docs/src/tutorial/observables.md
+++ b/docs/src/tutorial/observables.md
@@ -38,16 +38,16 @@ Note that `d[sites...]` produces a vector with the LDOS at sites defined by `sit
 We can also compute the convolution of the density of states with the Fermi distribution `f(ω)=1/(exp((ω-μ)/kBT) + 1)`, which yields the density matrix in thermal equilibrium, at a given temperature `kBT` and chemical potential `μ`. This is computed with `ρ = densitymatrix(gs, (ωmin, ωmax))`. Here `gs = g[sites...]` is a `GreenSlice`, and `(ωmin, ωmax)` are integration bounds (they should span the full bandwidth of the system). Then, `ρ(µ, kBT = 0; params...)` will yield a matrix over the selected `sites` for a set of model `params`.
 ```julia
 julia> ρ = densitymatrix(g[region = RP.circle(1)], (-0.1, 8.1))
-DensityMatrix: density matrix on specified sites using solver of type DensityMatrixIntegratorSolver
+DensityMatrix{DensityMatrixIntegratorSolver}: density matrix on specified sites
 
 julia> @time ρ(4)
-  6.150548 seconds (57.84 k allocations: 5.670 GiB, 1.12% gc time)
-5×5 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}:
-          0.5+0.0im          -7.34893e-10-3.94035e-15im  0.204478+1.9366e-14im   -7.34889e-10-1.44892e-15im  -5.70089e-10+5.48867e-15im
- -7.34893e-10+3.94035e-15im           0.5+0.0im          0.200693-2.6646e-14im   -5.70089e-10-1.95251e-15im  -7.34891e-10-2.13804e-15im
-     0.204478-1.9366e-14im       0.200693+2.6646e-14im        0.5+0.0im              0.200693+3.55692e-14im      0.204779-4.27255e-14im
- -7.34889e-10+1.44892e-15im  -5.70089e-10+1.95251e-15im  0.200693-3.55692e-14im           0.5+0.0im          -7.34885e-10-3.49861e-15im
- -5.70089e-10-5.48867e-15im  -7.34891e-10+2.13804e-15im  0.204779+4.27255e-14im  -7.34885e-10+3.49861e-15im           0.5+0.0im
+  4.594645 seconds (111.82 k allocations: 4.890 GiB, 2.81% gc time, 0.86% compilation time)
+5×5 OrbitalSliceMatrix{ComplexF64,Array}:
+          0.5+0.0im          -7.35075e-10+3.40256e-15im  0.204478+4.46023e-14im  -7.35077e-10-1.13342e-15im  -5.70426e-10-2.22213e-15im
+ -7.35075e-10-3.40256e-15im           0.5+0.0im          0.200693-4.46528e-14im  -5.70431e-10+3.53853e-15im  -7.35092e-10-4.07992e-16im
+     0.204478-4.46023e-14im      0.200693+4.46528e-14im       0.5+0.0im              0.200693+6.7793e-14im       0.204779-6.78156e-14im
+ -7.35077e-10+1.13342e-15im  -5.70431e-10-3.53853e-15im  0.200693-6.7793e-14im            0.5+0.0im            -7.351e-10+2.04708e-15im
+ -5.70426e-10+2.22213e-15im  -7.35092e-10+4.07992e-16im  0.204779+6.78156e-14im    -7.351e-10-2.04708e-15im           0.5+0.0im
 ```
 
 Note that the diagonal is `0.5`, indicating half-filling.
@@ -55,39 +55,43 @@ Note that the diagonal is `0.5`, indicating half-filling.
 The default algorithm used here is slow, as it relies on numerical integration in the complex plane. Some GreenSolvers have more efficient implementations. If they exist, they can be accessed by omitting the `(ωmin, ωmax)` argument. For example, using `GS.Spectrum`:
 ```julia
 julia> @time g = h |> greenfunction(GS.Spectrum());
- 37.638522 seconds (105 allocations: 2.744 GiB, 0.79% gc time)
+ 18.249136 seconds (75 allocations: 1.567 GiB, 0.67% gc time)
 
 julia> ρ = densitymatrix(g[region = RP.circle(1)])
-DensityMatrix: density matrix on specified sites with solver of type DensityMatrixSpectrumSolver
+DensityMatrix{DensityMatrixSpectrumSolver}: density matrix on specified sites
 
-julia> @time ρ(4)
-  0.001659 seconds (9 allocations: 430.906 KiB)
-5×5 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}:
-          0.5+0.0im  -2.21437e-15+0.0im  0.204478+0.0im   2.67668e-15+0.0im   3.49438e-16+0.0im
- -2.21437e-15+0.0im           0.5+0.0im  0.200693+0.0im  -1.40057e-15+0.0im  -2.92995e-15+0.0im
-     0.204478+0.0im      0.200693+0.0im       0.5+0.0im      0.200693+0.0im      0.204779+0.0im
-  2.67668e-15+0.0im  -1.40057e-15+0.0im  0.200693+0.0im           0.5+0.0im   1.81626e-15+0.0im
-  3.49438e-16+0.0im  -2.92995e-15+0.0im  0.204779+0.0im   1.81626e-15+0.0im           0.5+0.0im
+julia> @time ρ(4)  # second-run timing
+  0.029662 seconds (7 allocations: 688 bytes)
+5×5 OrbitalSliceMatrix{ComplexF64,Array}:
+         0.5+0.0im   -6.6187e-16+0.0im  0.204478+0.0im   2.49658e-15+0.0im  -2.6846e-16+0.0im
+ -6.6187e-16+0.0im           0.5+0.0im  0.200693+0.0im  -2.01174e-15+0.0im   1.2853e-15+0.0im
+    0.204478+0.0im      0.200693+0.0im       0.5+0.0im      0.200693+0.0im     0.204779+0.0im
+ 2.49658e-15+0.0im  -2.01174e-15+0.0im  0.200693+0.0im           0.5+0.0im  1.58804e-15+0.0im
+ -2.6846e-16+0.0im    1.2853e-15+0.0im  0.204779+0.0im   1.58804e-15+0.0im          0.5+0.0im
+
 ```
 
 Note, however, that the computation of `g` is much slower in this case, due to the need of a full diagonalization. A better algorithm choice in this case is `GS.KPM`. It requires, however, that we define the region for the density matrix beforehand, as a `nothing` contact.
 ```julia
 julia> @time g = h |> attach(nothing, region = RP.circle(1)) |> greenfunction(GS.KPM(order = 10000, bandrange = (0,8)));
-Computing moments: 100%|█████████████████████████████████████████████████████████████████████████████████| Time: 0:00:01
-  2.065083 seconds (31.29 k allocations: 11.763 MiB)
+Computing moments: 100%|███████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:01
+  1.360412 seconds (51.17 k allocations: 11.710 MiB)
 
 julia> ρ = densitymatrix(g[1])
-DensityMatrix: density matrix on specified sites with solver of type DensityMatrixKPMSolver
+DensityMatrix{DensityMatrixKPMSolver}: density matrix on specified sites
 
 julia> @time ρ(4)
-  0.006580 seconds (3 allocations: 1.156 KiB)
-5×5 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}:
+  0.004024 seconds (3 allocations: 688 bytes)
+5×5 OrbitalSliceMatrix{ComplexF64,Array}:
          0.5+0.0im  2.15097e-17+0.0im   0.20456+0.0im  2.15097e-17+0.0im   3.9251e-17+0.0im
  2.15097e-17+0.0im          0.5+0.0im  0.200631+0.0im  1.05873e-16+0.0im  1.70531e-18+0.0im
      0.20456+0.0im     0.200631+0.0im       0.5+0.0im     0.200631+0.0im      0.20482+0.0im
  2.15097e-17+0.0im  1.05873e-16+0.0im  0.200631+0.0im          0.5+0.0im  1.70531e-18+0.0im
   3.9251e-17+0.0im  1.70531e-18+0.0im   0.20482+0.0im  1.70531e-18+0.0im          0.5+0.0im
 ```
+
+!!! note "Alternative integration paths"
+    The integration algorithm allows many different integration paths that can be adjusted to each problem, see the `Paths` docstring. Another versatile choice is `Paths.radial(ωrate, ϕ)`. This one is called with `ϕ = π/4` when doing `ρ = densitymatrix(gs::GreenSlice, ωrate::Number)`. In the example above this is slightly faster than the `(ωmin, ωmax)` choice, which resorts to `Paths.sawtooth(ωmin, ωmax)`.
 
 ## Current
 
@@ -238,14 +242,7 @@ GreenFunction{Float64,2,0}: Green function of a Hamiltonian{Float64,2,0}
     Coordination     : 3.7448
 
 julia> J = josephson(g[1], 4.1)
-Integrator: Complex-plane integrator
-  Integration path    : (-4.1 + 1.4901161193847656e-8im, -2.05 + 2.050000014901161im, 0.0 + 1.4901161193847656e-8im)
-  Integration options : (atol = 1.0e-7,)
-  Integrand:          :
-  JosephsonIntegrand{Float64} : Equilibrium (dc) Josephson current observable before integration over energy
-    kBT                     : 0.0
-    Contact                 : 1
-    Number of phase shifts  : 0
+Josephson{JosephsonIntegratorSolver}: equilibrium Josephson current at a specific contact
 
 julia> qplot(g, children = (; sitecolor = :blue))
 ```
@@ -257,37 +254,31 @@ In this case we have chosen to introduce the superconducting leads with a model 
 corresponding to a BCS bulk, but any other self-energy form could be used. We have introduced the phase difference (`phase`) as a model parameter. We can now evaluate the zero-temperature Josephson current simply with
 ```julia
 julia> J(phase = 0)
--1.974396994480587e-16
+1.992660837638158e-12
 
 julia> J(phase = 0.2)
-0.004617597139699372
+0.0046175971391935605
 ```
 Note that finite temperatures can be taken using the `kBT` keyword argument for `josephson`, see docstring for details.
 
 One is often interested in the critical current, which is the maximum of the Josephson current over all phase differences. Quantica.jl can compute the integral over a collection of phase differences simultaneously, which is more efficient that computing them one by one. This is done with
 ```julia
 julia> φs = subdiv(0, pi, 11); J = josephson(g[1], 4.1; phases = φs)
-  Integration path    : (-4.1 + 1.4901161193847656e-8im, -2.05 + 2.050000014901161im, 0.0 + 1.4901161193847656e-8im)
-  Integration options : (atol = 1.0e-7,)
-  Integrand:          :
-  JosephsonIntegrand{Float64} : Equilibrium (dc) Josephson current observable before integration over energy
-    kBT                     : 0.0
-    Contact                 : 1
-    Number of phase shifts  : 11
+Josephson{JosephsonIntegratorSolver}: equilibrium Josephson current at a specific contact
 
 julia> Iφ = J()
 11-element Vector{Float64}:
- 1.868862401627357e-14
- 0.007231421775452674
- 0.014242855188877
- 0.02081870760779799
- 0.026752065104401878
- 0.031847203848574666
- 0.0359131410974842
- 0.03871895510547465
- 0.039762442694035505
- 0.03680096751905469
- 2.7677727119798235e-14
+ -6.361223111882911e-13
+  0.007231421776215144
+  0.01424285518831463
+  0.020818707606469377
+  0.026752065101976884
+  0.031847203846513975
+  0.035913141096514584
+  0.038718955102068034
+  0.03976244268586444
+  0.036800967573567184
+ -1.437196514806921e-12
 
 julia> f = Figure(); a = Axis(f[1,1], xlabel = "φ", ylabel = "I [e/h]"); lines!(a, φs, Iφ); scatter!(a, φs, Iφ); f
 ```

--- a/src/Quantica.jl
+++ b/src/Quantica.jl
@@ -28,7 +28,7 @@ export sublat, bravais_matrix, lattice, sites, supercell, hamiltonian,
        plusadjoint, neighbors, siteselector, hopselector, diagonal, sitepairs,
        unflat, torus, transform, translate, combine,
        spectrum, energies, states, bands, subdiv,
-       greenfunction, selfenergy, attach,
+       greenfunction, selfenergy, attach, Paths,
        plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults,
        conductance, josephson, ldos, current, transmission, densitymatrix,
        OrbitalSliceArray, OrbitalSliceVector, OrbitalSliceMatrix, orbaxes, siteindexdict,
@@ -63,6 +63,7 @@ include("transform.jl")
 include("mesh.jl")
 include("bands.jl")
 include("greenfunction.jl")
+include("integrator.jl")
 include("observables.jl")
 include("meanfield.jl")
 # Plumbing

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -1,0 +1,187 @@
+############################################################################################
+# Integrator paths
+#region
+
+abstract type AbstractIntegrationPath end
+
+struct PolygonPath{P} <: AbstractIntegrationPath
+    pts::P              # vertices of integration path
+end
+
+struct SawtoothPath{T<:Real} <: AbstractIntegrationPath
+    realpts::Vector{T}
+    slope::T
+    imshift::Bool
+end
+
+# straight from 0 to im*∞, but using a real variable from 0 to inf as parameter
+# this is because QuadGK doesn't understand complex infinities
+struct RadialPath{T<:AbstractFloat} <: AbstractIntegrationPath
+    rate::T
+    angle::T
+    cisinf::Complex{T}
+end
+
+#region ## Constructors ##
+
+SawtoothPath(pts::Vector{T}, slope, imshift) where {T<:Real} =
+    SawtoothPath(pts, T(slope), imshift)
+
+RadialPath(rate, angle) = RadialPath(promote(float(rate), float(angle))...)
+
+function RadialPath(rate::T, angle::T) where {T<:AbstractFloat}
+    0 <= angle < π/2 || argerror("The radial angle should be in the interval [0, π/2), got $angle")
+    RadialPath(rate, angle, cis(angle))
+end
+
+#endregion
+
+#region ## API ##
+
+points(p::PolygonPath, args...; _...) = p.pts
+points(p::PolygonPath{<:Function}, mu, kBT; params...) = p.pts(mu, kBT; params...)
+
+points(p::RadialPath{T}, mu, kBT; _...) where {T} = iszero(kBT) ?
+    [mu - T(Inf)*conj(p.cisinf), maybe_imshift(mu)] :
+    [mu - T(Inf)*conj(p.cisinf), maybe_imshift(mu), mu + T(Inf)*p.cisinf]
+
+function points(p::SawtoothPath, mu, kBT; _...)
+    pts = complex(p.realpts)
+    if (maximum(real, pts) > real(mu) > minimum(real, pts) && !any(≈(real(mu)), pts))
+        # insert µ if it is within extrema and not already included
+        sort!(push!(pts, mu), by = real)
+        iszero(kBT) && cut_tail!(x -> real(x) > real(mu), pts)
+    end
+    p.imshift && imshift!(pts)
+    triangular_sawtooth!(pts, p.slope)
+    return pts
+end
+
+maybe_imshift(x::T) where {T<:Real} = float(x) + sqrt(eps(float(T)))*im
+maybe_imshift(x::Complex) = float(x)
+
+imshift!(v::AbstractArray{Complex{T}}) where {T} = (v .+= sqrt(eps(T))*im; v)
+
+# Must be a type-stable tuple, and avoiding 0 in RadialPath
+realpoints(p::RadialPath{T}, pts) where {T} = (-T(Inf), T(0), ifelse(length(pts)==2, T(0), T(Inf)))
+realpoints(::Union{SawtoothPath,PolygonPath}, pts) = 1:length(pts)
+
+# note: pts[2] == µ
+point(x::Real, p::RadialPath, pts) = pts[2] + p.rate*x*ifelse(x <= 0, conj(p.cisinf), p.cisinf)
+
+function point(x::Real, p::Union{SawtoothPath,PolygonPath}, pts)
+    x0 = floor(Int, x)
+    p0, p1 = pts[x0], pts[ceil(Int, x)]
+    return p0 + (x-x0)*(p1 - p0)
+end
+
+# the minus sign inverts the RadialPath, so it is transformed to run from Inf to 0
+jacobian(x::Real, p::RadialPath, pts) =  p.rate*ifelse(x <= 0, conj(p.cisinf), p.cisinf)
+jacobian(x::Real, p::Union{SawtoothPath,PolygonPath}, pts) = pts[ceil(Int, x)] - pts[floor(Int, x)]
+
+function triangular_sawtooth!(pts, slope)
+    for i in 2:length(pts)
+        push!(pts, 0.5 * (pts[i-1] + pts[i]) + im * slope * 0.5 * (pts[i] - pts[i-1]))
+    end
+    sort!(pts, by = real)
+    return pts
+end
+
+#endregion
+
+#endregion
+#endregion
+
+############################################################################################
+# Paths module
+#region
+
+module Paths
+
+using Quantica: Quantica, PolygonPath, SawtoothPath, RadialPath, argerror
+
+## API
+
+sawtooth(ω1::Real, ω2::Real, ωs::Real...; kw...) = sawtooth(float.((ω1, ω2, ωs...)); kw...)
+sawtooth(ωmax::Real; kw...) = sawtooth!([-float(ωmax), float(ωmax)]; kw...)
+sawtooth(ωpoints::Tuple; kw...) = sawtooth!(collect(float.(ωpoints)); kw...)
+sawtooth(ωpoints::AbstractVector; kw...) = sawtooth!(float.(ωpoints); kw...)
+
+sawtooth!(pts::AbstractVector{<:AbstractFloat}; slope = 1, imshift = true) =
+    SawtoothPath(sort!(pts), slope, imshift)
+
+sawtooth!(pts; kw...) = argerror("Path.sawtooth expects a collection of real points, got $pts")
+
+radial(rate, angle) = RadialPath(rate, angle)
+
+polygon(ωmax::Real) = polygon((-ωmax, ωmax))
+polygon(ω1::Number, ω2::Number, ωs::Number...) = PolygonPath((ω1, ω2, ωs...))
+polygon(ωs) = PolygonPath(ωs)
+
+end # Module
+
+#endregion
+
+############################################################################################
+# Integrator - integrates a function f along a complex path ωcomplex(ω::Real), connecting ωi
+#   The path is piecewise linear in the form of a triangular sawtooth with a given ± slope
+#region
+
+struct Integrator{I,T,P,O<:NamedTuple,C,F}
+    integrand::I    # call!(integrand, ω::Complex; params...)::Union{Number,Array{Number}}
+    pts::P          # points in the integration interval
+    result::T       # can be missing (for scalar integrand) or a mutable type (nonscalar)
+    quadgk_opts::O  # kwargs for quadgk
+    callback::C     # callback to call at each integration step (callback(ω, i(ω)))
+    post::F         # function to apply to the result of the integration
+end
+
+#region ## Constructor ##
+
+function Integrator(result, f, path; post = identity, callback = Returns(nothing), quadgk_opts...)
+    quadgk_opts´ = NamedTuple(quadgk_opts)
+    return Integrator(f, path, result, quadgk_opts´, callback, post)
+end
+
+Integrator(f, path; kw...) = Integrator(missing, f, path; kw...)
+
+#endregion
+
+#region ## API ##
+
+integrand(I::Integrator) = I.integrand
+
+points(I::Integrator) = I.pts
+
+options(I::Integrator) = I.quadgk_opts
+
+## call! ##
+# scalar version
+function call!(I::Integrator{<:Any,Missing}; params...)
+    fx = x -> begin
+        y = call!(I.integrand, x; params...)  # should be a scalar
+        I.callback(x, y)
+        return y
+    end
+    result, err = quadgk(fx, points(I)...; I.quadgk_opts...)
+    result´ = I.post(result)
+    return result´
+end
+
+# nonscalar version
+function call!(I::Integrator{<:Any,T}; params...) where {T}
+    fx! = (y, x) -> begin
+        y .= serialize(call!(I.integrand, x; params...))
+        I.callback(x, y)
+        return nothing
+    end
+    result, err = quadgk!(fx!, serialize(I.result), points(I)...; I.quadgk_opts...)
+    # note: post-processing is not element-wise & can be in-place
+    result´ = I.post(unsafe_deserialize(I.result, result))
+    return result´
+end
+
+(I::Integrator)(; params...) = copy(call!(I; params...))
+
+#endregion
+#endregion

--- a/src/show.jl
+++ b/src/show.jl
@@ -428,26 +428,26 @@ Base.summary(::Transmission) =
 
 #endregion
 
-############################################################################################
-# Integrator
-#region
+# ############################################################################################
+# # Integrator
+# #region
 
-function Base.show(io::IO, I::Integrator)
-    i = get(io, :indent, "")
-    print(io, i, summary(I), "\n",
-"$i  Integration path    : $(path(I))
-$i  Integration options : $(display_namedtuple(options(I)))
-$i  Integrand           : ")
-    ioindent = IOContext(io, :indent => i * "  ")
-    show(ioindent, integrand(I))
-end
+# function Base.show(io::IO, I::Integrator)
+#     i = get(io, :indent, "")
+#     print(io, i, summary(I), "\n",
+# "$i  Integration path    : $(path(I))
+# $i  Integration options : $(display_namedtuple(options(I)))
+# $i  Integrand           : ")
+#     ioindent = IOContext(io, :indent => i * "  ")
+#     show(ioindent, integrand(I))
+# end
 
-Base.summary(::Integrator) = "Integrator: Complex-plane integrator"
+# Base.summary(::Integrator) = "Integrator: Complex-plane integrator"
 
 
-display_namedtuple(nt::NamedTuple) = isempty(nt) ? "()" : "$nt"
+# display_namedtuple(nt::NamedTuple) = isempty(nt) ? "()" : "$nt"
 
-#endregion
+# #endregion
 
 ############################################################################################
 # Josephson and DensityMatrix integrands

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -359,6 +359,11 @@ sites_to_orbs(c::SparseIndices{<:Any,<:Hamiltonian}, _) = c
 # unused
 # sites_to_orbs_nogroups(cs::CellOrbitals, _) =  cs
 
+## CellOrbitals{L,Colon} -> CellOrbitals with explicit index range
+
+sites_to_orbs(cs::CellOrbitals{<:Any,Colon}, g) =
+    sites_to_orbs_nogroups(sites(cell(cs), :), g)
+
 ## DiagIndices -> DiagIndices
 
 function sites_to_orbs(d::DiagIndices, g)
@@ -403,14 +408,13 @@ end
 
 ## convert CellSites -> CellOrbitalsGrouped
 
-sites_to_orbs(c::CellSites, g, ker...) =
-    sites_to_orbs(sanitize_cellindices(c, g), blockstructure(g), ker...)
+sites_to_orbs(c::CellSites, g) =
+    sites_to_orbs(sanitize_cellindices(c, g), blockstructure(g))
 
-function sites_to_orbs(cs::CellSites, os::OrbitalBlockStructure, ker...)
-    os´ = maybe_scalarize(os, ker...)
+function sites_to_orbs(cs::CellSites, os::OrbitalBlockStructure)
     sites = siteindices(cs)
-    groups = _groups(sites, os´) # sites, orbranges
-    orbinds = _orbinds(sites, groups, os´)
+    groups = _groups(sites, os) # sites, orbranges
+    orbinds = _orbinds(sites, groups, os)
     return CellOrbitalsGrouped(cell(cs), orbinds, Dictionary(groups...))
 end
 

--- a/src/solvers/green.jl
+++ b/src/solvers/green.jl
@@ -76,3 +76,4 @@ include("green/spectrum.jl")
 include("green/schur.jl")
 include("green/kpm.jl")
 include("green/bands.jl")
+include("green/internal.jl")    # solvers for internal use only

--- a/src/solvers/green/bands.jl
+++ b/src/solvers/green/bands.jl
@@ -883,12 +883,14 @@ minimal_callsafe_copy(s::BandsGreenSlicer, parentham, parentcontacts) = s  # it 
 
 ############################################################################################
 # getindex_diag: optimized cell indexing for BandsGreenSlicer, used by diagonal indexing
+#   no need to compute full ψ * ψ' if only diagonal is needed
 #region
 
 # triggers fast codepath above
-getindex_diag(gω::GreenSolution{T,<:Any,<:Any,G}, o::CellOrbitalsGrouped) where {T,G<:BandsGreenSlicer{<:Any,Missing}} =
-    inf_band_slice(slicer(gω), SparseIndices(o, Missing), SparseIndices(o, Missing))
+getindex_diag(gω::GreenSolution{T,<:Any,<:Any,G}, o::CellOrbitalsGrouped, symmetrize) where {T,G<:BandsGreenSlicer{<:Any,Missing}} =
+    maybe_symmetrized_matrix(
+        inf_band_slice(slicer(gω), SparseIndices(o, Missing), SparseIndices(o, Missing)),
+        symmetrize)
 
 #endregion
-
 #endregion

--- a/src/solvers/green/internal.jl
+++ b/src/solvers/green/internal.jl
@@ -1,0 +1,50 @@
+############################################################################################
+# AppliedModelGreenSolver - only for internal use
+#   Given a function f(ω) that returns a function fω(::CellOrbital, ::CellOrbital),
+#   implement an AppliedGreenSolver that returns a s::ModelGreenSlicer that returns fω(i,j)
+#   for each single orbital when calling getindex(s, ::CellOrbitals...). view not supported.
+#region
+
+struct AppliedModelGreenSolver{F} <: AppliedGreenSolver
+    f::F
+end
+
+struct ModelGreenSlicer{C<:Complex,L,F} <: GreenSlicer{C}
+    ω::C
+    fω::F
+    contactorbs::ContactOrbitals{L}
+    g0contacts::Matrix{C}
+end
+
+## API ##
+
+function (g::GreenSlice)(x::UniformScaling)
+    s = AppliedModelGreenSolver(Returns((i, j) -> ifelse(i == j, x.λ, zero(x.λ))))
+    g´ = swap_solver(g, s)
+    return g´(0)
+end
+
+## GreenFunction API ##
+
+function (s::AppliedModelGreenSolver)(ω::C, Σblocks, contactorbs) where {C}
+    n = norbitals(contactorbs)
+    fω = s.f(ω)
+    g0contacts = Matrix{C}(undef, n, n)
+    slicer = ModelGreenSlicer(ω, fω, contactorbs, g0contacts)
+    fill_g0contacts!(g0contacts, slicer, contactorbs)
+    return slicer
+end
+
+needs_omega_shift(s::AppliedModelGreenSolver) = false
+
+minimal_callsafe_copy(s::Union{ModelGreenSlicer,AppliedModelGreenSolver}, args...) = s
+
+Base.getindex(s::ModelGreenSlicer, is::CellOrbitals, js::CellOrbitals) =
+    [s.fω(i, j) for i in cellorbs(is), j in cellorbs(js)]
+
+Base.view(s::ModelGreenSlicer, i::Integer, j::Integer) =
+    view(s.g0contacts, contactinds(s.contactorbs, i), contactinds(s.contactorbs, j))
+
+Base.view(s::ModelGreenSlicer, ::Colon, ::Colon) = view(s.g0contacts, :, :)
+
+#endregion

--- a/src/solvers/green/sparselu.jl
+++ b/src/solvers/green/sparselu.jl
@@ -101,6 +101,8 @@ end
 Base.view(s::SparseLUGreenSlicer, ::Colon, ::Colon) =
     compute_or_retrieve_green(s, s.unitcindsall, s.unitcindsall, s.source64, s.sourceC)
 
+# Here it is assumed that CellOrbitals has explicit orbindices (i.e. not Colon)
+# This is enforced by indexing in greenfunction.jl
 function Base.view(s::SparseLUGreenSlicer{C}, i::CellOrbitals, j::CellOrbitals) where {C}
     # we only preallocate if we actually need to call ldiv! below (empty unitg cache)
     must_call_ldiv! = !isdefined(s, :unitg)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -71,6 +71,10 @@ chopsmall(xs, atol) = chopsmall.(xs, Ref(atol))
 chopsmall(xs) = chopsmall.(xs)
 chopsmall(xs::UniformScaling, atol...) = I * chopsmall(xs.λ, atol...)
 
+mul_scalar_or_array!(x::Number, factor) = factor * x
+mul_scalar_or_array!(x::Tuple, factor) = factor .* x
+mul_scalar_or_array!(x::AbstractArray, factor) = (x .*= factor; x)
+
 # Flattens matrix of Matrix{<:Number} into a matrix of Number's
 function mortar(ms::AbstractMatrix{M}) where {C<:Number,M<:Matrix{C}}
     isempty(ms) && return convert(Matrix{C}, ms)
@@ -137,6 +141,15 @@ lengths_to_offsets(v::NTuple{<:Any,Integer}) = (0, cumsum(v)...)
 lengths_to_offsets(v) = prepend!(cumsum(v), 0)
 lengths_to_offsets(f::Function, v) = prepend!(accumulate((i,j) -> i + f(j), v; init = 0), 0)
 
+# remove elements of xs after and including the first for which f(x) is true
+function cut_tail!(f, xs)
+    i = 1
+    for outer i in eachindex(xs)
+        f(xs[i]) && break
+    end
+    resize!(xs, i-1)
+    return xs
+end
 
 # fast tr(A*B)
 trace_prod(A, B) = (check_sizes(A,B); unsafe_trace_prod(A, B))

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -39,6 +39,8 @@
         @test nothing === show(stdout, sites(SA[1], 2:4))
         @test nothing === show(stdout, sites(:))
         @test nothing === show(stdout, sites(SA[0], :))
+        m = LP.linear() |> hopping(1) |> greenfunction |> meanfield
+        @test nothing === show(stdout, m)
     end
     h = first(hs)
     @test nothing === show(stdout, serializer(h))


### PR DESCRIPTION
We introduce submodule `Paths` that contain different possible integration paths for `densitymatrix` and `josephson`. The default `densitymatrix(gs, ω0; kw...)` corresponds to `densitymatrix(gs, Paths.radial(ω0, π/4); kw...)`. This no longer an integral from `-ω0` to `ω0`, but rather along a path as shown in the figure, where the angle in orange is set to `ϕ = π/4`, and the outer arcs are taken to infinity. (The angle can of course be changed by using the full `densitymatrix(gs, Paths.radial(ω0, ϕ); kw...)` syntax)

<img width="360" alt="image" src="https://github.com/user-attachments/assets/60c9ebd3-adac-4027-a932-5d020338b49d">

The integral over the arcs is analytic (thanks to spectral weight normalization), so only the radial parts need to be computed numerically. Along these radial parts the path is parametrized as `ω = x * ω0 * cis(sign(x)*ϕ)` with `x` from `-Inf` to `Inf`, so that `ω0` has the meaning of a radial speed. This method is often faster than the old sawtooth path default, and does not require precomputing `ω0` precisely as we did before (where it needed to be greater than the system half-bandwidth): the integral will converge to the same value regardless of `ω0`, only integration time will change, making this a much more robust default.

The old sawtooth path is available through `Paths.sawtooth(reak_ω_points...; slope = 1, imshift = true)` and we also have a general `Paths.polygon(complex_ω_points...)`. Note that `josephson(gs, ωs::Tuple)` defaults to `josephson(gs, Paths.sawtooth(ωs...))`, and the same for `densitymatrix`.

The old `path_override` hack is no longer necessary, since we now also have `Paths.polygon((µ, kBT; params...) -> ωpoints)` as a possible path, which changes depending on chemical potential, temperature or system parameters.

As this is a breaking change, I summarize what needs to be done to old codebases to adapt:
- `josephson(gs, ωmax)` will now use a different (often faster) algorithm, and `ωmax` may be replaced with any estimated `ω0` energy scale that dominates the contribution to the Josephson current (no need to compute a band range explicitly). This parameter only affects integration speed, not the result. To get the old behavior use `josephson(gs, (-ωmax, ωmax))` instead. Same story for `densitymatrix`
- `J(kBT, ωpoints; params...)` as syntax to override `ωpoints` should now be replace with `J = josephson(gs, Paths.polygon((µ, kBT; params...) -> ωpoints)`, and then simply `J(kBT; params...)`. Note the use of µ in the polygon function signature, which is simply ignored in the `josephson` case, as `µ = 0` there. Same story for `densitymatrix`, although in that case ωpoints can depend on `µ` too.