### PR TITLE
Add `selector_hartree` and `selector_fock` to `meanfield`

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2670,7 +2670,8 @@ where `U` is the onsite interaction.
 - `charge`: a number (in single-orbital systems) or a matrix (in multi-orbital systems) representing the charge operator on each site. Default: `I`
 - `nambu::Bool`: specifies whether the model is defined in Nambu space. In such case, `charge` should also be in Nambu space, typically `SA[1 0; 0 -1]` or similar. Default: `false`
 - `namburotation::Bool`: if `nambu == true` and spinful systems, specifies whether the spinor basis is `[c↑, c↓, c↓⁺, -c↑⁺]` (`namburotation = true`) or `[c↑, c↓, c↑⁺, c↓⁺]` (`namburotation = false`). Default: `false`
-- `selector::NamedTuple`: a collection of `hopselector` directives that defines the pairs of sites (`pair_selection` above) that interact through the charge-charge potential. Default: `(; range = 0)` (i.e. onsite)
+- `selector::NamedTuple`: a collection of `hopselector` directives that defines the pairs of sites (`pair_selection` above) that interact through the charge-charge potential. Default: `(; range = 0)` (i.e. only onsite)
+- `selector_hartree::NamedTuple`: same as `selector`, but restricted to the Hartree interaction. Useful to do efficient Hartree-only simulations, by setting `fock = 0` and leaving `selector` at its `(; range =0)` default. Then, having a large range in `selector_hartree` will be cheap. Default: `selector`.
 
 Any additional keywords `kw` are passed to the `densitymatrix` function used to compute the
 mean field, see above

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2666,12 +2666,13 @@ where `U` is the onsite interaction.
 - `potential`: charge-charge potential to use for both Hartree and Fock. Can be a number or a function of position. Default: `1`
 - `hartree`: charge-charge potential `v_H` for the Hartree mean field. Can be a number or a function of position. Overrides `potential`. Default: `potential`
 - `fock`: charge-charge potential `v_F` for the Fock mean field. Can be a number, a function of position or `nothing`. In the latter case all Fock terms (even onsite) will be dropped. Default: `hartree`
-- `onsite`: charge-charge onsite potential. Overrides both Hartree and Fock potentials for onsite interactions. Default: `hartree(0)`
+- `onsite`: charge-charge onsite potential. Overrides both Hartree and Fock potentials for onsite interactions, unless `fock = nothing` (it then overrides only Hartree, see above). Default: `hartree(0)`
 - `charge`: a number (in single-orbital systems) or a matrix (in multi-orbital systems) representing the charge operator on each site. Default: `I`
 - `nambu::Bool`: specifies whether the model is defined in Nambu space. In such case, `charge` should also be in Nambu space, typically `SA[1 0; 0 -1]` or similar. Default: `false`
 - `namburotation::Bool`: if `nambu == true` and spinful systems, specifies whether the spinor basis is `[c↑, c↓, c↓⁺, -c↑⁺]` (`namburotation = true`) or `[c↑, c↓, c↑⁺, c↓⁺]` (`namburotation = false`). Default: `false`
 - `selector::NamedTuple`: a collection of `hopselector` directives that defines the pairs of sites (`pair_selection` above) that interact through the charge-charge potential. Default: `(; range = 0)` (i.e. only onsite)
-- `selector_hartree::NamedTuple`: same as `selector`, but restricted to the Hartree interaction. Useful to do efficient Hartree-only simulations, by setting `fock = 0` and leaving `selector` at its `(; range =0)` default. Then, having a large range in `selector_hartree` will be cheap. Default: `selector`.
+- `selector_hartree::NamedTuple`: same as `selector`, but restricted to the Hartree interactions. Useful e.g. to do efficient Hartree-only simulations: a long-range `selector_hartree` is cheap in periodic systems, as lattice periodicity is exploited to make the computational cost independent of the range. Default: `selector`.
+- `selector_fock::NamedTuple`: same as `selector_hartree`, but for Fock interactions. Note that `selector_fock` increases the number of entries that need to be computed for the density matrix, so increasing the Fock range is typically not cheap. Default: `selector`.
 
 Any additional keywords `kw` are passed to the `densitymatrix` function used to compute the
 mean field, see above

--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -26,7 +26,7 @@ struct ZeroField end
 function meanfield(g::GreenFunction{T,E}, args...;
     potential = Returns(1), hartree = potential, fock = hartree,
     onsite = missing, charge = I, nambu::Bool = false, namburotation = missing,
-    selector::NamedTuple = (; range = 0), kw...) where {T,E}
+    selector::NamedTuple = (; range = 0), selector_hartree = selector, kw...) where {T,E}
 
     Vh = sanitize_potential(hartree)
     Vf = sanitize_potential(fock)
@@ -46,8 +46,8 @@ function meanfield(g::GreenFunction{T,E}, args...;
     lat = lattice(hamiltonian(g))
     # The sparse structure of hFock will be inherited by the evaluated mean field. Need onsite.
     hFock = lat |> hopping((r, dr) -> iszero(dr) ? Uf : T(Vf(dr)); selector..., includeonsite = true)
-    hHartree = (Uf == U && Vh === Vf) ? hFock :
-        lat |> hopping((r, dr) -> iszero(dr) ? U : T(Vh(dr)); selector..., includeonsite = true)
+    hHartree = (Uf == U && Vh == Vf && selector == selector_hartree) ? hFock :
+        lat |> hopping((r, dr) -> iszero(dr) ? U : T(Vh(dr)); selector_hartree..., includeonsite = true)
     # this drops zeros
     potHartree = T.(sum(unflat, harmonics(hHartree)))
 

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -697,7 +697,7 @@ function (s::DensityMatrixSchurSolver)(µ, kBT; params...)
     xs = sort!(ϕs ./ (2π))
     pushfirst!(xs, -0.5)
     push!(xs, 0.5)
-    xs = [mean(view(xs, rng)) for rng in approxruns(xs)]  # elliminate approximate duplicates
+    xs = [mean(view(xs, rng)) for rng in approxruns(xs)]  # eliminate approximate duplicates
     result = call!_output(s.gs)
     integrand!(x) = fermi_h!(result, s, 2π * x, µ, inv(kBT); params...)
     fx! = (y, x) -> (y .= integrand!(x))


### PR DESCRIPTION
When doing meanfield calculations, sometimes we want long-range Hartree interactions (which take the form of purely onsite terms), but don't need long-range Fock terms (which induce long-range hoppings, which in turn often make calculations more expensive).

Currently, the `selector` kwarg in `meanfield` sets the interacting site pairs for building both the Hartree onsite terms and the Fock hopping terms. The only way to switch off Fock is to set `fock = 0`, but that doesn't eliminate the Fock hopping terms, it just makes them zero, producing unnecessary overhead in some solvers (e.g. GS.Schur, which then requires building a large supercell to preserve only nearest-cell hoppings).

In this PR we provide `selector_hartree` that applies to the calculation of Hartree onsite terms, overriding the general `selector` that applies to both Hatree and Fock by default. In this way, we can set `selector = (; range = 0)` (i.e. the default), `fock = 0` and `selector_hartree = (; range = large_distance)`, and have long-range Hartree-only meanfields without the long-range hopping overhead.

EDIT: we also add `selector_fock` for completeness and symmetry. Both default to `selector`, which is the one to use when we don't want to make a difference, just as `potential` is the one to use, instead of `hartree` and `fock`, when we want to treat hartree and fock consistently.