### PR TITLE
Remove unintended `nameof` type piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -64,6 +64,7 @@ KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [targets]
 test = ["Test", "LinearMaps", "ArnoldiMethod", "KrylovKit", "Arpack", "CairoMakie", "Distributed"]

--- a/Project.toml
+++ b/Project.toml
@@ -66,4 +66,4 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "LinearMaps", "ArnoldiMethod", "KrylovKit", "Arpack", "CairoMakie"]
+test = ["Test", "LinearMaps", "ArnoldiMethod", "KrylovKit", "Arpack", "CairoMakie", "Distributed"]

--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -213,7 +213,7 @@ julia> g(0.2)
 GreenSolution{Float64,2,0}: Green function at arbitrary positions, but at a fixed energy
 
 julia> g(0.2)[1, 3]
-5×5 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}:
+5×5 OrbitalSliceArray{ComplexF64,Array}:
  -2.56906+0.000123273im  -4.28767+0.00020578im   -4.88512+0.000234514im  -4.28534+0.00020578im    -2.5664+0.000123273im
  -4.28767+0.00020578im   -7.15613+0.00034351im   -8.15346+0.000391475im  -7.15257+0.00034351im    -4.2836+0.000205781im
  -4.88512+0.000234514im  -8.15346+0.000391475im  -9.29002+0.000446138im  -8.14982+0.000391476im  -4.88095+0.000234514im
@@ -221,7 +221,7 @@ julia> g(0.2)[1, 3]
   -2.5664+0.000123273im   -4.2836+0.000205781im  -4.88095+0.000234514im  -4.28211+0.000205781im  -2.56469+0.000123273im
 
 julia> g(0.2)[siteselector(region = RP.circle(1, (0.5, 0))), 3]
-2×5 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}:
+2×5 OrbitalSliceArray{ComplexF64,Array}:
  0.0749214+3.15744e-8im   0.124325+5.27948e-8im   0.141366+6.01987e-8im   0.124325+5.27948e-8im  0.0749214+3.15744e-8im
  -0.374862+2.15287e-5im  -0.625946+3.5938e-5im   -0.712983+4.09561e-5im  -0.624747+3.59379e-5im   -0.37348+2.15285e-5im
 ```
@@ -248,19 +248,19 @@ GreenFunction{Float64,2,2}: Green function of a Hamiltonian{Float64,2,2}
     Coordination     : 3.0
 
 julia> g(0.5)[diagonal(cells = (0, 0))]
-4-element OrbitalSliceVector{Vector{ComplexF64}}:
-  -0.3497363468480622 - 0.3118358260294266im
-  -0.3497363468271048 - 0.31183582602942655im
-  -0.3497363468402952 - 0.31183582602942667im
- -0.34973634686125243 - 0.3118358260294267im
+4×4 OrbitalSliceMatrix{ComplexF64,LinearAlgebra.Diagonal{ComplexF64, Vector{ComplexF64}}}:
+ -0.349736-0.311836im        0.0+0.0im             0.0+0.0im             0.0+0.0im
+       0.0+0.0im       -0.349736-0.311836im        0.0+0.0im             0.0+0.0im
+       0.0+0.0im             0.0+0.0im       -0.349736-0.311836im        0.0+0.0im
+       0.0+0.0im             0.0+0.0im             0.0+0.0im       -0.349736-0.311836im
 ```
 
 Note that we get an `OrbitalSliceVector`, which is equal to the diagonal `diag(g(0.5)[cells = (0, 0)])`. Like the `g` `OrbitalSliceMatrix`, this vector is resolved in orbitals, of which there are two per site and four per unit cell in this case. Using `diagonal(sᵢ; kernel = K)` we can collect all the orbitals of different sites, and compute `tr(g[site, site] * K)` for a given matrix `K`. This is useful to obtain spectral densities. In the above example, and interpreting the two orbitals per site as the electron spin, we could obtain the spin density along the `x` axis, say, using `σx = SA[0 1; 1 0]` as `kernel`,
 ```julia
 julia> g(0.5)[diagonal(cells = (0, 0), kernel = SA[0 1; 1 0])]
-2-element OrbitalSliceVector{Vector{ComplexF64}}:
-   4.26186044627701e-12 - 2.2846013280115095e-17im
- -4.261861877528737e-12 + 1.9177925470610777e-17im
+2×2 OrbitalSliceMatrix{ComplexF64,LinearAlgebra.Diagonal{ComplexF64, Vector{ComplexF64}}}:
+ -2.57031e-12-2.62859e-17im          0.0+0.0im
+          0.0+0.0im          2.57031e-12+2.27291e-17im
 ```
 which is zero in this spin-degenerate case
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -716,7 +716,7 @@ julia> h[sites(1), sites(2)]
  1.0+0.0im  0.0+0.0im
 
 julia> ph = h |> @hopping!((t; p = 3) -> p*t); ph[region = RP.square(1)]
-4×4 OrbitalSliceMatrix{ComplexF64,SparseMatrixCSC}:
+4×4 OrbitalSliceMatrix{ComplexF64,SparseArrays.SparseMatrixCSC{ComplexF64, Int64}}:
  0.0+0.0im  0.0+0.0im  0.0+0.0im  3.0+0.0im
  0.0+0.0im  0.0+0.0im  3.0+0.0im  0.0+0.0im
  0.0+0.0im  3.0+0.0im  0.0+0.0im  0.0+0.0im
@@ -1684,7 +1684,7 @@ julia> gω[ss] == gs(0.1; t = 2)
 true
 
 julia> summary(gω[ss])
-"14×14 OrbitalSliceMatrix{ComplexF64,Array}"
+"14×14 OrbitalSliceMatrix{ComplexF64,Matrix{ComplexF64}}"
 ```
 
 # See also
@@ -1752,7 +1752,7 @@ julia> g(1)[diagonal(:)]                            # g(ω = 1) diagonal on all 
       0.0+0.0im             0.0+0.0im             0.0+0.0im        -0.10919-0.0839858im
 
 julia> g(1)[diagonal(:, kernel = SA[1 0; 0 -1])]    # σz spin density of the above
-2×2 OrbitalSliceMatrix{ComplexF64,LinearAlgebra.Diagonal{ComplexF64, Vector{ComplexF64}}}:
+4×4 OrbitalSliceMatrix{ComplexF64,LinearAlgebra.Diagonal{ComplexF64, Vector{ComplexF64}}}:
  5.61885e-12+1.38778e-17im           0.0+0.0im
          0.0+0.0im          -5.61882e-12+2.77556e-17im
 ```
@@ -1845,7 +1845,7 @@ GreenFunction{Float64,2,0}: Green function of a Hamiltonian{Float64,2,0}
     Coordination     : 2.94065
 
 julia> ldos(g(0.2))[1]
-6-element OrbitalSliceVector{Vector{Float64}}:
+6-element OrbitalSliceVector{Float64,Vector{Float64}}:
  0.036802204179316955
  0.034933055722650375
  0.03493305572265026
@@ -2302,7 +2302,7 @@ used e.g. to index another `OrbitalSliceArray` or to inspect the indices of each
 julia> g = HP.graphene(orbitals = 2) |> supercell((1,-1)) |> greenfunction;
 
 julia> d = ldos(g[cells = SA[0]])(2); summary(d)
-"8-element OrbitalSliceVector{Float64,Array}"
+"8-element OrbitalSliceVector{Float64,Vector{Float64}}"
 
 julia> a = only(orbaxes(d))
 OrbitalSliceGrouped{Float64,2,1} : collection of subcells of orbitals (grouped by sites) for a 1D lattice in 2D space

--- a/src/show.jl
+++ b/src/show.jl
@@ -547,12 +547,13 @@ Base.summary(::CurrentDensitySlice{T}) where {T} =
 
 function Base.showarg(io::IO, ::A, toplevel) where {T,M,A<:AbstractOrbitalArray{T,<:Any,M}}
     toplevel || print(io, "::")
-    print(io,  "$(nameof(A)){$T,$(nameof(M))}")
+    print(io,  "$(shortalias(A)){$T,$M}")
 end
 
-Base.nameof(::Type{<:OrbitalSliceMatrix}) = "OrbitalSliceMatrix"
-Base.nameof(::Type{<:OrbitalSliceVector}) = "OrbitalSliceVector"
-Base.nameof(::Type{<:CompressedOrbitalMatrix}) = "CompressedOrbitalMatrix"
+shortalias(::Type{<:OrbitalSliceMatrix}) = "OrbitalSliceMatrix"
+shortalias(::Type{<:OrbitalSliceVector}) = "OrbitalSliceVector"
+shortalias(::Type{<:CompressedOrbitalMatrix}) = "CompressedOrbitalMatrix"
+shortalias(::Type{A}) where {A} = nameof(A)
 
 #endregion
 

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -629,4 +629,10 @@ end
     m´ = g(0.2)[cells = 0]
     v = serialize(m)
     @test_throws ArgumentError deserialize(m´, v)
+
+    # issue #327
+    using Distributed; addprocs(1) # for Serialization
+    @everywhere using Quantica
+    g = LP.linear() |> hopping(1) |> attach(nothing, cells = 0) |> greenfunction
+    @test remotecall_fetch(g[1], 2, 0) isa OrbitalSliceMatrix
 end

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -610,6 +610,9 @@ end
     @test_throws ArgumentError meanfield(g)
 end
 
+using Distributed; addprocs(1) # for Serialization below
+@everywhere using Quantica
+
 @testset begin "OrbitalSliceArray serialization"
     g = LP.linear() |> supercell(4) |> supercell |> hamiltonian(hopping(I), orbitals = 2) |> greenfunction
     m = g(0.2)[cells = 0]
@@ -631,8 +634,6 @@ end
     @test_throws ArgumentError deserialize(m´, v)
 
     # issue #327
-    using Distributed; addprocs(1) # for Serialization
-    @everywhere using Quantica
     g = LP.linear() |> hopping(1) |> attach(nothing, cells = 0) |> greenfunction
     @test remotecall_fetch(g[1], 2, 0) isa OrbitalSliceMatrix
 end


### PR DESCRIPTION
Closes #327 

The reason for #327 was an obscure problem with stdlib Serialization caused by the following methods
```
Base.nameof(::Type{<:OrbitalSliceMatrix}) = "OrbitalSliceMatrix"
Base.nameof(::Type{<:OrbitalSliceVector}) = "OrbitalSliceVector"
Base.nameof(::Type{<:CompressedOrbitalMatrix}) = "CompressedOrbitalMatrix"
```
It might not seem at first sight, but this is a rookie mistake: those are doing pretty terrible `nameof` piracy (even though `OrbitalSliceArray` etc. are all property of Quantica), and were causing all sort of havoc, particularly in Distributed calculations (which relies on Serialization, which mysteriously choked due to the above)
