### PR TITLE
Disallow integrand params to be different from integration path params

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2186,8 +2186,7 @@ josephson
 Return the complex integrand `d::JosephsonIntegrand` whose integral over frequency yields
 the Josephson current, `J(kBT; params...) = Re(∫dx d(x; params...))`, where `ω(x) =
 Quantica.point(x, d)` is a path parametrization over real variable `x` . To evaluate the `d`
-for a given `x` and parameters, use `d(x; params...)`, or `call!(d, x; params...)` for its
-mutating (non-allocating) version.
+for a given `x`, use `d(x)`, or `call!(d, x)` for its mutating (non-allocating) version.
 
     Quantica.integrand(ρ::DensityMatrix{<:DensityMatrixIntegratorSolver}, mu = 0, kBT = 0; params...)
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -37,6 +37,9 @@ call!_output(c::Contacts) = selfenergyblocks(c)
 
 ############################################################################################
 # GreenFuntion call! API
+#   `symmetrize` and `post` allow to obtain gij and conj(gji) combinations efficiently.
+#   Useful when computing e.g. the spectral density A = (Gʳ-Gʳ')/2πi on a non-diagonal slice
+#   These kwargs are currently not documented - see specialmatrices.jl
 #region
 
 (g::GreenFunction)(ω; params...) = minimal_callsafe_copy(call!(g, ω; params...))

--- a/src/integrator.jl
+++ b/src/integrator.jl
@@ -157,9 +157,9 @@ options(I::Integrator) = I.quadgk_opts
 
 ## call! ##
 # scalar version
-function call!(I::Integrator{<:Any,Missing}; params...)
+function call!(I::Integrator{<:Any,Missing})
     fx = x -> begin
-        y = call!(I.integrand, x; params...)  # should be a scalar
+        y = call!(I.integrand, x)  # should be a scalar
         I.callback(x, y)
         return y
     end
@@ -169,9 +169,9 @@ function call!(I::Integrator{<:Any,Missing}; params...)
 end
 
 # nonscalar version
-function call!(I::Integrator{<:Any,T}; params...) where {T}
+function call!(I::Integrator{<:Any,T}) where {T}
     fx! = (y, x) -> begin
-        y .= serialize(call!(I.integrand, x; params...))
+        y .= serialize(call!(I.integrand, x))
         I.callback(x, y)
         return nothing
     end
@@ -181,7 +181,7 @@ function call!(I::Integrator{<:Any,T}; params...) where {T}
     return result´
 end
 
-(I::Integrator)(; params...) = copy(call!(I; params...))
+(I::Integrator)() = copy(call!(I))
 
 #endregion
 #endregion

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -552,6 +552,16 @@ end
     ρ2 = densitymatrix(g[is, js], Paths.sawtooth(4))
     @test ρ0() ≈ ρ1() ≈ ρ2()
     @test ρ0(0.1, 0.2) ≈ ρ1(0.1, 0.2) ≈ ρ2(0.1, 0.2)
+
+    # parametric path and system
+    g = LP.linear() |> supercell |> @onsite((; o = 0.5) -> o) |> greenfunction
+    ρ = densitymatrix(g[], Paths.polygon((µ, T; o = 0.5) -> o > µ ? (-1, µ, o + im, 1) : (-1, o + im, µ, 1)))
+    @test real(only(ρ(0, 0; o = -0.5))) ≈ 1
+    @test real(only(ρ(0, 0; o = 0.5))) < 1e-7
+    @test real(only(ρ(0, 0; o = 1.5))) < 1e-7
+    @test real(only(ρ(0, 0; o = -1.5))) < 1e-7
+    d = Quantica.integrand(ρ)
+    @test_throws MethodError d(2; o = 0.8)
 end
 
 @testset "greenfunction aliasing" begin


### PR DESCRIPTION
Closes #329 (implements fix 1 therein)

When the integrand is built using `params`, these are bundled into a closure, together with `omegamap`, which simplifies the `JosephsonIntegrand` and `DensityMatrixIntegrand` structs.