### PR TITLE
Release v1.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Quantica"
 uuid = "ae5ea0c6-3f5e-46a2-bc28-a7c4c7a4773c"
 authors = ["Pablo San-Jose"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
PRs from #283 to #334

## Changes since v1.1.0

### Fixes

- Fixed some rare band artifacts (#284)
- Fixed bug in `reverse` (#285)
- Various plot fixes and updates (#273, #288, #290)
- Remove unnecessary intermediary copies (#292, #333)
- Fixed bug in `supercell` with `mincoordination` (#296)
- Fixed bugs in `combine` (#305, #313)
- Fixed bug when computing the adjoint of parametric models (#312)
- Fixed aliasing bugs (#319, #321)
- Fixed subtle bug due to type-piracy (#328)

### New features

- Unexported `Quantica.retarded_eigvals` and `Quantica.decay_lengths` functions for 1D AbstractHamiltonians (#289)
- Unexported `Quantica.gap` and `Quantica.gaps` for 1D AbstractHamiltonians (#294, #324)
- We can now use a fast solver used on the Generalized Schur algorithm and adaptive numerical integration to compute the density matrix in 1D and 2D systems (#291, #332)
- Serializers/Deserializers for AbstractHamiltonians and OrbitalSliceArrays (#299, #301, #302)
- Made `josephson` computation more flexible (#306, #307, #309, #310)
- Made `densitymatrix` computations more powerful (#311)
- Generalized integration paths for `josephson` and `densitymatrix`. New `Paths` submodule (#325, #330)
- New `meanfield`: efficient and general Hartree-Fock-Bogoliubov mean fields (#316, #323, #326)
- Introduced `sitepairs` as a more general sparse indexer for GreenFunctions, a kind of "hopping" complement to `diagonal` (#315)

### Refactors

- Did a major rewrite of the indexing machinery for GreenFunctions, to allow for new features, such as general sparse indexing (#315)

### Breaking changes

- Converted EigenSolvers into extensions. The relevant libraries have to be imported before the corresponding solvers can be used (#298)
- Renamed `torus` to `stitch`, and introduced a parametric `@stitch` (#331, #334)