### PR TITLE
Integrate options incorporated into `GS.Schur`

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1798,7 +1798,7 @@ possible keyword arguments are
     - This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first. Contact self-energies that depend on parameters are supported.
 - `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
-    - If the system is 2D, the wavevector along transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7, order = 5)` by default.
+    - If the system is 2D, the wavevector along the transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7)` by default.
     - In 2D systems a warning may be thrown associated to `stitch` conflicts which should not be ignored. See `@stitch` for details.
 - `GS.KPM(; order = 100, bandrange = missing, kernel = I)` : Kernel polynomial method solver for 0D Hamiltonians
     - `order` : order of the expansion in Chebyshev polynomials `Tₙ(h)` of the Hamiltonian `h` (lowest possible order is `n = 0`).
@@ -2177,11 +2177,11 @@ The generic integration algorithm allows for the following `opts` (see also `jos
 - `callback`: a function to be called as `callback(xs..., y)` at each point in the integration, where `xs` is the integration point (e.g. `xs = (ω,)` along a contour) and `y` is the integrand evaluated at that point. Useful for inspection and debugging, e.g. `callback(x, y) = @show x`. Default: `Returns(nothing)`.
 - `atol`: absolute integration tolerance. The default `1e-7` is chosen to avoid excessive integration times when the current is actually zero. Default `1e-7`.
 
-The `quadgk_opts` are extra keyword arguments (other than `atol`) to pass on to the function `QuadGK.quadgk` that is used for the integration.
+The `quadgk_opts` are extra keyword arguments (other than `atol`) to pass on to the function `QuadGK.quadgk` that is used for integrations.
 
 Currently, the following GreenSolvers implement dedicated densitymatrix algorithms:
 
-- `GS.Schur`: based on numerical integration over Bloch phase (1D and 2D). Boundaries and non-empty contacts are not currently supported. Assumes a Hermitian AbstractHamiltonian. No `opts`.
+- `GS.Schur`: based on numerical integration over Bloch phase (1D and 2D). Boundaries and non-empty contacts are not currently supported. Assumes a Hermitian AbstractHamiltonian. Only `callback` in `opts`.
 - `GS.Spectrum`: based on summation occupation-weigthed eigenvectors. No `opts`.
 - `GS.KPM`: based on the Chebyshev expansion of the Fermi function. Currently only works for zero temperature and only supports `nothing` contacts (see `attach`). No `opts`.
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1796,9 +1796,10 @@ possible keyword arguments are
 - `GS.Spectrum(; spectrum_kw...)` : Diagonalization solver for 0D Hamiltonians using `spectrum(h; spectrum_kw...)`
     - `spectrum_kw...` : keyword arguments passed on to `spectrum`
     - This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first. Contact self-energies that depend on parameters are supported.
-- `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization
+- `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization and (possibly) integration over the Brillouin zone.
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
     - If the system is 2D, the wavevector along the transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7)` by default.
+    - `integrate_opts` can contain a `callback = f`, where `f` is a function that will be called `f(ϕs..., y)` at each point in the momentum integration. Here `ϕs` is the integration point in the Brillouin zone and `y` is the integrand evaluated at that point. Useful for inspection and debugging, e.g. `callback(x, y) = @show x`. Default: `Returns(nothing)`.
     - In 2D systems a warning may be thrown associated to `stitch` conflicts which should not be ignored. See `@stitch` for details.
 - `GS.KPM(; order = 100, bandrange = missing, kernel = I)` : Kernel polynomial method solver for 0D Hamiltonians
     - `order` : order of the expansion in Chebyshev polynomials `Tₙ(h)` of the Hamiltonian `h` (lowest possible order is `n = 0`).
@@ -2181,7 +2182,7 @@ The `quadgk_opts` are extra keyword arguments (other than `atol`) to pass on to 
 
 Currently, the following GreenSolvers implement dedicated densitymatrix algorithms:
 
-- `GS.Schur`: based on numerical integration over Bloch phase (1D and 2D). Boundaries and non-empty contacts are not currently supported. Assumes a Hermitian AbstractHamiltonian. Only `callback` in `opts`.
+- `GS.Schur`: based on numerical integration over Bloch phase (1D and 2D). Boundaries and non-empty contacts are not currently supported. Assumes a Hermitian AbstractHamiltonian. No `opts`.
 - `GS.Spectrum`: based on summation occupation-weigthed eigenvectors. No `opts`.
 - `GS.KPM`: based on the Chebyshev expansion of the Fermi function. Currently only works for zero temperature and only supports `nothing` contacts (see `attach`). No `opts`.
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1799,7 +1799,7 @@ possible keyword arguments are
 - `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization and (possibly) integration over the Brillouin zone.
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
     - If the system is 2D, the wavevector along the transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7)` by default.
-    - `integrate_opts` can contain a `callback = f`, where `f` is a function that will be called `f(ϕs..., y)` at each point in the momentum integration. Here `ϕs` is the integration point in the Brillouin zone and `y` is the integrand evaluated at that point. Useful for inspection and debugging, e.g. `callback(x, y) = @show x`. Default: `Returns(nothing)`.
+    - `integrate_opts` can also contain a `callback = f`, where `f` is a function that will be called `f(ϕs..., y)` at each point in the momentum integration. Here `ϕs` is the integration point in the Brillouin zone and `y` is the integrand evaluated at that point. Useful for inspection and debugging, e.g. `callback(x, y) = @show x`. Default: `Returns(nothing)`.
     - In 2D systems a warning may be thrown associated to `stitch` conflicts which should not be ignored. See `@stitch` for details.
 - `GS.KPM(; order = 100, bandrange = missing, kernel = I)` : Kernel polynomial method solver for 0D Hamiltonians
     - `order` : order of the expansion in Chebyshev polynomials `Tₙ(h)` of the Hamiltonian `h` (lowest possible order is `n = 0`).
@@ -2182,7 +2182,7 @@ The `quadgk_opts` are extra keyword arguments (other than `atol`) to pass on to 
 
 Currently, the following GreenSolvers implement dedicated densitymatrix algorithms:
 
-- `GS.Schur`: based on numerical integration over Bloch phase (1D and 2D). Boundaries and non-empty contacts are not currently supported. Assumes a Hermitian AbstractHamiltonian. No `opts`.
+- `GS.Schur`: based on numerical integration over Bloch phase (1D and 2D). Boundaries and non-empty contacts are not currently supported. Assumes a Hermitian AbstractHamiltonian. `opts` can contain a `callback`.
 - `GS.Spectrum`: based on summation occupation-weigthed eigenvectors. No `opts`.
 - `GS.KPM`: based on the Chebyshev expansion of the Fermi function. Currently only works for zero temperature and only supports `nothing` contacts (see `attach`). No `opts`.
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -731,7 +731,7 @@ end
 # if any ptr´ in ps appears in the duplicate list of that harmonic, it means that the
 # corresponding wrapped hopping comes from summing a modified hopping and an unmodified hopping
 function check_ptr_duplicates(pss, ptrmap, harmap)
-    message0 =  "The modifier will be applied to the sum, which may lead to unexpected results e.g. with non-linear or position-dependent modifiers. A possible fix is to use an enlarged supercell."
+    message0 = "The modifier will be applied to the sum, which may lead to unexpected results e.g. with non-linear or position-dependent modifiers. A possible fix is to use an enlarged supercell."
     message1 = "Two modified hoppings have been wrapped into one. " * message0
     message2 = "A modified and a non-modified hopping have been wrapped into one. " * message0
     # First check if two modified hoppings have been wrapped into one

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -784,12 +784,12 @@ check_no_boundaries_schur(s) = isempty(boundaries(s)) ||
 check_no_contacts_schur(gs) = has_selfenergy(gs) &&
     argerror("The Schur densitymatrix solver currently support only `nothing` contacts")
 
-function densitymatrix_schur(gs; callback = Returns(nothing), quadgk_opts...)
+function densitymatrix_schur(gs; int_opts...)
     g = parent(gs)
     hmat = similar_Array(hamiltonian(g))
     psis = similar(hmat)
     orbaxes = orbrows(gs), orbcols(gs)
-    solver = DensityMatrixSchurSolver(gs, orbaxes, hmat, psis, (; callback, quadgk_opts...))
+    solver = DensityMatrixSchurSolver(gs, orbaxes, hmat, psis, NamedTuple(int_opts))
     return DensityMatrix(solver, gs)
 end
 

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -766,10 +766,10 @@ end
 
 ## Constructor
 
-function densitymatrix(s::Union{AppliedSchurGreenSolver,AppliedSchurGreenSolver2D}, gs::GreenSlice; callback = Returns(nothing), quadgk_opts...)
+function densitymatrix(s::Union{AppliedSchurGreenSolver,AppliedSchurGreenSolver2D}, gs::GreenSlice; int_opts...)
     check_no_boundaries_schur(s)
     check_no_contacts_schur(gs)
-    return densitymatrix_schur(gs; integrate_opts(s)..., callback, quadgk_opts...)
+    return densitymatrix_schur(gs; integrate_opts(s)..., int_opts...)
 end
 
 check_no_boundaries_schur(s) = isempty(boundaries(s)) ||
@@ -778,12 +778,12 @@ check_no_boundaries_schur(s) = isempty(boundaries(s)) ||
 check_no_contacts_schur(gs) = has_selfenergy(gs) &&
     argerror("The Schur densitymatrix solver currently support only `nothing` contacts")
 
-function densitymatrix_schur(gs; integrate_opts...)   # integrate_opts contains callback
+function densitymatrix_schur(gs; callback = Returns(nothing), quadgk_opts...)
     g = parent(gs)
     hmat = similar_Array(hamiltonian(g))
     psis = similar(hmat)
     orbaxes = orbrows(gs), orbcols(gs)
-    solver = DensityMatrixSchurSolver(gs, orbaxes, hmat, psis, NamedTuple(integrate_opts))
+    solver = DensityMatrixSchurSolver(gs, orbaxes, hmat, psis, (; callback, quadgk_opts...))
     return DensityMatrix(solver, gs)
 end
 
@@ -874,7 +874,7 @@ function fermi_h!(s, ϕ, µ, β = 0; params...)
 end
 
 quadgk_opts(s::DensityMatrixSchurSolver) = quadgk_opts(; s.integrate_opts...)
-quadgk_opts(; callback = Return(nothing), quadgk_opts...) = quadgk_opts
+quadgk_opts(; callback = Returns(nothing), quadgk_opts...) = quadgk_opts
 
 callback(s::DensityMatrixSchurSolver) = s.integrate_opts.callback
 

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -748,9 +748,9 @@ boundaries(s::AppliedSchurGreenSolver2D) = boundaries(s.solver1D)
 
 integrate_opts(s::AppliedSchurGreenSolver2D) = s.integrate_opts
 
-quadgk_opts(s::AppliedSchurGreenSolver2D) = quadgk_opts(; s.integrate_opts...)
+quadgk_opts(s::AppliedSchurGreenSolver2D) = quadgk_opts(s.integrate_opts)
 
-callback(s::AppliedSchurGreenSolver2D) = get(s.integrate_opts, :callback, Returns(nothing))
+callback(s::AppliedSchurGreenSolver2D) = callback(s.integrate_opts)
 
 #endregion
 
@@ -879,9 +879,8 @@ function fermi_h!(s, ϕ, µ, β = 0; params...)
     return data
 end
 
-quadgk_opts(s::DensityMatrixSchurSolver) = quadgk_opts(; s.integrate_opts...)
-quadgk_opts(; callback = Returns(nothing), quadgk_opts...) = quadgk_opts
+quadgk_opts(s::DensityMatrixSchurSolver) = quadgk_opts(s.integrate_opts)
 
-callback(s::DensityMatrixSchurSolver) = get(s.integrate_opts, :callback, Returns(nothing))
+callback(s::DensityMatrixSchurSolver) = callback(s.integrate_opts)
 
 #endregion top

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -750,7 +750,7 @@ integrate_opts(s::AppliedSchurGreenSolver2D) = s.integrate_opts
 
 quadgk_opts(s::AppliedSchurGreenSolver2D) = quadgk_opts(; s.integrate_opts...)
 
-callback(s::AppliedSchurGreenSolver2D) = s.integrate_opts.callback
+callback(s::AppliedSchurGreenSolver2D) = get(s.integrate_opts, :callback, Returns(nothing))
 
 #endregion
 
@@ -882,6 +882,6 @@ end
 quadgk_opts(s::DensityMatrixSchurSolver) = quadgk_opts(; s.integrate_opts...)
 quadgk_opts(; callback = Returns(nothing), quadgk_opts...) = quadgk_opts
 
-callback(s::DensityMatrixSchurSolver) = s.integrate_opts.callback
+callback(s::DensityMatrixSchurSolver) = get(s.integrate_opts, :callback, Returns(nothing))
 
 #endregion top

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -574,6 +574,7 @@ end
     g = LP.square() |> hopping(1) |> supercell(3,1) |> greenfunction(GS.Schur(; axis = 2, atol = 1e-2, callback))
     ρ = densitymatrix(g[])
     @test iszero(ref[])
+    @show diag(g(0)[])
     @test all(x->abs(real(x)) < 1e-6, diag(g(0)[]))
     @test !iszero(ref[])
     ref = Ref(0.0)

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -574,8 +574,7 @@ end
     g = LP.square() |> hopping(1) |> supercell(3,1) |> greenfunction(GS.Schur(; axis = 2, atol = 1e-2, callback))
     ρ = densitymatrix(g[])
     @test iszero(ref[])
-    @show diag(g(0)[])
-    @test all(x->abs(real(x)) < 1e-6, diag(g(0)[]))
+    @test all(x->abs(real(x)) < 1e-4, diag(g(0)[]))
     @test !iszero(ref[])
     ref = Ref(0.0)
     @test diag(ρ()) ≈ [0.5,0.5,0.5]

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -574,7 +574,7 @@ end
     g = LP.square() |> hopping(1) |> supercell(3,1) |> greenfunction(GS.Schur(; axis = 2, atol = 1e-2, callback))
     ρ = densitymatrix(g[])
     @test iszero(ref[])
-    @test all(x->abs(real(x)) < 1e-8, diag(g(0)[]))
+    @test all(x->abs(real(x)) < 1e-6, diag(g(0)[]))
     @test !iszero(ref[])
     ref = Ref(0.0)
     @test diag(ρ()) ≈ [0.5,0.5,0.5]

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -567,6 +567,19 @@ end
     @test ρ0() ≈ ρ1() ≈ ρ2()
     @test ρ0(0.1, 0.2) ≈ ρ1(0.1, 0.2) ≈ ρ2(0.1, 0.2)
 
+    # test DensityMatrixSchurSolver in 2D
+    ref = Ref(0.0)
+    callback(x,z) = (ref[] = sum(abs, z))
+    callback(x,y,z) = (ref[] = sum(abs, z))
+    g = LP.square() |> hopping(1) |> supercell(3,1) |> greenfunction(GS.Schur(; axis = 2, atol = 1e-2, callback))
+    ρ = densitymatrix(g[])
+    @test iszero(ref[])
+    @test all(x->abs(real(x)) < 1e-8, diag(g(0)[]))
+    @test !iszero(ref[])
+    ref = Ref(0.0)
+    @test diag(ρ()) ≈ [0.5,0.5,0.5]
+    @test !iszero(ref[])
+
     # parametric path and system
     g = LP.linear() |> supercell |> @onsite((; o = 0.5) -> o) |> greenfunction
     ρ = densitymatrix(g[], Paths.polygon((µ, T; o = 0.5) -> o > µ ? (-1, µ, o + im, 1) : (-1, o + im, µ, 1)))


### PR DESCRIPTION
Since `GS.Schur` is used for 1D density matrices (which integrate over k with kF points), and in 2D green and density matrices (which integrates over a 2D Brillouin zone), it needs to know the default integration options and/or callbacks. We now pass them to `GS.Schur` and subsequent applied solvers.

Example with a 2D Hamiltonian `h2D`
```julia
xs, ys, zs = [0.0], [0.0], [0.0];
g = greenfunction(h2D, GS.Schur(; atol = 1e-3, callback = (x,y,z) -> (push!(xs, x); push!(ys, y); push!(zs, real(sum(z .^ 2))))))
ρ = densitymatrix(g[])() # uses atol and callback in the 2D integrals
```