### PR TITLE
Bugfix: spinless nambu decoder

### DIFF
--- a/src/meanfield.jl
+++ b/src/meanfield.jl
@@ -119,7 +119,7 @@ nambu_adjoint_significants(mat::SMatrix{N,N}, is_rotated) where {N} =
     nambu_adjoint_significants(nambu_significants(mat), is_rotated)
 
 function nambu_adjoint_significants(lmat::SVector{2}, _)
-    return -SA[0 1; 1 0] * conj(lmat)
+    return SA[0 1; -1 0] * conj(lmat)
 end
 
 function nambu_adjoint_significants(lmat::SMatrix{4,2}, is_rotated)

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -663,10 +663,11 @@ end
     @test Φ[sites(1), sites(2)] ≈ -1.5 * Q * ρ12 * Q
 
     # spinless nambu
-    oh = LP.linear() |> hamiltonian(hopping((r, dr) -> SA[1 sign(dr[1]); -sign(dr[1]) -1]) - onsite(SA[1 0; 0 -1]), orbitals = 2)
+    oh = LP.linear() |> hamiltonian(hopping((r, dr) -> SA[1 sign(dr[1]); -sign(dr[1]) -1]) - onsite(SA[1 0.1; 0.1 -1]), orbitals = 2)
     g = oh |> greenfunction
     Q = SA[1 0; 0 -1]
     m = meanfield(g; selector = (; range = 1), nambu = true, hartree = r -> 1/(1+norm(r)), fock = 1.5, charge = Q)
+    @test !iszero(m()[sites(1)][1,2])       # decoder preserves pairing
     @test_throws ArgumentError m(0.2, 0.3)  # µ cannot be nonzero
     Φ = m(0, 0.3)
     ρ11 = m.rho(0, 0.3)[sites(1), sites(1)] - SA[0 0; 0 1]


### PR DESCRIPTION
There was an error in the decoder of the CompressedOrbitalMatrix produced by meanfield for spinless superconductors.