### PR TITLE
`qplot` support for non-default self-energy parameters

### DIFF
--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -110,6 +110,8 @@ The supported `attach` forms are the following
 
   This is the generic form of `attach`, which couples some sites `i` of a `g::Greenfunction` (defined by the slice `gs = g[i]`), to `sites` of `h` using a `coupling` model. This results in a self-energy `Σ(ω) = V´⋅gs(ω)⋅V` on `h` `sites`, where `V` and `V´` are couplings matrices given by `coupling`.
 
+  Note: currently, `attach` of a `GreenSlice` created with direct site indexing (e.g. `gs = g[sites(3)]`) is not supported. Use a `siteselector` instead, such as `gs = g[cells = 1]`.
+
 
 - **Dummy self-energy**
 

--- a/ext/QuanticaMakieExt/QuanticaMakieExt.jl
+++ b/ext/QuanticaMakieExt/QuanticaMakieExt.jl
@@ -7,7 +7,8 @@ using Makie.GeometryBasics: Ngon
 using Quantica: Lattice, LatticeSlice, AbstractHamiltonian, Hamiltonian, OpenHamiltonian,
       ParametricHamiltonian, Harmonic, Bravais, SVector, GreenFunction, GreenSolution,
       argerror, harmonics, sublats, siterange, site, norm,
-      normalize, nsites, nzrange, rowvals, nonzeros, sanitize_SVector, default_hamiltonian
+      normalize, nsites, nzrange, rowvals, nonzeros, sanitize_SVector,
+      default_plottable, default_parameters
 
 import Quantica: plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults
 

--- a/ext/QuanticaMakieExt/QuanticaMakieExt.jl
+++ b/ext/QuanticaMakieExt/QuanticaMakieExt.jl
@@ -8,7 +8,7 @@ using Quantica: Lattice, LatticeSlice, AbstractHamiltonian, Hamiltonian, OpenHam
       ParametricHamiltonian, Harmonic, Bravais, SVector, GreenFunction, GreenSolution,
       argerror, harmonics, sublats, siterange, site, norm,
       normalize, nsites, nzrange, rowvals, nonzeros, sanitize_SVector,
-      default_plottable, default_parameters
+      default_plottable, parameters
 
 import Quantica: plotlattice, plotlattice!, plotbands, plotbands!, qplot, qplot!, qplotdefaults
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -498,7 +498,7 @@ function Makie.plot!(plot::PlotLattice{Tuple{G}}) where {G<:Union{GreenFunction,
     g = to_value(plot[1])
     gsel = haskey(plot, :selector) && plot[:selector][] !== missing ?
         plot[:selector][] : green_selector(g)
-    params = default_parameters(g)
+    params = parameters(g)
     h = default_plottable(g; params...)
     latslice = lattice(h)[gsel]
     latslice´ = Quantica.growdiff(latslice, h)

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -498,7 +498,8 @@ function Makie.plot!(plot::PlotLattice{Tuple{G}}) where {G<:Union{GreenFunction,
     g = to_value(plot[1])
     gsel = haskey(plot, :selector) && plot[:selector][] !== missing ?
         plot[:selector][] : green_selector(g)
-    h = default_hamiltonian(g)
+    params = default_parameters(g)
+    h = default_plottable(g; params...)
     latslice = lattice(h)[gsel]
     latslice´ = Quantica.growdiff(latslice, h)
     L = Quantica.latdim(h)
@@ -534,7 +535,8 @@ function Makie.plot!(plot::PlotLattice{Tuple{G}}) where {G<:Union{GreenFunction,
             Σplottables = Quantica.selfenergy_plottables(Σ)
             for Σp in Σplottables
                 plottables, kws = get_plottables_and_kws(Σp)
-                plotlattice!(plot, plottables...; plot.attributes..., hide = hideΣ, marker = squaremarker, kws..., Σkw...)
+                plottables´ = default_plottable.(plottables; params...)
+                plotlattice!(plot, plottables´...; plot.attributes..., hide = hideΣ, marker = squaremarker, kws..., Σkw...)
             end
         end
     end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -43,7 +43,7 @@ function ParametricHamiltonian{E}(ph::ParametricHamiltonian) where {E}
     h = Hamiltonian{E}(hamiltonian(ph))
     ms = modifiers(ph)
     ptrs = pointers(ph)
-    pars = parameters(ph)
+    pars = parameter_names(ph)
     return ParametricHamiltonian(hparent, h, ms, ptrs, pars)
 end
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -345,8 +345,27 @@ function minimal_callsafe_copy(s::FixedParamGreenSolver, parentham, parentcontac
     return s´
 end
 
-default_hamiltonian(g::GreenFunction{<:Any,<:Any,<:Any,<:FixedParamGreenSolver}) =
-    default_hamiltonian(parent(g); parameters(solver(g))...)
+#endregion
+
+############################################################################################
+# default_plottable and default_parameters
+#   Retrieves the relevant object to plot with the relevant parameters
+#   Necessary to support e.g. qplot(g(; new_params...))
+# region
+
+default_plottable(g::GreenFunction; params...) = call!(parent(g); params...)
+
+default_plottable(h::AbstractHamiltonian; params...) = call!(h; params...)
+
+default_plottable(oh::OpenHamiltonian; params...) = call!(oh.h; params...)
+
+# fallback
+default_plottable(l; params...) = l
+
+default_parameters(g::GreenFunction{<:Any,<:Any,<:Any,<:FixedParamGreenSolver}) =
+    parameters(solver(g))
+# fallback
+default_parameters(g) = (;)
 
 #endregion
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -348,7 +348,7 @@ end
 #endregion
 
 ############################################################################################
-# default_plottable and default_parameters
+# default_plottable and parameters
 #   Retrieves the relevant object to plot with the relevant parameters
 #   Necessary to support e.g. qplot(g(; new_params...))
 # region
@@ -362,10 +362,10 @@ default_plottable(oh::OpenHamiltonian; params...) = call!(oh.h; params...)
 # fallback
 default_plottable(l; params...) = l
 
-default_parameters(g::GreenFunction{<:Any,<:Any,<:Any,<:FixedParamGreenSolver}) =
+parameters(g::GreenFunction{<:Any,<:Any,<:Any,<:FixedParamGreenSolver}) =
     parameters(solver(g))
 # fallback
-default_parameters(g) = (;)
+parameters(g) = (;)
 
 #endregion
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -199,14 +199,14 @@ function parametric!(p::ParametricHamiltonian, ms::AppliedModifier...)
     allmodifiers = (modifiers(p)..., ms...)
     # restores aliasing of any serializer to h
     relinked_modifiers = maybe_relink_serializer.(allmodifiers, Ref(h))
-    allparams = parameters(p)
+    allparams = parameter_names(p)
     merge_parameters!(allparams, ms...)
     allptrs = pointers(p)
     merge_pointers!(allptrs, ms...)
     return ParametricHamiltonian(hparent, h, relinked_modifiers, allptrs, allparams)
 end
 
-merge_parameters!(p, m, ms...) = merge_parameters!(append!(p, parameters(m)), ms...)
+merge_parameters!(p, m, ms...) = merge_parameters!(append!(p, parameter_names(m)), ms...)
 merge_parameters!(p) = unique!(sort!(p))
 
 merge_pointers!(p, m, ms...) = merge_pointers!(_merge_pointers!(p, m), ms...)
@@ -422,7 +422,7 @@ function applymodifiers!(h, m::AppliedHoppingModifier{B}; kw...) where {B<:SMatr
 end
 
 function applymodifiers!(h, m::AppliedSerializer; kw...)
-    pname = only(parameters(m))
+    pname = only(parameter_names(m))
     nkw = NamedTuple(kw)
     # this should override hamiltonian(s), which should be aliased with h
     haskey(nkw, pname) && deserialize!(m, nkw[pname])

--- a/src/models.jl
+++ b/src/models.jl
@@ -137,13 +137,13 @@ zero_model(term::ParametricHoppingTerm) =
 
 function modifier(term::ParametricOnsiteTerm{N}) where {N}
     f = (o, args...; kw...) -> o + term(args...; kw...)
-    pf = ParametricFunction{N+1}(f, parameters(term))
+    pf = ParametricFunction{N+1}(f, parameter_names(term))
     return OnsiteModifier(pf, selector(term), is_spatial(term))
 end
 
 function modifier(term::ParametricHoppingTerm{N}) where {N}
     f = (t, args...; kw...) -> t + term(args...; kw...)
-    pf = ParametricFunction{N+1}(f, parameters(term))
+    pf = ParametricFunction{N+1}(f, parameter_names(term))
     return HoppingModifier(pf, selector(term), is_spatial(term))
 end
 
@@ -156,16 +156,16 @@ model_ω_to_param(model::ParametricModel) =
 model_ω_to_param(model::TightbindingModel) = model_ω_to_param(ParametricModel(model))
 
 function model_ω_to_param(term::ParametricOnsiteTerm{N}, default = 0) where {N}
-    # parameters(term) only needed for reporting, we omit adding :ω_internal
+    # parameter_names(term) only needed for reporting, we omit adding :ω_internal
     f = (args...; ω_internal = default, kw...) -> term(ω_internal, args...; kw...)
-    pf = ParametricFunction{N-1}(f, parameters(term))
+    pf = ParametricFunction{N-1}(f, parameter_names(term))
     return ParametricOnsiteTerm(pf, selector(term), coefficient(term), is_spatial(term))
 end
 
 function model_ω_to_param(term::ParametricHoppingTerm{N}, default = 0) where {N}
-    # parameters(term) only needed for reporting, we omit adding :ω_internal
+    # parameter_names(term) only needed for reporting, we omit adding :ω_internal
     f = (args...; ω_internal = default, kw...) -> term(ω_internal, args...; kw...)
-    pf = ParametricFunction{N-1}(f, parameters(term))
+    pf = ParametricFunction{N-1}(f, parameter_names(term))
     return ParametricHoppingTerm(pf, selector(term), coefficient(term), is_spatial(term))
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -165,7 +165,7 @@ function Base.show(io::IO, t::Union{AbstractModelTerm,Modifier})
     end
     if t isa AbstractParametricTerm || t isa Modifier
         print(io, "\n", "$(i)  Argument type     : $(display_argument_type(t))")
-        print(io, "\n", "$(i)  Parameters        : $(parameters(t))")
+        print(io, "\n", "$(i)  Parameters        : $(parameter_names(t))")
     end
 end
 
@@ -230,7 +230,7 @@ displaytype(::Type{T}) where {T} = "scalar ($T)"
 showextrainfo(io, i, h) = nothing
 
 showextrainfo(io, i, h::ParametricHamiltonian) = print(io, i, "\n",
-"$i  Parameters       : $(parameters(h))")
+"$i  Parameters       : $(parameter_names(h))")
 
 showextrainfo(io, i, o::Operator) = showextrainfo(io, i, hamiltonian(o))
 #endregion
@@ -587,7 +587,7 @@ function Base.show(io::IO, s::Serializer)
     i = get(io, :indent, "")
     ioindent = IOContext(io, :indent => i * "  ")
     print(io, i, summary(s), "\n",
-"$i  Stream parameter  : :$(only(parameters(s)))
+"$i  Stream parameter  : :$(only(parameter_names(s)))
 $i  Output eltype     : $(eltype(s))
 $i  Encoder/Decoder   : $(display_encdec(encoder(s)))")
 end
@@ -598,7 +598,7 @@ function Base.show(io::IO, s::AppliedSerializer)
     print(io, i, summary(s), "\n",
 "$i  Object            : $(nameof(typeof(parent_hamiltonian(s))))
 $i  Object parameters : $(display_parameters(s))
-$i  Stream parameter  : :$(only(parameters(s)))
+$i  Stream parameter  : :$(only(parameter_names(s)))
 $i  Output eltype     : $(eltype(s))
 $i  Encoder/Decoder   : $(display_encdec(encoder(s)))
 $i  Length            : $(length(s))")
@@ -613,7 +613,7 @@ display_encdec(::Function) = "Single"
 display_encdec(::Tuple) = "(Onsite, Hopping pairs)"
 
 display_parameters(s::AppliedSerializer{<:Any,<:Hamiltonian}) = "none"
-display_parameters(s::AppliedSerializer{<:Any,<:ParametricHamiltonian}) = string(parameters(parent_hamiltonian(s)))
+display_parameters(s::AppliedSerializer{<:Any,<:ParametricHamiltonian}) = string(parameter_names(parent_hamiltonian(s)))
 
 #endregion
 

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -323,6 +323,9 @@ function sublatsites(l::LatticeSlice, s::Integer, store = missing)
     return gen
 end
 
+lattice0D(::CellIndices, store...) =
+    argerror("Attaching a GreenSlice with direct site indexing (i.e. of the form `g[sites(...)]`) is currently unsupported. Use a `siteselector` instead.")
+
 #endregion
 
 ############################################################################################

--- a/src/solvers/selfenergysolvers.jl
+++ b/src/solvers/selfenergysolvers.jl
@@ -26,7 +26,7 @@
 selfenergy_plottables(s::SelfEnergy) = selfenergy_plottables(s.solver, orbslice(s))
 
 # fallback
-selfenergy_plottables(s::AbstractSelfEnergySolver, parent_latslice) = (parent_latslice,)
+selfenergy_plottables(::AbstractSelfEnergySolver, parent_latslice) = (parent_latslice,)
 
 include("selfenergy/nothing.jl")
 include("selfenergy/model.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -700,7 +700,7 @@ selector(t::AbstractModelTerm) = t.selector
 
 functor(t::AbstractModelTerm) = t.f
 
-parameters(t::AbstractParametricTerm) = t.f.params
+parameter_names(t::AbstractParametricTerm) = t.f.params
 
 coefficient(t::OnsiteTerm) = t.coefficient
 coefficient(t::HoppingTerm) = t.coefficient
@@ -832,7 +832,7 @@ AppliedHoppingModifier(m::AppliedHoppingModifier, sel::Selector) =
 selector(m::Modifier) = m.selector
 selector(m::AppliedModifier) = m.parentselector
 
-parameters(m::AbstractModifier) = m.f.params
+parameter_names(m::AbstractModifier) = m.f.params
 
 parametric_function(m::AbstractModifier) = m.f
 
@@ -1490,8 +1490,8 @@ Base.parent(s::AppliedSerializer) = s.parent
 selectors(s::Serializer) = s.selectors
 selectors(s::AppliedSerializer) = selectors(s.parent)
 
-parameters(s::Serializer) = (s.parameter,)
-parameters(s::AppliedSerializer) = parameters(s.parent)
+parameter_names(s::Serializer) = (s.parameter,)
+parameter_names(s::AppliedSerializer) = parameter_names(s.parent)
 
 encoder(s::Serializer) = s.encoder
 encoder(s::AppliedSerializer) = encoder(s.parent)
@@ -1664,7 +1664,7 @@ hamiltonian(h::ParametricHamiltonian) = h.h
 
 bloch(h::ParametricHamiltonian) = h.h.bloch
 
-parameters(h::ParametricHamiltonian) = h.allparams
+parameter_names(h::ParametricHamiltonian) = h.allparams
 
 modifiers(h::ParametricHamiltonian) = h.modifiers
 modifiers(h::Hamiltonian) = ()

--- a/src/types.jl
+++ b/src/types.jl
@@ -1564,9 +1564,6 @@ function harmonic_index(h::AbstractHamiltonian, dn)
     return first(harmonics(h)), 1  # unreachable
 end
 
-# Unless params are given, it returns the Hamiltonian with defaults parameters
-default_hamiltonian(h::AbstractHamiltonian; params...) = h(; params...)
-
 # type-stable computation of common blocktype (for e.g. combine)
 blocktype(h::AbstractHamiltonian, hs::AbstractHamiltonian...) =
     blocktype(promote_type(typeof.((h, hs...))...))
@@ -2055,8 +2052,6 @@ selfenergies(oh::OpenHamiltonian) = oh.selfenergies
 
 hamiltonian(oh::OpenHamiltonian) = oh.h
 
-default_hamiltonian(oh::OpenHamiltonian) = default_hamiltonian(oh.h)
-
 lattice(oh::OpenHamiltonian) = lattice(oh.h)
 
 zerocell(h::OpenHamiltonian) = zerocell(parent(h))
@@ -2319,10 +2314,6 @@ orbindices(i::GreenIndices) = i.orbinds
 
 # returns the Hamiltonian field
 hamiltonian(g::Union{GreenFunction,GreenSolution,GreenSlice}) = hamiltonian(g.parent)
-
-# Like the above, but it may not be === the field (it can be a copy with parameters applied)
-# needed for qplot(g(; params...))
-default_hamiltonian(g::GreenFunction) = default_hamiltonian(parent(g))  # default params
 
 lattice(g::Union{GreenFunction,GreenSolution,GreenSlice}) = lattice(g.parent)
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -391,7 +391,7 @@ end
         @hopping(r->0, sublats, range = 2) + @onsite((r; p = 3) ->3p; sublats) + @onsite((r; q = 3) ->3q, sublats, region = RP.circle(2)) |>
         @hopping!((t, r, dr; p = 1) -> p+r[2], dcells = SVector{2,Int}[]) |> @onsite!((o, r; q = 1) -> o + q, sublats, region = RP.circle(3))
     @test h0 isa ParametricHamiltonian
-    @test Quantica.parameters(h0) == [:p, :q]
+    @test Quantica.parameter_names(h0) == [:p, :q]
 end
 
 @testset "ExternalPresets.wannier90" begin
@@ -606,7 +606,7 @@ end
     # Serializer -> ParametricHamiltonian conversion
     hs = hamiltonian(serializer(h0; parameter = :mystream))
     @test hs isa ParametricHamiltonian
-    @test Quantica.parameters(hs) == [:mystream]
+    @test Quantica.parameter_names(hs) == [:mystream]
     @test h0 == hamiltonian(hs)
     @test hs.modifiers[1].h === hs.h
     hs = hamiltonian(serializer(h1))


### PR DESCRIPTION
Fixes #345 

This is the minimal change to fix #345. We implement `default_plottable` and `default_parameters` as a hook to inject non-default parameters to self-energies through `FixedParamGreenSolver`.