### PR TITLE
GS.Spectrum support for ParametricHamiltonian

### DIFF
--- a/docs/src/advanced/meanfield.md
+++ b/docs/src/advanced/meanfield.md
@@ -129,7 +129,7 @@ Note that the content of `pdata` is passed by `aasol` as a third argument to `f!
 
 ## GreenSolvers without support for ParametricHamiltonians
 
-Some `GreenSolver`'s, like `GS.Spectrum` or `GS.KPM`, do not support `ParametricHamiltonian`s. In such cases, the approach above will fail, since it will not be possible to build `g` before knowing `phi`. In such cases one would need to rebuild the `meanfield` object at each step of the fixed-point solver. This is one way to do it.
+Some `GreenSolver`'s, like `GS.KPM`, do not support `ParametricHamiltonian`s. In such cases, the approach above will fail, since it will not be possible to build `g` before knowing `phi`. In such cases one would need to rebuild the `meanfield` object at each step of the fixed-point solver. This is one way to do it.
 
 ```julia
 julia> using SIAMFANLEquations

--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -70,7 +70,7 @@ The currently implemented `GreenSolvers` (abbreviated as `GS`) are the following
 
 - `GS.Spectrum(; spectrum_kw...)`
 
-  For bounded (`L == 0`) Hamiltonians. This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first.
+  For bounded (`L == 0`) AbstractHamiltonians.
 
   Uses a diagonalization of `H`, obtained with `spectrum(H; spectrum_kw...)`, to compute the `G⁰ᵢⱼ` using the Lehmann representation `∑ₖ⟨i|ϕₖ⟩⟨ϕₖ|j⟩/(ω - ϵₖ)`. Any eigensolver supported by `spectrum` can be used here. If there are contacts, it dresses `G⁰` using a T-matrix approach, `G = G⁰ + G⁰TG⁰`.
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1793,9 +1793,9 @@ solvers. The alias `GS` can be used in place of `GS`. Currently supported solver
 possible keyword arguments are
 
 - `GS.SparseLU()` : Direct inversion solver for 0D Hamiltonians using a `SparseArrays.lu(hmat)` factorization
-- `GS.Spectrum(; spectrum_kw...)` : Diagonalization solver for 0D Hamiltonians using `spectrum(h; spectrum_kw...)`
+- `GS.Spectrum(; spectrum_kw...)` : Diagonalization solver for 0D AbstractHamiltonians using `spectrum(h; spectrum_kw...)`
     - `spectrum_kw...` : keyword arguments passed on to `spectrum`
-    - This solver does not accept ParametricHamiltonians. Convert to Hamiltonian with `h(; params...)` first. Contact self-energies that depend on parameters are supported.
+    - Contact self-energies that depend on parameters are supported.
 - `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization and (possibly) integration over the Brillouin zone.
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
     - If the system is 2D, the wavevector along the transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7)` by default.

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1795,7 +1795,8 @@ possible keyword arguments are
 - `GS.SparseLU()` : Direct inversion solver for 0D Hamiltonians using a `SparseArrays.lu(hmat)` factorization
 - `GS.Spectrum(; spectrum_kw...)` : Diagonalization solver for 0D AbstractHamiltonians using `spectrum(h; spectrum_kw...)`
     - `spectrum_kw...` : keyword arguments passed on to `spectrum`
-    - Contact self-energies that depend on parameters are supported.
+    - Contact self-energies are supported, even if they depend on parameters.
+    - For Green functions of `h::ParametricHamiltonian`s, the spectrum of `h` for given parameters is computed on each call to `g(ω; params...)`. This is suboptimal if we want to scan `ω` for fixed `params`. In such case consider doing `g´ = g(; params...)` (this evaluates the spectrum once) and then `g´(ω)` in your ω-loop.
 - `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization and (possibly) integration over the Brillouin zone.
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
     - If the system is 2D, the wavevector along the transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7)` by default.

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -314,34 +314,38 @@ view_or_scalar(mat_cell, orb::Integer, orb´::Integer) = mat_cell[orb, orb´]
 #region
 
 struct FixedParamGreenSolver{P,G<:GreenFunction} <: AppliedGreenSolver
-    gparent::G
+    gfixed::G
     params::P
 end
-
-Base.parent(s::FixedParamGreenSolver) = s.gparent
 
 parameters(s::FixedParamGreenSolver) = s.params
 
 function (g::GreenFunction)(; params...)
-    h´ = minimal_callsafe_copy(parent(g))
-    c´ = minimal_callsafe_copy(contacts(g))
-    s´ = minimal_callsafe_copy(solver(g), h´, c´)
-    gparent = GreenFunction(h´, s´, c´)
-    return GreenFunction(h´, FixedParamGreenSolver(gparent, params), c´)
+    h´ = maybe_apply_params(parent(g); params...)
+    c´ = maybe_apply_params(contacts(g); params...)
+    s´ = maybe_apply_params(solver(g), h´, c´; params...)
+    gfixed = GreenFunction(h´, s´, c´)
+    return GreenFunction(h´, FixedParamGreenSolver(gfixed, params), c´)
 end
+
+# should be callsafe_copy, to avoid interfering with the original object when call!ing
+maybe_apply_params(h::ParametricHamiltonian; params...) =
+    minimal_callsafe_copy(call!(h; params...))
+# fallback (if we don't know how to apply params for this object)
+maybe_apply_params(xs...; params...) = minimal_callsafe_copy(xs...)
 
 (g::GreenSlice)(; params...) = GreenSlice(parent(g)(; params...), greenindices(g)...)
 
 # params are ignored, solver.params are used instead. T required to disambiguate.
 function call!(g::GreenFunction{T,<:Any,<:Any,<:FixedParamGreenSolver}, ω::Complex{T}; params...) where {T}
     s = solver(g)
-    return call!(s.gparent, ω; s.params...)
+    return call!(s.gfixed, ω; s.params...)
 end
 
 function minimal_callsafe_copy(s::FixedParamGreenSolver, parentham, parentcontacts)
-    solver´ = minimal_callsafe_copy(solver(s.gparent), parentham, parentcontacts)
-    gparent = GreenFunction(parentham, solver´, parentcontacts)
-    s´ = FixedParamGreenSolver(gparent, s.params)
+    solver´ = minimal_callsafe_copy(solver(s.gfixed), parentham, parentcontacts)
+    gfixed = GreenFunction(parentham, solver´, parentcontacts)
+    s´ = FixedParamGreenSolver(gfixed, s.params)
     return s´
 end
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -318,6 +318,8 @@ struct FixedParamGreenSolver{P,G<:GreenFunction} <: AppliedGreenSolver
     params::P
 end
 
+Base.parent(s::FixedParamGreenSolver) = s.gfixed
+
 parameters(s::FixedParamGreenSolver) = s.params
 
 function (g::GreenFunction)(; params...)
@@ -336,10 +338,12 @@ maybe_apply_params(xs...; params...) = minimal_callsafe_copy(xs...)
 
 (g::GreenSlice)(; params...) = GreenSlice(parent(g)(; params...), greenindices(g)...)
 
-# params are ignored, solver.params are used instead. T required to disambiguate.
+# params are only used as overrides of solver.params. T required to disambiguate.
 function call!(g::GreenFunction{T,<:Any,<:Any,<:FixedParamGreenSolver}, ω::Complex{T}; params...) where {T}
+    isempty(params) ||
+        @warn("Called a FixedParamGreenSolver with non-empty parameters. These will be ignored.")
     s = solver(g)
-    return call!(s.gfixed, ω; s.params...)
+    return call!(s.gfixed, ω; s.params...)  # we pass s.params in case they were not applied (e.g. to contacts)
 end
 
 function minimal_callsafe_copy(s::FixedParamGreenSolver, parentham, parentcontacts)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -2,13 +2,18 @@
 # Spectrum - for 0D AbstractHamiltonians
 #region
 
-struct AppliedSpectrumGreenSolver{S<:Spectrum} <: AppliedGreenSolver
+struct SpectrumSolver{H<:ParametricHamiltonian{<:Any,<:Any,0}, S<:GS.Spectrum}
+    h::H
+    solver::S
+end
+
+struct AppliedSpectrumGreenSolver{S<:Union{Spectrum,SpectrumSolver}} <: AppliedGreenSolver
     spectrum::S
 end
 
-struct SpectrumGreenSlicer{C,S<:AppliedSpectrumGreenSolver} <: GreenSlicer{C}
+struct SpectrumGreenSlicer{C,S<:Spectrum} <: GreenSlicer{C}
     ω::C
-    solver::S
+    spectrum::S
 end
 
 #region ## Constructor ##
@@ -18,11 +23,11 @@ end
 
 #region ## API ##
 
-spectrum(s::AppliedSpectrumGreenSolver) = s.spectrum
-
 # Parent ham needs to be non-parametric, so no need to alias
-minimal_callsafe_copy(s::AppliedSpectrumGreenSolver, parentham, parentcontacts) =
+minimal_callsafe_copy(s::AppliedSpectrumGreenSolver{<:Spectrum}, parentham, parentcontacts) =
     AppliedSpectrumGreenSolver(s.spectrum)
+minimal_callsafe_copy(s::AppliedSpectrumGreenSolver{<:SpectrumSolver}, parentham, parentcontacts) =
+    AppliedSpectrumGreenSolver(SpectrumSolver(parentham, s.spectrum.solver))
 
 #endregion
 
@@ -31,21 +36,32 @@ minimal_callsafe_copy(s::AppliedSpectrumGreenSolver, parentham, parentcontacts) 
 apply(s::GS.Spectrum, h::Hamiltonian{<:Any,<:Any,0}, ::Contacts) =
     AppliedSpectrumGreenSolver(spectrum(h; s.spectrumkw...))
 
-apply(s::GS.Spectrum, h::ParametricHamiltonian, ::Contacts) =
-    argerror("Cannot use GS.Spectrum with ParametricHamiltonian. Apply parameters with h(;params...) first.")
+apply(s::GS.Spectrum, h::ParametricHamiltonian{<:Any,<:Any,0}, ::Contacts) =
+    AppliedSpectrumGreenSolver(SpectrumSolver(h, s))
 
 apply(::GS.Spectrum, h::AbstractHamiltonian, ::Contacts) =
-    argerror("Can only use Spectrum with bounded Hamiltonians")
+    argerror("Can only use GS.Spectrum with bounded (L=0) AbstractHamiltonians. Received one with lattice dimension L=$(latdim(h))")
 
 #endregion
 
 #region ## call ##
 
 function build_slicer(s::AppliedSpectrumGreenSolver, g, ω, Σblocks, corbitals; params...)
-    g0slicer = SpectrumGreenSlicer(complex(ω), s)
+    sp = spectrum(s; params...)
+    g0slicer = SpectrumGreenSlicer(complex(ω), sp)
     gslicer = maybe_TMatrixSlicer(g0slicer, Σblocks, corbitals)
     return gslicer
 end
+
+# get spectrum from solver
+spectrum(s::AppliedSpectrumGreenSolver{<:Spectrum}; params...) =
+    s.spectrum
+spectrum(s::AppliedSpectrumGreenSolver{<:SpectrumSolver}; params...) =
+    spectrum(call!(s.spectrum.h; params...); s.spectrum.solver.spectrumkw...)
+
+# FixedParamGreenSolver support
+maybe_apply_params(s::AppliedSpectrumGreenSolver{<:SpectrumSolver}, h, c; params...) =
+    AppliedSpectrumGreenSolver(spectrum(call!(h; params...); s.spectrum.solver.spectrumkw...))
 
 #endregion
 
@@ -58,7 +74,7 @@ end
 
 function Base.getindex(s::SpectrumGreenSlicer{C}, i::CellOrbitals{0}, j::CellOrbitals{0}) where {C}
     oi, oj = orbindices(i), orbindices(j)
-    es, psis = spectrum(s.solver)
+    es, psis = s.spectrum
     vi, vj = view(psis, oi, :), view(psis, oj, :)
     vj´ = vj' ./ (s.ω .- es)
     return vi * vj´
@@ -71,13 +87,10 @@ end
 #   specialized DensityMatrix method for GS.Spectrum
 #region
 
-struct DensityMatrixSpectrumSolver{T,G<:GreenSlice{T},A,P}
+struct DensityMatrixSpectrumSolver{T,G<:GreenSlice{T},A,S<:AppliedSpectrumGreenSolver}
     gs::G
     orbaxes::A
-    es::Vector{Complex{T}}
-    fs::Vector{Complex{T}}
-    psis::P
-    fpsis::P
+    solver::S
 end
 
 ## Constructor
@@ -86,11 +99,8 @@ function densitymatrix(s::AppliedSpectrumGreenSolver, gs::GreenSlice)
     # SpectrumGreenSlicer is 0D, so there is a single cellorbs in dict.
     # If rows/cols are contacts, we need their orbrows/orbcols (unlike for gs(ω; params...))
     has_selfenergy(gs) && argerror("The Spectrum densitymatrix solver currently support only `nothing` contacts")
-    es, psis = spectrum(s)
-    fpsis = copy(psis)
-    fs = copy(es)
     orbaxes = orbrows(gs), orbcols(gs)
-    solver = DensityMatrixSpectrumSolver(gs, orbaxes, es, fs, psis, fpsis)
+    solver = DensityMatrixSpectrumSolver(gs, orbaxes, s)
     return DensityMatrix(solver, gs)
 end
 
@@ -98,10 +108,10 @@ end
 
 function (s::DensityMatrixSpectrumSolver)(µ, kBT; params...)
     bs = blockstructure(s.gs)
-    psis, fpsis, es, fs = s.psis, s.fpsis, s.es, s.fs
+    es, psis = spectrum(s.solver; params...)
     β = inv(kBT)
-    (@. fs = fermi(es - µ, β))
-    fpsis .= psis .* transpose(fs)
+    fs = (@. es = fermi(es - µ, β)) # doesn't allocate
+    fpsis = psis .* transpose(fs)   # allocates
     ρcell = EigenProduct(bs, psis, fpsis)
     result = call!_output(s.gs)
     getindex!(result, ρcell, s.orbaxes...)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -110,8 +110,8 @@ function (s::DensityMatrixSpectrumSolver)(µ, kBT; params...)
     bs = blockstructure(s.gs)
     es, psis = spectrum(s.solver; params...)
     β = inv(kBT)
-    fs = (@. es = fermi(es - µ, β)) # doesn't allocate
-    fpsis = psis .* transpose(fs)   # allocates
+    fs = (@. fermi(es - µ, β))
+    fpsis = psis .* transpose(fs)
     ρcell = EigenProduct(bs, psis, fpsis)
     result = call!_output(s.gs)
     getindex!(result, ρcell, s.orbaxes...)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -2,11 +2,11 @@
 # Spectrum - for 0D AbstractHamiltonians
 #region
 
-struct AppliedSpectrumGreenSolver{B,S<:Spectrum{<:Any,B}} <: AppliedGreenSolver
+struct AppliedSpectrumGreenSolver{S<:Spectrum} <: AppliedGreenSolver
     spectrum::S
 end
 
-struct SpectrumGreenSlicer{C,B,S<:AppliedSpectrumGreenSolver{B}} <: GreenSlicer{C}
+struct SpectrumGreenSlicer{C,S<:AppliedSpectrumGreenSolver} <: GreenSlicer{C}
     ω::C
     solver::S
 end

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -29,12 +29,13 @@ end
 
 @testset "basic greenfunctions" begin
     h0 = LP.honeycomb() |> hamiltonian(hopping(SA[0 1; 1 0]), orbitals = 2) |> supercell(region = RP.circle(10))
+    h0´ = h0 |> @hopping!((t; p = 1) -> p*t)
     s0 = GS.SparseLU()
     s0´ = GS.Spectrum()
     h1 = LP.square() |> hamiltonian(@onsite((; o = 1) -> o*I) + hopping(SA[0 1; 1 0]), orbitals = 2) |> supercell((1,0), region = r -> abs(r[2]) < 2)
     s1 = GS.Schur()
     s1´ = GS.Schur(boundary = -1)
-    for (h, s) in zip((h0, h0, h1, h1), (s0, s0´, s1, s1´))
+    for (h, s) in zip((h0, h0, h0´, h1, h1), (s0, s0´, s0´, s1, s1´))
         testgreen(h, s; o = 2)
     end
     # This ensures that flat_sync! is called with multiorbitals when call!-ing ph upon calling g
@@ -146,7 +147,7 @@ end
     @test_throws ArgumentError greenfunction(h, GS.Schur())
     @test_throws ArgumentError greenfunction(h, GS.Bands())
     h = LP.honeycomb() |> @onsite((; o = 1) -> o*I) |> supercell
-    @test_throws ArgumentError greenfunction(h, GS.Spectrum())
+    @test greenfunction(h, GS.Spectrum()) isa GreenFunction
     @test greenfunction(h(), GS.Spectrum()) isa GreenFunction
 end
 

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -337,9 +337,9 @@ end
         gs´ = Quantica.minimal_callsafe_copy(gs)  # exercise minimal_callsafe_copy for different solvers
         ρ0 = densitymatrix(gs, path)
         ρ = densitymatrix(gs´)
-        @test isapprox(ρ0(), ρ(); atol = 1e-7)
-        @test isapprox(ρ0(0.2), ρ(0.2); atol = 1e-7)
-        @test isapprox(ρ0(0.2, 0.3), ρ(0.2, 0.3))
+        @test isapprox(ρ0(), ρ(); atol = 1e-6)
+        @test isapprox(ρ0(0.2), ρ(0.2); atol = 1e-6)
+        @test isapprox(ρ0(0.2, 0.3), ρ(0.2, 0.3); atol = 1e-6)
     end
     # g2 excluded since it is single-orbital
     for g in (g1, g3)


### PR DESCRIPTION
Before, `g=greenfunction(h, GS.Spectrum())` would only accept 0D `h::Hamiltonian`s, without parameters, and would compute the spectrum up-front when building the GreenFunction. This inhibits the use of this solver, which may be optimal, for many problems that depend on parameters.

With this PR we now support also 0D `ParametricHamiltonians`. For these, we defer the computation of the spectrum to the `g(ω; params...)` or `g(; params...)`. However, to avoid repeated computation of the spectrum when scanning `ω`s, the user should be advised to do `g´ = g(; params...)` (this computes the spectrum) and then `g´(ω)`. 

Note that this leaves one possible use case still inaccessible: a 0D h::ParametricHamiltonian with parametric contacts. If we want to precompute the spectrum of h for fixed parameters, but then scan the GreenFunction for varying ω's and contact parameters (incorporated through a T-matrix), there is no way to do that still. We will need to recompute the spectrum every time. This could perhaps be implemented by making FixedParamsGreenSolvers honor passed parameters, so that they override previously fixed parameters, but that could be problematic precisely in this case, because the spectrum has already been computed. So that solution is not good. I leave this problem for a future me.