### PR TITLE
Eliminate unnecessary broadcast of identity

### DIFF
--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -234,10 +234,10 @@ function getindex_sparse!(output, g, hmask::Hamiltonian, ker; symmetrize = missi
     for har in harmonics(hmask)
         oi = CellIndices(dcell(har), oj)
         mat_cell = getindex_sparse(g, oi, oj, symmetrize)
-        fill_sparse!(har, mat_cell, bs, ker; kw...)
+        # fill_sparse!(har, mat_cell, bs, ker; kw...)
     end
-    fill_sparse!(parent(output), hmask)
-    return output
+    # fill_sparse!(parent(output), hmask)
+    # return output
 end
 
 # non-optimized fallback, can be specialized by solvers

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -234,10 +234,10 @@ function getindex_sparse!(output, g, hmask::Hamiltonian, ker; symmetrize = missi
     for har in harmonics(hmask)
         oi = CellIndices(dcell(har), oj)
         mat_cell = getindex_sparse(g, oi, oj, symmetrize)
-        # fill_sparse!(har, mat_cell, bs, ker; kw...)
+        fill_sparse!(har, mat_cell, bs, ker; kw...)
     end
-    # fill_sparse!(parent(output), hmask)
-    # return output
+    fill_sparse!(parent(output), hmask)
+    return output
 end
 
 # non-optimized fallback, can be specialized by solvers

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -783,13 +783,13 @@ Base.@propagate_inbounds Base.getindex(a::SymmetrizedMatrix, i::Int, j::Int) =
 #region
 
 function maybe_symmetrize!(out, gij, ::Missing; post = identity)
-    out .= post.(gij)
-    return out
+    out .= gij
+    return maybe_broadcast!(post, out)
 end
 
 function maybe_symmetrize!(out, (gij, gji´), sym::Number; post = identity)
-    out .= post.(sym .* gij .+ conj(sym) .* gji´)
-    return out
+    out .= sym .* gij .+ conj(sym) .* gji´
+    return maybe_broadcast!(post, out)
 end
 
 # see specialmatrices.jl
@@ -811,7 +811,8 @@ function maybe_symmetrized_getindex!(output, g, i, j, sym; kw...)
     return maybe_symmetrize!(output, (gij, gji´), sym; kw...)
 end
 
-maybe_symmetrized_getindex(g, i, j, ::Missing; post = identity) = post.(g[i, j])
+maybe_symmetrized_getindex(g, i, j, ::Missing; post = identity) =
+    maybe_broadcast!(post, g[i, j])
 
 function maybe_symmetrized_getindex(g, i, j, sym; kw...)
     gij = g[i, j]   # careful, this could be non-mutable
@@ -825,6 +826,6 @@ end
 
 # in case gij above is non-mutable
 maybe_symmetrize!(::StaticArray, (gij, gji´), sym::Number; post = identity) =
-    post.(sym * gij + conj(sym) * gji´)
+    maybe_broadcast!(post, sym * gij + conj(sym) * gji´)
 
 #endregion

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -259,6 +259,9 @@ end
 is_square(a::AbstractMatrix) = size(a, 1) == size(a, 2)
 is_square(a) = false
 
+maybe_broadcast!(::typeof(identity), x) = x
+maybe_broadcast!(f, x) = (x .= f.(x); x)
+
 #endregion
 
 ############################################################################################


### PR DESCRIPTION
A `post` keyword, identity by default, was broadcasted after `getindex!` of various objects. When `post === identity`, this was imposing a huge runtime penalty, at least in objects for which scalar indexing is expensive, such as `EigenProduct`. This PR skips the broadcast when unnecessary.