### PR TITLE
Generalize `GS.Spectrum` to allow parametric contacts, even in `densitymatrix`

### DIFF
--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -68,21 +68,21 @@ The currently implemented `GreenSolvers` (abbreviated as `GS`) are the following
   Uses a sparse `LU` factorization to compute the inverse of `⟨i|ω - H - Σ(ω)|j⟩`, where `Σ(ω)` is the self-energy from the contacts.
 
 
-- `GS.Spectrum(; spectrum_kw...)`
+- `GS.Spectrum(; solver = ES.LinearAlgebra())`
 
   For bounded (`L == 0`) AbstractHamiltonians.
 
-  Uses a diagonalization of `H`, obtained with `spectrum(H; spectrum_kw...)`, to compute the `G⁰ᵢⱼ` using the Lehmann representation `∑ₖ⟨i|ϕₖ⟩⟨ϕₖ|j⟩/(ω - ϵₖ)`. Any eigensolver supported by `spectrum` can be used here. If there are contacts, it dresses `G⁰` using a T-matrix approach, `G = G⁰ + G⁰TG⁰`.
+  Uses a diagonalization of a 0D Hamiltonian computed with `solver(h)`, to compute the `G⁰ᵢⱼ` using the Lehmann representation `∑ₖ⟨i|ϕₖ⟩⟨ϕₖ|j⟩/(ω - ϵₖ)`. Any solver from `EigenSolvers` can be used here. If there are contacts, it dresses `G⁰` using a T-matrix approach, `G = G⁰ + G⁰TG⁰`.
 
 
-- `GS.KPM(order = 100, bandrange = missing, kernel = I)`
+- `GS.KPM(; order = 100, bandrange = missing, kernel = I)`
 
   For bounded (`L == 0`) Hamiltonians, and restricted to sites belonging to contacts (see the section on Contacts).
 
   It precomputes the Chebyshev momenta, and incorporates the contact self energy with a T-matrix approach.
 
 
-- `GS.Schur(boundary = In, axis = 1, integrate_options...)`
+- `GS.Schur(; boundary = In, axis = 1, integrate_options...)`
 
   For 1D (`L == 1`) and 2D (`L == 2`) AbstractHamiltonians with only nearest-cell coupling along `axis`. Default for `L=1`.
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -73,8 +73,7 @@ call!(gs::GreenSlice{T}, ω::Complex{T}; post = identity, symmetrize = missing, 
 real_or_complex_convert(::Type{T}, ω::Real) where {T<:Real} = convert(T, ω)
 real_or_complex_convert(::Type{T}, ω::Complex) where {T<:Real} = convert(Complex{T}, ω)
 
-retarded_omega(ω::T, s::AppliedGreenSolver) where {T<:Real} =
-    ω + im * sqrt(eps(float(T))) * needs_omega_shift(s)
+retarded_omega(ω::T, s) where {T<:Real} = ω + im * sqrt(eps(float(T))) * needs_omega_shift(s)
 
 # fallback, may be overridden
 needs_omega_shift(s::AppliedGreenSolver) = true

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -24,7 +24,7 @@ end
 #region ## API ##
 
 minimal_callsafe_copy(s::AppliedSpectrumGreenSolver{<:InverseGreen0DEigenSolver}, parentham, parentcontacts) =
-    apply(s.solver, parentham, parentcontacts)
+    apply(s.eigen.solver, parentham, parentcontacts)
 # parentham needs to be non-parametric and s.eigen is its eigenspectrum, so no need to recompute
 minimal_callsafe_copy(s::AppliedSpectrumGreenSolver{<:Eigen}, parentham, parentcontacts) = s
 
@@ -69,6 +69,8 @@ function get_eigen(solver, mat, h)
     # mat´ could be dense, while mat is sparse, so if not egal, we copy
     # the solver always receives the type of matrix mat´ declared by ES.input_matrix
     eigen = solver(mat´)
+    # _, psis = eigen
+    # orthonormalize!(psis)
     return eigen
 end
 

--- a/src/solvers/greensolvers.jl
+++ b/src/solvers/greensolvers.jl
@@ -27,7 +27,7 @@
 
 module GreenSolvers
 
-using Quantica: Quantica, AbstractGreenSolver, I
+using Quantica: Quantica, AbstractGreenSolver, AbstractEigenSolver, I
 
 struct SparseLU <:AbstractGreenSolver end
 
@@ -51,11 +51,11 @@ end
 KPM(; order = 100, bandrange = missing, padfactor = 1.01, kernel = I) =
     KPM(order, bandrange, kernel, padfactor)
 
-struct Spectrum{K} <:AbstractGreenSolver
-    spectrumkw::K
+struct Spectrum{S<:AbstractEigenSolver} <:AbstractGreenSolver
+    solver::S
 end
 
-Spectrum(; spectrumkw...) = Spectrum(NamedTuple(spectrumkw))
+Spectrum(; solver = Quantica.ES.LinearAlgebra()) = Spectrum(solver)
 
 struct Bands{B<:Union{Missing,Pair},A,K} <: AbstractGreenSolver
     bandsargs::A    # sorted to make slices easier

--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -81,5 +81,7 @@ function selfenergy_plottables(s::SelfEnergyGenericSolver, ls::LatticeSlice)
     return (p1, p2)
 end
 
+needs_omega_shift(s::SelfEnergyGenericSolver) = needs_omega_shift(parent(s.gslice).solver)
+
 #endregion
 #endregion

--- a/src/solvers/selfenergy/model.jl
+++ b/src/solvers/selfenergy/model.jl
@@ -47,6 +47,8 @@ call!_output(s::SelfEnergyModelSolver) =
 minimal_callsafe_copy(s::SelfEnergyModelSolver) =
     SelfEnergyModelSolver(minimal_callsafe_copy(s.ph), s.parentinds)
 
+needs_omega_shift(::SelfEnergyModelSolver) = false
+
 #endregion
 
 #endregion top

--- a/src/solvers/selfenergy/nothing.jl
+++ b/src/solvers/selfenergy/nothing.jl
@@ -21,4 +21,6 @@ call!_output(s::SelfEnergyNothingSolver) = s.emptymat
 
 minimal_callsafe_copy(s::SelfEnergyNothingSolver) = s
 
+needs_omega_shift(::SelfEnergyNothingSolver) = false
+
 #endregion

--- a/src/solvers/selfenergy/nothing.jl
+++ b/src/solvers/selfenergy/nothing.jl
@@ -3,7 +3,7 @@
 #    Empty self energy at selectors
 #region
 
-struct SelfEnergyEmptySolver{C} <: RegularSelfEnergySolver
+struct SelfEnergyNothingSolver{C} <: EmptySelfEnergySolver      # <: RegularSelfEnergySolver
     emptymat::SparseMatrixCSC{C,Int}
 end
 
@@ -11,16 +11,14 @@ function SelfEnergy(h::AbstractHamiltonian{T}, ::Nothing; kw...) where {T}
     orbslice = contact_orbslice(h; kw...)
     norbs = norbitals(orbslice)
     emptyΣ = spzeros(Complex{T}, norbs, norbs)
-    solver = SelfEnergyEmptySolver(emptyΣ)
+    solver = SelfEnergyNothingSolver(emptyΣ)
     return SelfEnergy(solver, orbslice)
 end
 
-call!(s::SelfEnergyEmptySolver, ω; params...) = s.emptymat
+call!(s::SelfEnergyNothingSolver, ω; params...) = s.emptymat
 
-call!_output(s::SelfEnergyEmptySolver) = s.emptymat
+call!_output(s::SelfEnergyNothingSolver) = s.emptymat
 
-has_selfenergy(::SelfEnergyEmptySolver) = false
-
-minimal_callsafe_copy(s::SelfEnergyEmptySolver) = s
+minimal_callsafe_copy(s::SelfEnergyNothingSolver) = s
 
 #endregion

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -267,6 +267,8 @@ check_lead_contact_reversal(::GreenFunctionSchurLead1D, reverse) =
 
 check_lead_contact_reversal(::GreenFunctionSchurEmptyLead1D, reverse) = nothing
 
+needs_omega_shift(::SelfEnergyCouplingSchurSolver) = true
+
 #endregion
 
 #endregion

--- a/src/solvers/selfenergysolvers.jl
+++ b/src/solvers/selfenergysolvers.jl
@@ -13,6 +13,7 @@
 #   Optional: AbstractSelfEnergySolver's can also implement `selfenergy_plottables`
 #     - selfenergy_plottables(s::AbstractSelfEnergySolver, parent_latslice)
 #       -> collection of tuples to be passed to plotlattice!(axis, tup...) for visualization
+#     - needs_omega_shift(s::AbstractSelfEnergySolver) -> Bool (default true)
 #   Aliasing: AbstractSelfEnergySolver's are not allowed to alias anything from outside
 ############################################################################################
 

--- a/src/specialmatrices.jl
+++ b/src/specialmatrices.jl
@@ -447,27 +447,27 @@ dense_addblocks!(mat) = mat
 ## InverseGreenBlockSparse
 #region
 
-# inverse_green from 0D AbstractHamiltonian + contacts
-function inverse_green(h::AbstractHamiltonian{T,<:Any,0}, contacts) where {T}
+# inverse_green_blockmat from 0D AbstractHamiltonian + contacts
+function inverse_green_blockmat(h::AbstractHamiltonian0D{T}, contacts) where {T}
     hdim = flatsize(h)
     haxis = 1:hdim
     ωblock = MatrixBlock((zero(Complex{T}) * I)(hdim), haxis, haxis)
     hblock = MatrixBlock(call!_output(h), haxis, haxis)
-    mat, unitcinds, unitcindsall = inverse_green_mat((ωblock, -hblock), hdim, contacts)
+    mat, unitcinds, unitcindsall = inverse_green_mat_contactinds((ωblock, -hblock), hdim, contacts)
     source = zeros(Complex{T}, size(mat, 2), length(unitcindsall))
     nonextrng = 1:flatsize(h)
     return InverseGreenBlockSparse(mat, nonextrng, unitcinds, unitcindsall, source)
 end
 
 # case without contacts
-function inverse_green_mat(blocks, _, ::Contacts{<:Any,0})
+function inverse_green_mat_contactinds(blocks, _, ::Contacts{<:Any,0})
     mat = BlockSparseMatrix(blocks...)
     unitcinds = Vector{Int}[]
     unitcindsall = Int[]
     return mat, unitcinds, unitcindsall
 end
 
-function inverse_green_mat(blocks, hdim, contacts)
+function inverse_green_mat_contactinds(blocks, hdim, contacts)
     Σs = selfenergies(contacts)
     extoffset = hdim
     unitcinds = [orbindices(only(cellsdict(contacts, i))) for i in 1:ncontacts(contacts)]

--- a/src/types.jl
+++ b/src/types.jl
@@ -2023,7 +2023,14 @@ solver(Σ::SelfEnergy) = Σ.solver
 has_selfenergy(s::EmptySelfEnergy) = false
 has_selfenergy(s::SelfEnergy) = true
 
-call!(Σ::SelfEnergy, ω; params...) = call!(Σ.solver, ω; params...)
+call!(Σ::SelfEnergy{T}, ω; params...) where {T} =
+    call!(Σ, real_or_complex_convert(T, ω); params...)
+
+call!(Σ::SelfEnergy{T}, ω::T; params...) where {T} =
+    call!(Σ, retarded_omega(ω, solver(Σ)); params...)
+
+call!(Σ::SelfEnergy{T}, ω::Complex{T}; params...) where {T} =
+    call!(Σ.solver, ω; params...)
 
 call!_output(Σ::SelfEnergy) = call!_output(solver(Σ))
 
@@ -2031,6 +2038,9 @@ call!_output(Σ::SelfEnergy) = call!_output(solver(Σ))
 
 minimal_callsafe_copy(Σ::SelfEnergy) =
     SelfEnergy(minimal_callsafe_copy(Σ.solver), Σ.orbslice)
+
+# fallback
+needs_omega_shift(s::AbstractSelfEnergySolver) = true
 
 #endregion
 #endregion

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -613,7 +613,7 @@ end
     gs = Quantica.call!(g, 0.4, q = 0.1)
     parent(g)(q = 2)
     @test_broken gs[cells = 0] == m
-    # Ensure that g.solver.invgreen alias of parent contacts is not broken by minimal_callsafe_copy
+    # Ensure that g.solver.invgreenmat alias of parent contacts is not broken by minimal_callsafe_copy
     glead = LP.linear() |> @onsite((; o = 1) -> o) - hopping(1) |> greenfunction(GS.Schur(boundary = 0));
     g = LP.linear() |> -hopping(1) |> supercell |> attach(glead) |> greenfunction;
     g´ = Quantica.minimal_callsafe_copy(g);


### PR DESCRIPTION
In #347 we generalized GS.Spectrum to allow for parametric dependencies of Hamiltonians. However, Green functions with contacts were only supported through T-matrix, by dressing the Lehman G0(ω) for each specific ω with Σ(ω).
This, however, did not generalize to `densitymatrix`, which only worked for Green functions without any (non-empty) contacts, since there is no T-matrix for the density matrix AFAIK

However, there is the possibility of including contacts for densitymatrix by diagonalizing H+Σ(ω = µ), instead of simply H. If Σ has a gap larger than temperature, summing the occupied eigenstates of H+Σ(µ) still gives the exact density matrix. For gapless Σ(ω) this is just an approximation.

In this PR we lay out the machinery to allow the above generalization for densitymatrix. Without contacts, it works as before. With contacts, instead of refusing to work, it computes the above approximation.

To do this we did some refactoring, creating a new type `InverseGreen0D` that can be `call!`ed with all system parameters at a given ω, and which gives the spectrum of H+Σ(ω). It builds on top of `InverseGreenBlockSparse`. We also tweaked `GS.Spectrum` which no longer takes `spectrum` kwargs, only an AbstractEigenSolver (things like `transform` make no sense in this context).