### PR TITLE
Meanfield with nonparametric models instead of potentials

### DIFF
--- a/docs/src/tutorial/glossary.md
+++ b/docs/src/tutorial/glossary.md
@@ -7,8 +7,8 @@ This is a summary of the type of objects you will be studying.
 - **`SiteSelector`**: a rule that defines a subset of sites in a `Lattice` (not necessarily restricted to a single unit cell)
 - `HopSelector`: a rule that defines a subset of site pairs in a `Lattice` (not necessarily restricted to the same unit cell)
 - **`LatticeSlice`**: a *finite* subset of sites in a `Lattice`, defined by their cell index (an `L`-dimensional integer vector, usually denoted by `n` or `cell`) and their site index within the unit cell (an integer). A `LatticeSlice` an be constructed by combining a `Lattice` and a (bounded) `SiteSelector`.
-- **`AbstractModel`**: either a `TightBindingModel` or a `ParametricModel`
-  - **`TightBindingModel`**: a set of `HoppingTerm`s and `OnsiteTerm`s
+- **`AbstractModel`**: either a `TightbindingModel` or a `ParametricModel`
+  - **`TightbindingModel`**: a set of `HoppingTerm`s and `OnsiteTerm`s
     - **`OnsiteTerm`**: a rule that, applied to a single site, produces a scalar or a (square) matrix that represents the intra-site Hamiltonian elements (single or multi-orbital)
     - **`HoppingTerm`**: a rule that, applied to a pair of sites, produces a scalar or a matrix that represents the inter-site Hamiltonian elements (single or multi-orbital)
   - **`ParametricModel`**: a set of `ParametricOnsiteTerm`s and `ParametricHoppingTerm`s

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1815,7 +1815,7 @@ Equivalent to `diagonal(siteselector(; sites...); kernel)`
 
 ## Keywords
 
-    - `kernel`: if missing, all orbitals in the diagonal `g[i, i]` are returned when indexing `g[diagonal(i)]`. Otherwise, `Tr(g[site, site]*kernel)` for each site included in `i` is returned.
+- `kernel`: if missing, all orbitals in the diagonal `g[i, i]` are returned when indexing `g[diagonal(i)]`. Otherwise, `Tr(g[site, site]*kernel)` for each site included in `i` is returned.
 
 # Example
 ```julia
@@ -1860,7 +1860,7 @@ Equivalent to `sitepairs(hopselector(; hops...); kernel)`
 
 ## Keywords
 
-    - `kernel`: if missing, all orbitals blocks `gᵢⱼ = g[i, j]` between selected sites pairs (i,j) are returned when indexing `g[sitepairs(...)]`. Otherwise, `gᵢⱼ` is replaced by `Tr(gᵢⱼ*kernel)`.
+- `kernel`: if missing, all orbitals blocks `gᵢⱼ = g[i, j]` between selected sites pairs (i,j) are returned when indexing `g[sitepairs(...)]`. Otherwise, `gᵢⱼ` is replaced by `Tr(gᵢⱼ*kernel)`.
 
 # Example
 ```julia
@@ -2772,6 +2772,12 @@ where `U` is the onsite interaction.
 
 Any additional keywords `kw` are passed to the `densitymatrix` function used to compute the
 mean field, see above
+
+If a non-parametric `TightbindingModel` is passed to the `hartree` and/or `fock` keywords,
+the model will be used to define the interaction, by translating `onsite` terms into onsite
+interactions, and `hopping` terms into inter-site interactions. In such case, the
+corresponding `selector_hartree` and/or `selector_fock` will be ignored. See `onsite` and
+`hopping` for details on defining non-parametric models.
 
 ## Evaluation and Indexing
 

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -380,7 +380,7 @@ end
 # creates a Hamiltonian with same blocktype as g, or complex if kernel::Missing
 # this may be used as an intermediate to build sparse versions of g[i,j]
 sites_to_orbs(d::PairIndices{<:HopSelector}, g) =
-    SparseIndices(g, hopping(I, parent(d)), kernel(d))
+    SparseIndices(g, hopping(I, parent(d)); kernel = kernel(d))
 
 sites_to_orbs(d::PairIndices{<:Hamiltonian}, g) = d
 

--- a/src/slices.jl
+++ b/src/slices.jl
@@ -379,15 +379,10 @@ end
 
 # creates a Hamiltonian with same blocktype as g, or complex if kernel::Missing
 # this may be used as an intermediate to build sparse versions of g[i,j]
-function sites_to_orbs(d::PairIndices{<:HopSelector}, g)
-    hg = hamiltonian(g)
-    ker = kernel(d)
-    bs = maybe_scalarize(blockstructure(hg), ker)
-    b = IJVBuilder(lattice(hg), bs)
-    hopsel = parent(d)
-    h = hamiltonian!(b, hopping(I, hopsel))
-    return SparseIndices(h, ker)   # OrbitalPairIndices
-end
+sites_to_orbs(d::PairIndices{<:HopSelector}, g) =
+    SparseIndices(g, hopping(I, parent(d)), kernel(d))
+
+sites_to_orbs(d::PairIndices{<:Hamiltonian}, g) = d
 
 ## convert SiteSlice -> OrbitalSliceGrouped
 

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -661,7 +661,18 @@ end
     m = meanfield(g; selector = (; range = 1), potential = 2, fock = 1.5, charge = Q)
     Φ = m(0.2, 0.3)
     ρ12 = m.rho(0.2, 0.3)[sites(1), sites(2)]
+    @test !iszero(Φ[sites(1), sites(2)])
     @test Φ[sites(1), sites(2)] ≈ -1.5 * Q * ρ12 * Q
+
+    # model potential
+    m = meanfield(g; hartree = nothing, fock = hopping(2, range = 1)+onsite(3), charge = Q)
+    Φ = m(0.2, 0.3)
+    ρ12 = m.rho(0.2, 0.3)[sites(1), sites(2)]
+    ρ11 = m.rho(0.2, 0.3)[sites(1), sites(1)]
+    @test !iszero(Φ[sites(1), sites(2)])
+    @test !iszero(Φ[sites(1), sites(1)])
+    @test Φ[sites(1), sites(2)] ≈ -2.0 * Q * ρ12 * Q
+    @test Φ[sites(1), sites(1)] ≈ -3.0 * Q * ρ11 * Q
 
     # spinless nambu
     oh = LP.linear() |> hamiltonian(hopping((r, dr) -> SA[1 sign(dr[1]); -sign(dr[1]) -1]) - onsite(SA[1 0.1; 0.1 -1]), orbitals = 2)


### PR DESCRIPTION
This extends meanfield to accept non-parametric models in `hartree` and `fock` kwargs, instead of potential functions. This allows to precisely define the interaction model using all the selector machinery. When using models, the `selector_hartree`/`selector_fock` kwargs are ignored.

Note that currently parametric models are not supported for the potentials. They should all be non-parametric.

As an example, the following will create a meanfield with no hartree, an on-site fock set to 3 and inter-site fock to 2, up to range 2.
```
meanfield(g; hartree = nothing, fock = hopping(2, range = 2) + onsite(3))
```