### PR TITLE
Remove allocations in `call!` of large parametric models

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -316,7 +316,9 @@ call!(p::ParametricHamiltonian, ft::FrankenTuple) = call!(p, Tuple(ft); NamedTup
 function call!(ph::ParametricHamiltonian; kw...)
     reset_to_parent!(ph)
     h = hamiltonian(ph)
-    applymodifiers!(h, modifiers(ph)...; kw...)
+    foreach(modifiers(ph)) do m
+        applymodifiers!(h, m; kw...)
+    end
     flat_sync!(h)  # modifiers are applied to unflat, need to be synced to flat
     return h
 end
@@ -340,10 +342,6 @@ function reset_to_parent!(ph)
     end
     return ph
 end
-
-applymodifiers!(h; kw...) = h
-
-applymodifiers!(h, m, m´, ms...; kw...) = applymodifiers!(applymodifiers!(h, m; kw...), m´, ms...; kw...)
 
 applymodifiers!(h, m::Modifier; kw...) = applymodifiers!(h, apply(m, h); kw...)
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -413,6 +413,10 @@ end
         @hopping!((t, r, dr; p = 1) -> p+r[2], dcells = SVector{2,Int}[]) |> @onsite!((o, r; q = 1) -> o + q, sublats, region = RP.circle(3))
     @test h0 isa ParametricHamiltonian
     @test Quantica.parameter_names(h0) == [:p, :q]
+
+    # no allocations even for large models
+    h = LP.linear() |> sum(@onsite((; a = 0) -> 0) for _ in 1:20)
+    Quantica.call!(h; a=0); @test (@allocations Quantica.call!(h; a=0)) <= 1
 end
 
 @testset "ExternalPresets.wannier90" begin

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -416,7 +416,7 @@ end
 
     # no allocations even for large models
     h = LP.linear() |> sum(@onsite((; a = 0) -> 0) for _ in 1:20)
-    Quantica.call!(h; a=0); @test (@allocations Quantica.call!(h; a=0)) <= 1
+    Quantica.call!(h; a=0); @test (@allocations Quantica.call!(h; a=0)) <= 10
 end
 
 @testset "ExternalPresets.wannier90" begin


### PR DESCRIPTION
Splatting modifiers in lisp-style `applymodifiers!` was a bad idea. If you have more than 15 modifiers, this produces lots of allocations (compiler internals!). We now do  much more natural `foreach` over modifiers.