### PR TITLE
Release v1.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Quantica"
 uuid = "ae5ea0c6-3f5e-46a2-bc28-a7c4c7a4773c"
 authors = ["Pablo San-Jose"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
PRs from #336 to #368

## Changes since v1.2.0

### Fixes

- Bugfix in meanfield of spinless superconductors
  - #344
- Functional cell selectors now respect other selection constraints
  - #367

### New features

- General polish (indexing, api, plotting) and optimizations 
  - #336, #341, #342, #346, #348, #355, #356
- GreenSolver.Spectrum can now be used with ParametricHamiltonians
  - #347
- Overhauled `stitch` function that solves a number of issues with ParametricHamiltonians
  - #352
- `meanfield` can now accept general models instead of potentials
  - #353
- Built-in, although unexported, Pauli matrices! Do `using Quantica: σ` to use them
  - #354
- Support for custom color schemes in plots
  - #358
- Support for Makie 0.24 
  - #364
- Band metadata functionality, including Abelian and non-Abelian Berry curvature 
  - #368