### PR TITLE
Bugfix: `reverse = true` in `attach` subtly broke after `reverse` changes of #386

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -29,18 +29,16 @@ CellSites{L,V}(c::CellSites) where {L,V} =
 CellSites{L,V}(c::CellSite) where {L,V<:Vector} =
     CellIndices(convert(SVector{L,Int}, cell(c)), convert(V, [siteindices(c)]), SiteLike())
 
-function Hamiltonian{E}(h::Hamiltonian) where {E}
-    lat = lattice(h)
-    lat´ = lattice(lat, dim = Val(E))
+function Hamiltonian{E}(h::Hamiltonian, lat = lattice(lattice(h), dim = Val(E))) where {E}
     bs = blockstructure(h)
     hs = harmonics(h)
     b = bloch(h)
-    return Hamiltonian(lat´, bs, hs, b)
+    return Hamiltonian(lat, bs, hs, b)
 end
 
 function ParametricHamiltonian{E}(ph::ParametricHamiltonian) where {E}
     hparent = Hamiltonian{E}(parent(ph))
-    h = Hamiltonian{E}(hamiltonian(ph))
+    h = Hamiltonian{E}(hamiltonian(ph), lattice(hparent))
     ms = modifiers(ph)
     ptrs = pointers(ph)
     pars = parameter_names(ph)

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -29,6 +29,8 @@ function isleftside(side)
     end
 end
 
+isreversed(s::SelfEnergySchurSolver) = s.isleftside
+
 #endregion
 
 #region ## API ##
@@ -66,13 +68,13 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurEmpty
     transform === missing || Quantica.transform!(hlead, transform)
     translate!(hlead, displacement)
 
-    if reverse
-        # this new hlead updates harmonic matrices with call! just like the original hlead
-        # but the bravais vectors and ±dn indices are flipped in place. Nothing else changes
-        # consequently, this only affects plotting, not calculations
-        hlead = copy_harmonics_shallow(hlead)
-        reverse_bravais!(hlead)
-    end
+    # if reverse
+    #     # this new hlead updates harmonic matrices with call! just like the original hlead
+    #     # but the bravais vectors and ±dn indices are flipped in place. Nothing else changes
+    #     # consequently, this only affects plotting, not calculations
+    #     hlead = copy_harmonics_shallow(hlead)
+    #     reverse_bravais!(hlead)
+    # end
 
     solver´ = SelfEnergySchurSolver(fsolver, hlead, reverse, boundary, leadorbs)
     return SelfEnergy(solver´, lsparent)
@@ -125,7 +127,8 @@ function minimal_callsafe_copy(s::SelfEnergySchurSolver)
 end
 
 function selfenergy_plottables(s::SelfEnergySchurSolver, ls::LatticeSlice)
-    p1 = ftuple(s.hlead; selector = siteselector(cells = SA[1]))
+    cells = ifelse(isreversed(s), SA[-1], SA[1])
+    p1 = ftuple(s.hlead; selector = siteselector(; cells))
     p2 = (ls, )
     return p1, p2
 end
@@ -214,14 +217,6 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead1
     gslice = glead[cells = SA[xunit]]
     Σs = selfenergies(contacts(glead))
 
-    if reverse
-        # this new hlead updates harmonic matrices with call! just like the original hlead
-        # but the bravais vectors and ±dn indices are flipped in place. Nothing else changes
-        # consequently, this only affects plotting, not calculations
-        hlead = copy_harmonics_shallow(hlead)
-        reverse_bravais!(hlead)
-    end
-
     solver´ = extended_or_regular_solver(Σs, gslice, gunit, hcoupling, nparent)
 
     return SelfEnergy(solver´, lsparent)
@@ -302,25 +297,17 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurLead1
     # convert lead site indices to lead orbital indices using lead's ContactOrbitals
     leadorbs = reordered_site_orbitals(leadsites, cellsdict(contactorbitals(glead)))
 
-    # build V and V´ as a leadorbs reordering of inter-cell harmonics of hlead
-    hlead = copy_lattice(hamiltonian(glead))  # careful, not parent, which could be a ParametricHamiltonian
-    h₊₁, h₋₁ = hlead[SA[1]], hlead[SA[-1]]
+    # build V and V´ as a leadorbs reordering of inter-cell harmonics of hcoupling
+    hcoupling = copy_lattice(hamiltonian(glead))  # careful, not parent, which could be a ParametricHamiltonian
+    h₊₁, h₋₁ = reverse ? (hcoupling[SA[-1]], hcoupling[SA[1]]) : (hcoupling[SA[1]], hcoupling[SA[-1]])
     V  = SparseMatrixView(view(h₊₁, :, leadorbs))
     V´ = SparseMatrixView(view(h₋₁, leadorbs, :))
 
-    # transform hlead (note that we did copy_lattice, so this preserves glead's lattice)
-    transform === missing || Quantica.transform!(hlead, transform)
-    translate!(hlead, displacement)
+    # transform hcoupling (note that we did copy_lattice, so this preserves glead's lattice)
+    transform === missing || Quantica.transform!(hcoupling, transform)
+    translate!(hcoupling, displacement)
 
-    if reverse
-        # this new hlead updates harmonic matrices with call! just like the original hlead
-        # but the bravais vectors and ±dn indices are flipped in place. Nothing else changes
-        # consequently, this only affects plotting, not calculations
-        hlead = copy_harmonics_shallow(hlead)
-        reverse_bravais!(hlead)
-    end
-
-    solver´ = SelfEnergyGenericSolver(gslice, hlead, V´, V)
+    solver´ = SelfEnergyGenericSolver(gslice, hcoupling, V´, V)
     return SelfEnergy(solver´, lsparent)
 end
 

--- a/src/solvers/selfenergy/schur.jl
+++ b/src/solvers/selfenergy/schur.jl
@@ -68,14 +68,6 @@ function SelfEnergy(hparent::AbstractHamiltonian, glead::GreenFunctionSchurEmpty
     transform === missing || Quantica.transform!(hlead, transform)
     translate!(hlead, displacement)
 
-    # if reverse
-    #     # this new hlead updates harmonic matrices with call! just like the original hlead
-    #     # but the bravais vectors and ±dn indices are flipped in place. Nothing else changes
-    #     # consequently, this only affects plotting, not calculations
-    #     hlead = copy_harmonics_shallow(hlead)
-    #     reverse_bravais!(hlead)
-    # end
-
     solver´ = SelfEnergySchurSolver(fsolver, hlead, reverse, boundary, leadorbs)
     return SelfEnergy(solver´, lsparent)
 end

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -206,15 +206,6 @@ Base.parent(m::StitchModifier) = m.ph
 # copy(StitchModifer) must dealias, since m.groups_dcells_uw can be mutated, e.g. by reverse_bravais!
 Base.copy(m::StitchModifier) = StitchModifier(m.ph, m.wrapped_phases, copy.(m.groups_dcells_uw))
 
-# Used for reverse: flip sign of dcells_u of unwrapped axes which are used to select the
-# stitched harmonics (assumed reversed) that are the sum of subsets of original harmonics.
-# see sum_harmonics_group! below
-function flip_dcells!(m::StitchModifier)
-    _, dcells_u, _ = stitch_groups(m)
-    dcells_u .*= -1
-    return m
-end
-
 #endregion
 
 #region ## applymodifier! API
@@ -292,6 +283,7 @@ end
 
 Base.reverse(lat::Lattice) = reverse_bravais!(copy(lat))
 
+# cannot copy only lattice, since we also transform harmonics to match
 Base.reverse(h::AbstractHamiltonian) = reverse_bravais!(copy(h))
 
 # unexported
@@ -299,6 +291,19 @@ reverse_bravais!(lat::Lattice) = (matrix(bravais(lat)) .*= -1; lat)
 
 function reverse_bravais!(h::Hamiltonian)
     reverse_bravais!(lattice(h))
+    flip_dcells!(h)
+    return h
+end
+
+function reverse_bravais!(ph::ParametricHamiltonian)
+    reverse_bravais!(lattice(parent(ph)))
+    flip_dcells!(parent(ph))
+    flip_dcells!(hamiltonian(ph))
+    flip_dcells!.(modifiers(ph))
+    return ph
+end
+
+function flip_dcells!(h::Hamiltonian)
     hars = harmonics(h)
     for (i, har) in enumerate(hars)
         hars[i] = Harmonic(-dcell(har), matrix(har))
@@ -306,18 +311,20 @@ function reverse_bravais!(h::Hamiltonian)
     return h
 end
 
-function reverse_bravais!(ph::ParametricHamiltonian)
-    reverse_bravais!(parent(ph))
-    reverse_bravais!(hamiltonian(ph))
-    reverse_bravais!.(modifiers(ph))
-    return ph
+# by default, modifiers do not care about reverse
+flip_dcells!(m::AbstractModifier) = m
+
+# StitchModifier is special, in that it contains a reference to the dn of stitched
+# harmonics that are a sum over subsets of parent harmonics. If the dcell of the former are
+# flipped, we must flip the dcell reference to them as well.
+function flip_dcells!(m::StitchModifier)
+    _, dcells_u, _ = stitch_groups(m)
+    dcells_u .*= -1
+    return m
 end
 
-# by default, modifiers do not care about reverse
-reverse_bravais!(m::AbstractModifier) = m
-
 # AppliedHoppingModifiers contain CellSite's that contain nonzero dcell that must be flipped
-function reverse_bravais!(m::AppliedHoppingModifier)
+function flip_dcells!(m::AppliedHoppingModifier)
     ptrs = pointers(m)
     for pcell in ptrs, (i, p) in enumerate(pcell)
         (ptr, r, dr, si, sj, norbs) = p
@@ -326,9 +333,5 @@ function reverse_bravais!(m::AppliedHoppingModifier)
     return m
 end
 
-# The StitchModifier is special, in that it contains a reference to the dn of stitched
-# harmonics that are a sum over subsets of parent harmonics. If the dcell of the former are
-# flipped, we must flip the dcell reference to them as well.
-reverse_bravais!(m::StitchModifier) = flip_dcells!(m)
 
 #endregion

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -296,7 +296,7 @@ function reverse_bravais!(h::Hamiltonian)
 end
 
 function reverse_bravais!(ph::ParametricHamiltonian)
-    reverse_bravais!(lattice(parent(ph)))
+    reverse_bravais!(lattice(parent(ph)))  # lattice of ph.hparent and ph.h are aliased, so do this only once
     flip_dcells!(parent(ph))
     flip_dcells!(hamiltonian(ph))
     flip_dcells!.(modifiers(ph))

--- a/src/types.jl
+++ b/src/types.jl
@@ -1546,6 +1546,9 @@ Base.iszero(h::Hamiltonian) = all(iszero, harmonics(h))
 Base.copy(h::Hamiltonian) = Hamiltonian(
     copy(lattice(h)), copy(blockstructure(h)), copy.(harmonics(h)), copy(bloch(h)))
 
+copy_except_lattice(h::Hamiltonian, lat) = Hamiltonian(
+    lat, copy(blockstructure(h)), copy.(harmonics(h)), copy(bloch(h)))
+
 copy_lattice(h::Hamiltonian) = Hamiltonian(
     copy(lattice(h)), blockstructure(h), harmonics(h), bloch(h))
 
@@ -1581,7 +1584,14 @@ struct ParametricHamiltonian{T,E,L,B,M<:NTuple{<:Any,AppliedModifier}} <: Abstra
                                    # because they involve kwargs
     allptrs::Vector{Vector{Int}}   # allptrs are all modified ptrs in each harmonic (needed for reset!)
     allparams::Vector{Symbol}
+    function ParametricHamiltonian{T,E,L,B,M}(hparent, h, modifiers, allptrs, allparams) where {T,E,L,B,M<:NTuple{<:Any,AppliedModifier}}
+        lattice(h) === lattice(hparent) || argerror("Lattice of ParametricHamiltonian's h must alias that of hparent")
+        return new(hparent, h, modifiers, allptrs, allparams)
+    end
 end
+
+ParametricHamiltonian(hparent::Hamiltonian{T,E,L,B}, h::Hamiltonian{T,E,L,B}, modifiers::M, allptrs::Vector{Vector{Int}}, allparams::Vector{Symbol}) where {T,E,L,B,M<:NTuple{<:Any,AppliedModifier}} =
+    ParametricHamiltonian{T,E,L,B,M}(hparent, h, modifiers, allptrs, allparams)
 
 #region ## API ##
 
@@ -1618,14 +1628,23 @@ Base.parent(h::ParametricHamiltonian) = h.hparent
 
 Base.size(h::ParametricHamiltonian, i...) = size(parent(h), i...)
 
-Base.copy(p::ParametricHamiltonian) = ParametricHamiltonian(
-    copy(p.hparent), copy(p.h), copy.(p.modifiers), copy.(p.allptrs), copy(p.allparams))
+function Base.copy(p::ParametricHamiltonian)
+    lat = copy(lattice(p))
+    p´ = ParametricHamiltonian(copy_except_lattice(p.hparent, lat), copy_except_lattice(p.h, lat),
+        copy.(p.modifiers), copy.(p.allptrs), copy(p.allparams))
+    return p´
+end
 
-LinearAlgebra.ishermitian(h::ParametricHamiltonian) =
+
+LinearAlgebra.ishermitian(::ParametricHamiltonian) =
     argerror("`ishermitian(::ParametricHamiltonian)` not supported, as the result can depend on the values of parameters.")
 
-copy_lattice(p::ParametricHamiltonian) = ParametricHamiltonian(
-    p.hparent, copy_lattice(p.h), p.modifiers, p.allptrs, p.allparams)
+function copy_lattice(p::ParametricHamiltonian)
+    lat = copy(lattice(p))
+    h = Hamiltonian(lat, blockstructure(p.h), harmonics(p.h), bloch(p.h))
+    hparent = Hamiltonian(lat, blockstructure(p.hparent), harmonics(p.hparent), bloch(p.hparent))
+    return ParametricHamiltonian(hparent, h, p.modifiers, p.allptrs, p.allparams)
+end
 
 copy_harmonics_shallow(p::ParametricHamiltonian) = ParametricHamiltonian(
     copy_harmonics_shallow(p.hparent), copy_harmonics_shallow(p.h), p.modifiers, p.allptrs, p.allparams)
@@ -1996,7 +2015,7 @@ attach(h::AbstractHamiltonian, args...; kw...) = attach(h, SelfEnergy(h, args...
 attach(h::AbstractHamiltonian, Σ::SelfEnergy) = OpenHamiltonian(h, (Σ,))
 
 # fallback for SelfEnergy constructor
-SelfEnergy(h::AbstractHamiltonian, args...; kw...) = argerror("Unknown attach/SelfEnergy systax")
+SelfEnergy(h::AbstractHamiltonian, args...; kw...) = argerror("Unknown attach/SelfEnergy syntax")
 
 minimal_callsafe_copy(oh::OpenHamiltonian) =
     OpenHamiltonian(minimal_callsafe_copy(oh.h), minimal_callsafe_copy.(oh.selfenergies))

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -121,6 +121,14 @@ end
     gs = g(0.2)
     @test view(gs, 1, 2) isa SubArray
     @test (@allocations view(gs, 1, 2)) <= 2  # should be 1, but in some platforms/versions it could be 2
+
+    # check reverse gives same as non-reverse
+    model = -hopping(SA[1 0; 0 -1]) + @hopping((r, dr) ->  SA[0 dr[1]; -dr[1] 0])
+    h = LP.square() |> hamiltonian(model, orbitals = 2) |> stitch(SA[2])
+    glead = h |> greenfunction(GS.Schur(boundary = 0))
+    gR = h |> attach(glead, cells = SA[0], reverse = true) |> greenfunction(GS.Schur(boundary = -1))
+    gL = h |> attach(glead, cells = SA[0]) |> greenfunction(GS.Schur(boundary = 1))
+    @test gR[](0.01) ≈ gL[](0.01)
 end
 
 @testset "GreenFunction partial evaluation" begin
@@ -626,8 +634,8 @@ end
        attach(glead, region = r -> SA[-√3/2,1/2]' * r > 3.5, reverse = true) |>
        attach(glead, region = r -> SA[-√3/2,1/2]' * r < 0, reverse = false) |> greenfunction;
     @test g.contacts.selfenergies[2].solver.hlead[(0,)] === g.contacts.selfenergies[1].solver.hlead[(0,)]
-    @test g.contacts.selfenergies[2].solver.hlead[(1,)] === g.contacts.selfenergies[1].solver.hlead[(-1,)]
-    @test g.contacts.selfenergies[2].solver.hlead[(-1,)] === g.contacts.selfenergies[1].solver.hlead[(1,)]
+    @test g.contacts.selfenergies[2].solver.hlead[(-1,)] === g.contacts.selfenergies[1].solver.hlead[(-1,)]
+    @test g.contacts.selfenergies[2].solver.hlead[(1,)] === g.contacts.selfenergies[1].solver.hlead[(1,)]
 
     # ensure full dealiasing of lattices in attach
     model = hopping(SA[1 0; 0 -1]) + @onsite((; µ = 0) -> SA[-µ 0; 0 µ])

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -60,7 +60,7 @@ end
     h = LP.linear() |> @hopping((; t = 1) -> t)
     h´ = Quantica.copy_lattice(h)
     @test lattice(hamiltonian(h´)) === lattice(parent(h´))
-        # without the above guarantee, this would fail (reverse would flip the bravais vectors of h)
+        # without the above guarantee (#387), this would fail
         # begin
         #     h2 = LP.square() |> hopping(1)
         #     h = @stitch(h2, SA[2], k)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -55,6 +55,21 @@ using Quantica: Hamiltonian, ParametricHamiltonian, BarebonesOperator, OrbitalSl
     @test ishermitian(h())
 end
 
+@testset "hamiltonian aliasing" begin
+    # lattice aliasing in ParametricHamiltonian
+    h = LP.linear() |> @hopping((; t = 1) -> t)
+    h´ = Quantica.copy_lattice(h)
+    @test lattice(hamiltonian(h´)) === lattice(parent(h´))
+        # without the above guarantee, this would fail (reverse would flip the bravais vectors of h)
+        # begin
+        #     h2 = LP.square() |> hopping(1)
+        #     h = @stitch(h2, SA[2], k)
+        #     g1 = greenfunction(h, GS.Schur(; boundary = 0))
+        #     oh = h |> attach(g1, cells = SA[0], reverse = true)
+        #     @test bravais_matrix(lattice(h)) == SA[1 0]'
+        # end
+end
+
 @testset "hamiltonian orbitals" begin
     lat = LP.honeycomb()
     hop = hopping(SA[1 0], sublats = :A => :B)
@@ -470,7 +485,7 @@ end
     @test h((1,2)) == h3((1,2))
     h = LP.square() |> @hopping((; t=1) -> t) |> supercell((2,0), (0, 1))
     h´ = h |> transform(r -> SA[r[2], r[1]])
-    @test sites(lattice(h´)) == sites(h´.h.lattice) != sites(lattice(parent(h´)))
+    @test sites(lattice(h´)) == sites(h´.h.lattice) != sites(lattice(h))
     @test sites(lattice(h´)) == [SA[0,0], SA[0,1]]
     h´´ = reverse(h´)
     @test bravais_matrix(lattice(h´´)) == - bravais_matrix(lattice(h´))


### PR DESCRIPTION
Before, doing an attach with reverse = true would make the new ParametricHamiltonian have different lattices for h and hparent. The one for hparent would remain aliased with the originating h, which would produce obscure bugs. We now impose the invariant in any ParametricHamiltonian, so that both lattices are ===.