### PR TITLE
Ensure `applymodifier!(::StitchModifier,...)` writes only on unflat harmonics

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -317,12 +317,15 @@ call!(p::ParametricHamiltonian, ft::FrankenTuple, axis = missing) =
     call!(p, sanitize_SVector(Tuple(ft)...), axis; NamedTuple(ft)...)
 
 function call!(ph::ParametricHamiltonian; kw...)
-    reset_to_parent!(ph)                # this sets flat_sync state to unsynced
+    # This reset also sets flat_sync state to unsynced, to be collected by flat_sync! below
+    reset_to_parent!(ph)
     h = hamiltonian(ph)
     foreach(modifiers(ph)) do m
-        applymodifiers!(h, m; kw...)    # we assume this never resets flat_sync state!
+        # we assume this only modifies unflat harmonics, and preserves needs_flat_sync state
+        applymodifiers!(h, m; kw...)
     end
-    flat_sync!(h)  # modifiers are applied to unflat, need to be synced to flat
+    # modifiers are applied *only* to unflat, need to be synced to flat
+    flat_sync!(h)
     return h
 end
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -317,10 +317,10 @@ call!(p::ParametricHamiltonian, ft::FrankenTuple, axis = missing) =
     call!(p, sanitize_SVector(Tuple(ft)...), axis; NamedTuple(ft)...)
 
 function call!(ph::ParametricHamiltonian; kw...)
-    reset_to_parent!(ph)
+    reset_to_parent!(ph)                # this sets flat_sync state to unsynced
     h = hamiltonian(ph)
     foreach(modifiers(ph)) do m
-        applymodifiers!(h, m; kw...)
+        applymodifiers!(h, m; kw...)    # we assume this never resets flat_sync state!
     end
     flat_sync!(h)  # modifiers are applied to unflat, need to be synced to flat
     return h

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -370,9 +370,10 @@ function merged_mul!(C::SparseMatrixCSC{<:Number}, A::HybridSparseMatrix, b::Num
 end
 
 merged_mul!(C::SparseMatrixCSC{<:Number}, ::OrbitalBlockStructure, A::SparseMatrixCSC{B}, b::Number, α = 1, β = 0) where {B<:Complex} =
-    merged_flat_mul!(C, A, b, α, β)
+    merged_mul!(C, A, b, α, β)
 
-function merged_flat_mul!(C::SparseMatrixCSC{<:Number}, A::SparseMatrixCSC{<:Number}, b::Number, α = 1, β = 0)
+# like mul! but preserves the sparse structure of C, which must include the structure of A.
+function merged_mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Number, α = 1, β = 0)
     nzA = nonzeros(A)
     nzC = nonzeros(C)
     αb = α * b

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -213,7 +213,7 @@ Base.copy(m::StitchModifier) = StitchModifier(m.ph, m.wrapped_phases, copy.(m.gr
 function applymodifiers!(ph, m::StitchModifier; kw...)
     h_parent = call!(m.ph; kw...)
     hars_parent = harmonics(h_parent)
-    h = hamiltonian(ph)
+    h = hamiltonian(ph)                     # this has been reset_to_parent! already
     wp = m.wrapped_phases
     groups, dcells_u, dcells_w = stitch_groups(m)
     for inds in groups
@@ -225,17 +225,14 @@ end
 # inds are hars_parent indices
 function sum_harmonics_group!(h, hars_parent, inds, phases_w, dcells_u, dcells_w)
     dn_u = dcells_u[first(inds)]
-    hybmat = h[hybrid(dn_u)]                    # unflat HybridMatrix
-    was_unsynced = needs_flat_sync(hybmat)
-    mat = flat(hybmat)                          # flat sparse matrix - may cause flat_sync!
+    mat = h[unflat(dn_u)]                    # unflat HybridMatrix
     for i in inds
         dn_w = dcells_w[i]
         e⁻ⁱᵠᵈⁿ = blochfactor(phases_w, dn_w)
-        mat_parent = flat(hars_parent[i])       # flat sparse matrix
-        # by construction, all structural elements in mat_parent are in mat too. See tools.jl
-        merged_flat_mul!(mat, mat_parent, e⁻ⁱᵠᵈⁿ, 1, 1)
+        mat_parent = unflat(hars_parent[i])
+        # We do mat .+= e⁻ⁱᵠᵈⁿ * mat_parent but preserving sparsity structure of mat
+        merged_mul!(mat, mat_parent, e⁻ⁱᵠᵈⁿ, 1, 1)
     end
-    was_unsynced && needs_flat_sync!(hybmat)    # we restore the sync state
     return h
 end
 

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -225,7 +225,9 @@ end
 # inds are hars_parent indices
 function sum_harmonics_group!(h, hars_parent, inds, phases_w, dcells_u, dcells_w)
     dn_u = dcells_u[first(inds)]
-    mat = h[dn_u]                               # flat sparse matrix
+    hybmat = h[hybrid(dn_u)]                    # unflat HybridMatrix
+    was_unsynced = needs_flat_sync(hybmat)
+    mat = flat(hybmat)                          # flat sparse matrix - may cause flat_sync!
     for i in inds
         dn_w = dcells_w[i]
         e⁻ⁱᵠᵈⁿ = blochfactor(phases_w, dn_w)
@@ -233,6 +235,7 @@ function sum_harmonics_group!(h, hars_parent, inds, phases_w, dcells_u, dcells_w
         # by construction, all structural elements in mat_parent are in mat too. See tools.jl
         merged_flat_mul!(mat, mat_parent, e⁻ⁱᵠᵈⁿ, 1, 1)
     end
+    was_unsynced && needs_flat_sync!(hybmat)    # we restore the sync state
     return h
 end
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -294,6 +294,10 @@ end
     h´´´ = h´ |> @hopping!((t; d = 0.5) -> t * d)
     @test h(SA[0.2,0.3,0.4]) ≈ h´(SA[0.3]; ϕ = SA[0.2,0.4]) ≈ h´´(SA[0.3,0.4]) ≈ h´´´(SA[0.3]; ϕ = SA[0.2,0.4], d = 1)
     @test !(h(SA[0.2,0.3,0.4]) ≈ h´´´(SA[0.3]; ϕ = SA[0.2,0.4]))
+
+    # sync state bug #389
+    h = @stitch(LP.honeycomb() |> hamiltonian(@onsite((; µ = 0.0) -> -µ*σ.z), orbitals=2), SA[1], ϕ) |> @onsite!((o; v=1) -> o + v*σ.z);
+    @test h(SA[0]; v = 5) == Quantica.Diagonal([5, -5, 5, -5])
 end
 
 @testset "hamiltonian HybridSparseMatrix" begin


### PR DESCRIPTION
Closes #389 

There is an implicit assumption of modifiers: they should not change the `needs_flat_sync(har) == true` state set by `reset_to_parent!`. If they do, their application before other modifiers may inhibit the final flat_sync! after all modifiers are applied. StitchModifiers did implicitly reset flat_sync state by calling `h[dn]`, which calls `flat`, which calls `flat_sync!`, which resets sync_state. We now make sure to restore sync_state