### PR TITLE
Fix multithreaded bands with interactive threads

### DIFF
--- a/src/bands.jl
+++ b/src/bands.jl
@@ -275,10 +275,10 @@ function subbands_diagonalize!(data)
             data.showprogress && ProgressMeter.next!(meter)
         end
     else
-        solver = first(data.solvers)
+        solver1 = first(data.solvers)
         for i in eachindex(baseverts)
             vert = baseverts[i]
-            data.eigens[i] = solver(vert)
+            data.eigens[i] = solver1(vert)
             data.showprogress && ProgressMeter.next!(meter)
         end
     end

--- a/src/bands.jl
+++ b/src/bands.jl
@@ -266,10 +266,12 @@ function subbands_diagonalize!(data)
     meter = Progress(length(baseverts); desc = "Step 1 - Diagonalizing: ")
     push!(data.coloffsets, 0) # first element
     if length(data.solvers) > 1
-        Threads.@threads :static for i in eachindex(baseverts)
+        solver_channel = build_channels(data.solvers)
+        Threads.@threads for i in eachindex(baseverts)
             vert = baseverts[i]
-            solver = data.solvers[Threads.threadid()]
+            solver = take!(solver_channel)
             data.eigens[i] = solver(vert)
+            put!(solver_channel, solver)
             data.showprogress && ProgressMeter.next!(meter)
         end
     else
@@ -285,6 +287,14 @@ function subbands_diagonalize!(data)
         append_bands_column!(data, basevert, eigen)
     end
     ProgressMeter.finish!(meter)
+end
+
+function build_channels(solvers::Vector{A}) where {A}
+    channel = Channel{A}(length(solvers))
+    for solver in solvers
+        put!(channel, solver)
+    end
+    return channel
 end
 
 const degeneracy_warning = 16

--- a/src/serializer.jl
+++ b/src/serializer.jl
@@ -55,9 +55,11 @@ call!(s::AppliedSerializer; kw...) = AppliedSerializer(s.parent, call!(s.h; kw..
 hamiltonian(s::AppliedSerializer) = parametric(s.h, s)
 
 # assume s has been applied to h or a copy of h
+minimal_callsafe_copy(s::AppliedSerializer, h) = maybe_relink_serializer(s, h)
+
 maybe_relink_serializer(s::AppliedSerializer, h) =
     s.h === h ? s : AppliedSerializer(s.parent, h, s.ptrs, s.len)
-maybe_relink_serializer(m::AppliedModifier, _) = m
+maybe_relink_serializer(s::AppliedModifier, _) = s
 
 parent_hamiltonian(s::AppliedSerializer) = s.h
 

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -206,6 +206,9 @@ Base.parent(m::StitchModifier) = m.ph
 # copy(StitchModifer) must dealias, since m.groups_dcells_uw can be mutated, e.g. by reverse_bravais!
 Base.copy(m::StitchModifier) = StitchModifier(m.ph, m.wrapped_phases, copy.(m.groups_dcells_uw))
 
+# to make call! threadsafe, we must copy the wrapped m.ph
+minimal_callsafe_copy(m::StitchModifier, _) = StitchModifier(minimal_callsafe_copy(m.ph), m.wrapped_phases, m.groups_dcells_uw)
+
 #endregion
 
 #region ## applymodifier! API

--- a/src/types.jl
+++ b/src/types.jl
@@ -1620,9 +1620,12 @@ lattice(h::ParametricHamiltonian) = lattice(hamiltonian(h))
 # if x´ = minimal_callsafe_copy(x), then a call!(x, ...; ...) will not affect x´ in any way
 function minimal_callsafe_copy(p::ParametricHamiltonian)
     h´ = minimal_callsafe_copy(p.h)
-    modifiers´ = maybe_relink_serializer.(p.modifiers, Ref(h´))
+    modifiers´ = minimal_callsafe_copy.(p.modifiers, Ref(h´))
     return ParametricHamiltonian(p.hparent, h´, modifiers´, p.allptrs, p.allparams)
 end
+
+# some modifiers may need some alias processing to be callsafe. Defaul fallback is a no-op.
+minimal_callsafe_copy(m::AppliedModifier, _) = m
 
 Base.parent(h::ParametricHamiltonian) = h.hparent
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -68,6 +68,9 @@ end
         #     oh = h |> attach(g1, cells = SA[0], reverse = true)
         #     @test bravais_matrix(lattice(h)) == SA[1 0]'
         # end
+    h = @stitch(HP.graphene(), SA[1], ϕ)
+    h´ = Quantica.minimal_callsafe_copy(h)
+    @test h´.modifiers[1].ph !== h.modifiers[1].ph
 end
 
 @testset "hamiltonian orbitals" begin


### PR DESCRIPTION
Moving away from `Threads.@threads :static` in favor of a `Channel`s based approach.

This includes also a dealising fix for `StitchModifier`s. We forgot to do a `minimal_callsafe_copy` of its wrapped Hamiltonian.