### PR TITLE
Allow repeated sublattice names

### DIFF
--- a/docs/src/tutorial/glossary.md
+++ b/docs/src/tutorial/glossary.md
@@ -2,7 +2,7 @@
 
 This is a summary of the type of objects you will be studying.
 
-- **`Sublat`**: a sublattice, representing a number of identical sites within the unit cell of a bounded or unbounded lattice. Each site has a position in an `E`-dimensional space (`E` is called the embedding dimension). All sites in a given `Sublat` will be able to hold the same number of orbitals, and they can be thought of as identical atoms. Each `Sublat` in a `Lattice` can be given a unique name, by default `:A`, `:B`, etc.
+- **`Sublat`**: a sublattice, representing a number of identical sites within the unit cell of a bounded or unbounded lattice. Each site has a position in an `E`-dimensional space (`E` is called the embedding dimension). All sites in a given `Sublat` will be able to hold the same number of orbitals, and they can be thought of as identical atoms. Each `Sublat` in a `Lattice` can be given a name, by default `:A`, `:B`, etc.
 - **`Lattice`**: a collection of `Sublat`s plus a collection of `L` Bravais vectors that define the periodicity of the lattice. A bounded lattice has `L=0`, and no Bravais vectors. A `Lattice` with `L > 0` can be understood as a periodic (unbounded) collection of unit cells, each containing a set of sites, each of which belongs to a different sublattice.
 - **`SiteSelector`**: a rule that defines a subset of sites in a `Lattice` (not necessarily restricted to a single unit cell)
 - `HopSelector`: a rule that defines a subset of site pairs in a `Lattice` (not necessarily restricted to the same unit cell)

--- a/docs/src/tutorial/hamiltonians.md
+++ b/docs/src/tutorial/hamiltonians.md
@@ -242,5 +242,5 @@ The `coupling` keyword, available when combining `h::AbstractHamiltonian`s, is a
 The objects to be combined must satisfy some conditions:
 
 - They must have the same Bravais vectors (modulo reorderings), which will be then inherited by the combined object.
+- Their embedding dimension must be the same
 - They must have the same position type (the `T` in `AbstractHamiltonian{T}` and `Lattice{T}`)
-- They must have no repeated sublattice names among them (unless the combined object is non-parametric)

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -19,7 +19,7 @@ function apply(s::SiteSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T
     intsublats = recursive_apply(name -> sublatindex_or_zero(lat, name), s.sublats)
     sublats = recursive_push!(Int[], intsublats)
     unique!(sort!(sublats))
-    merged_sublats(lat) == I || apply_merged_sublats!(sublats, merged_sublats(lat))
+    equivalent_sublats(lat) == I || apply_equivalent_sublats!(sublats, equivalent_sublats(lat))
     cells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.cells, Val(L)), cellcandidates...)
     # we don't sort cells, in case we have received them as an explicit list
     unique!(cells)
@@ -38,7 +38,7 @@ function apply(s::HopSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T,
     intsublats = recursive_apply(names -> sublatindex_or_zero(lat, names), s.sublats)
     sublats = recursive_push!(Pair{Int,Int}[], intsublats)
     unique!(sublats)
-    merged_sublats(lat) == I || apply_merged_sublats!(sublats, merged_sublats(lat))
+    equivalent_sublats(lat) == I || apply_equivalent_sublats!(sublats, equivalent_sublats(lat))
     dcells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.dcells, Val(L)), cellcandidates...)
     unique!(dcells)
     if s.adjoint
@@ -134,7 +134,7 @@ isnull_selector(_, list) = isempty(list)
 
 # M[i,j] = true if sublats i and j should be assumed to be the same by selectors.
 #  SiteSelector version
-function apply_merged_sublats!(sublats::Vector{Int}, M)
+function apply_equivalent_sublats!(sublats::Vector{Int}, M)
     sbool = in.(axes(M, 1), Ref(sublats))
     sbool´ = M * sbool
     empty!(sublats)
@@ -145,7 +145,7 @@ function apply_merged_sublats!(sublats::Vector{Int}, M)
 end
 
 #  HopSelector version
-function apply_merged_sublats!(sublats::Vector{Pair{Int,Int}}, M)
+function apply_equivalent_sublats!(sublats::Vector{Pair{Int,Int}}, M)
     sbool = ((j,i) -> in(j=>i, sublats)).(axes(M, 2)', axes(M, 1))
     sbool´ = M * sbool * M
     empty!(sublats)

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -18,8 +18,9 @@ function apply(s::SiteSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T
     region = applied_region_site(s.region, s.cells)
     intsublats = recursive_apply(name -> sublatindex_or_zero(lat, name), s.sublats)
     sublats = recursive_push!(Int[], intsublats)
-    cells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.cells, Val(L)), cellcandidates...)
     unique!(sort!(sublats))
+    merged_sublats(lat) == I || apply_merged_sublats!(sublats, merged_sublats(lat))
+    cells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.cells, Val(L)), cellcandidates...)
     # we don't sort cells, in case we have received them as an explicit list
     unique!(cells)
     # isnull: to distinguish in a type-stable way between s.cells === missing and no-selected-cells
@@ -36,8 +37,9 @@ function apply(s::HopSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T,
     region = applied_region_hop(sign, s.region, s.dcells)
     intsublats = recursive_apply(names -> sublatindex_or_zero(lat, names), s.sublats)
     sublats = recursive_push!(Pair{Int,Int}[], intsublats)
-    dcells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.dcells, Val(L)), cellcandidates...)
     unique!(sublats)
+    merged_sublats(lat) == I || apply_merged_sublats!(sublats, merged_sublats(lat))
+    dcells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.dcells, Val(L)), cellcandidates...)
     unique!(dcells)
     if s.adjoint
         sublats .= reverse.(sublats)
@@ -119,7 +121,7 @@ recursive_push!(v::Vector, cells, cellcandidates) =
     intersect!(recursive_push!(v, cells), cellcandidates)
 
 applyrange(ss::Tuple, h::AbstractHamiltonian) = applyrange.(ss, Ref(h))
-applyrange(s::Modifier, h::AbstractHamiltonian) = s
+applyrange(s::AbstractModifier, h::AbstractHamiltonian) = s
 applyrange(s::AppliedHoppingModifier, h::ParametricHamiltonian) =
     AppliedHoppingModifier(s, applyrange(selector(s), lattice(h)))
 applyrange(s::HopSelector, lat::Lattice) = hopselector(s; range = sanitize_minmaxrange(hoprange(s), lat))
@@ -129,6 +131,30 @@ applyrange(r::Real, lat::Lattice) = r
 
 isnull_selector(sel::Union{Missing,Function}, list) = false
 isnull_selector(_, list) = isempty(list)
+
+# M[i,j] = true if sublats i and j should be assumed to be the same by selectors.
+#  SiteSelector version
+function apply_merged_sublats!(sublats::Vector{Int}, M)
+    sbool = in.(axes(M, 1), Ref(sublats))
+    sbool´ = M * sbool
+    empty!(sublats)
+    for (i, s) in enumerate(sbool´)
+        !iszero(s) && push!(sublats, i)
+    end
+    return sublats
+end
+
+#  HopSelector version
+function apply_merged_sublats!(sublats::Vector{Pair{Int,Int}}, M)
+    sbool = ((j,i) -> in(j=>i, sublats)).(axes(M, 2)', axes(M, 1))
+    sbool´ = M * sbool * M
+    empty!(sublats)
+    for j in axes(sbool´, 2), i in axes(sbool´, 1)
+        !iszero(sbool´[i,j]) && push!(sublats, j=>i)
+    end
+    return sublats
+end
+
 
 #endregion
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -16,10 +16,11 @@ apply(s::Union{SiteSelector,HopSelector}, l::LatticeSlice) = apply(s, parent(l),
 
 function apply(s::SiteSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T,E,L}
     region = applied_region_site(s.region, s.cells)
-    # Here we assume names are unique: you can transform names to unique indices, or zero if not found
-    intsublats = recursive_apply(name -> sublatindex_or_zero(lat, name), s.sublats)
+    # Here we just match the first sublattice with a given name.
+    intsublats = recursive_apply(name -> first_sublatindex_or_zero(lat, name), s.sublats)
     sublats = recursive_push!(Int[], intsublats)
     unique!(sort!(sublats))
+    # Now we add equivalent sublattices (i.e. with the same name)
     equivalent_sublats(lat) == I || apply_equivalent_sublats!(sublats, equivalent_sublats(lat))
     cells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.cells, Val(L)), cellcandidates...)
     # we don't sort cells, in case we have received them as an explicit list
@@ -36,9 +37,11 @@ function apply(s::HopSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T,
         throw(ErrorException("Tried to apply an infinite-range HopSelector on an unbounded lattice"))
     sign = ifelse(s.adjoint, -1, 1)
     region = applied_region_hop(sign, s.region, s.dcells)
-    intsublats = recursive_apply(names -> sublatindex_or_zero(lat, names), s.sublats)
+    # Here we just match the first sublattice with a given name.
+    intsublats = recursive_apply(names -> first_sublatindex_or_zero(lat, names), s.sublats)
     sublats = recursive_push!(Pair{Int,Int}[], intsublats)
     unique!(sublats)
+    # Now we add equivalent sublattices (i.e. with the same name)
     equivalent_sublats(lat) == I || apply_equivalent_sublats!(sublats, equivalent_sublats(lat))
     dcells = recursive_push!(SVector{L,Int}[], sanitize_cells(s.dcells, Val(L)), cellcandidates...)
     unique!(dcells)
@@ -52,16 +55,16 @@ function apply(s::HopSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T,
     return AppliedHopSelector{T,E,L}(lat, region, sublats, dcells, (rmin, rmax), includeonsite, isnull)
 end
 
-sublatindex_or_zero(lat, ::Missing) = missing
-sublatindex_or_zero(lat, i::Integer) = ifelse(1 <= i <= nsublats(lat), Int(i), 0)
+first_sublatindex_or_zero(lat, ::Missing) = missing
+first_sublatindex_or_zero(lat, i::Integer) = ifelse(1 <= i <= nsublats(lat), Int(i), 0)
 
-function sublatindex_or_zero(lat, name::Symbol)
-    i = sublatindex_or_nothing(lat, name)
-    return sublatindex_or_zero(i)
+function first_sublatindex_or_zero(lat, name::Symbol)
+    i = first_sublatindex_or_nothing(lat, name)
+    return first_sublatindex_or_zero(i)
 end
 
-sublatindex_or_zero(i::Number) = Int(i)
-sublatindex_or_zero(_) = 0
+first_sublatindex_or_zero(i::Number) = Int(i)
+first_sublatindex_or_zero(_) = 0
 
 sanitize_minmaxrange(r, lat) = sanitize_minmaxrange((zero(numbertype(lat)), r), lat)
 sanitize_minmaxrange((rmin, rmax)::Tuple{Any,Any}, lat) =

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -16,6 +16,7 @@ apply(s::Union{SiteSelector,HopSelector}, l::LatticeSlice) = apply(s, parent(l),
 
 function apply(s::SiteSelector, lat::Lattice{T,E,L}, cellcandidates...) where {T,E,L}
     region = applied_region_site(s.region, s.cells)
+    # Here we assume names are unique: you can transform names to unique indices, or zero if not found
     intsublats = recursive_apply(name -> sublatindex_or_zero(lat, name), s.sublats)
     sublats = recursive_push!(Int[], intsublats)
     unique!(sort!(sublats))

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -424,7 +424,7 @@ translate
 
 If all `lats` have compatible Bravais vectors, combine them into a single lattice.
 If necessary, sublattice names are renamed to remain unique, but when they are, they will be
-marked as merged, so that selectors treat them as the same sublattice.
+marked as equivalent, so that selectors treat them as the same sublattice.
 
     combine(hams::Hamiltonians...; coupling = TighbindingModel())
 
@@ -434,7 +434,7 @@ lattices, and optionally by adding a coupling between them, given by the hopping
 
 Note that the `coupling` model will be applied to the combined lattice. However, only
 hopping terms between different `hams` blocks will be applied. When sublattice are renamed
-in the combined lattice, they will be marked as merged, so that sublattice selectors in
+in the combined lattice, they will be marked as equivalent, so that sublattice selectors in
 `coupling` need not be changed.
 
 ## Limitations

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -423,7 +423,8 @@ translate
     combine(lats::Lattice...)
 
 If all `lats` have compatible Bravais vectors, combine them into a single lattice.
-If necessary, sublattice names are renamed to remain unique.
+If necessary, sublattice names are renamed to remain unique, but when they are, they will be
+marked as merged, so that selectors treat them as the same sublattice.
 
     combine(hams::Hamiltonians...; coupling = TighbindingModel())
 
@@ -431,19 +432,15 @@ Combine a collection `hams` of Hamiltonians into one by combining their correspo
 lattices, and optionally by adding a coupling between them, given by the hopping terms in
 `coupling`.
 
-Note that the `coupling` model will be applied to the combined lattice (which may have
-renamed sublattices to avoid name collissions). However, only hopping terms between
-different `hams` blocks will be applied.
+Note that the `coupling` model will be applied to the combined lattice. However, only
+hopping terms between different `hams` blocks will be applied. When sublattice are renamed
+in the combined lattice, they will be marked as merged, so that sublattice selectors in
+`coupling` need not be changed.
 
 ## Limitations
 
 Currently, `combine` only works with `Lattice{T}` `AbstractHamiltonians{T}` with the same
-`T`. Furthermore, if any of the `hams` is a `ParametricHamiltonian` or `coupling` is a
-`ParametricModel`, the sublattice names of all `hams` must be distinct. This ensures that
-parametric models, which get applied through `Modifiers` after construction of the
-`ParametricHamiltonian`, are not applied to the wrong sublattice, since sublattice names
-could be renamed by `combine` if they are not unique. Therefore, be sure to choose unique
-sublattice names upon construction for all the `hams` to be combined (see `lattice`).
+`T`, with the same lattice dimension and the same embedding dimension.
 
 # Examples
 ```jldoctest

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -119,11 +119,13 @@ corresponding function.
 ExternalPresets
 
 """
-    sublat(sites...; name::Symbol = :A)
-    sublat(sites::AbstractVector; name::Symbol = :A)
+    sublat(sites...; name::Symbol = :unassigned)
+    sublat(sites::AbstractVector; name::Symbol = :unassigned)
 
 Create a `Sublat{E,T}` that adds a sublattice, of name `name`, with sites at positions
 `sites` in `E` dimensional space. Sites positions can be entered as `Tuple`s or `SVector`s.
+If `name == :unassigned`, it will be automatically renamed to a unique name `:A`, `:B`,
+etc. when the sublattice is added to a `Lattice`, see `lattice` for details.
 
 # Examples
 
@@ -133,6 +135,9 @@ Sublat{2,Float64} : sublattice of Float64-typed sites in 2D space
   Sites    : 3
   Name     : :A
 ```
+
+# See also
+    `lattice`
 """
 sublat
 
@@ -166,7 +171,10 @@ bravais_matrix
 
 Create a `Lattice{T,E,L}` from sublattices `sublats`, where `L` is the number of Bravais
 vectors given by `bravais`, `T = type` is the `AbstractFloat` type of spatial site
-coordinates, and `dim = E` is the spatial embedding dimension.
+coordinates, and `dim = E` is the spatial embedding dimension. Sublattice `names` need not
+be unique. Two or more sublattices with the same name will be considered equivalent by
+selectors. However, in `AbstractHamiltonians`, they will correspond to distinct matrix
+blocks.
 
     lattice(lat::Lattice; bravais = missing, dim = missing, type = missing, names = missing)
 
@@ -179,7 +187,7 @@ Return the parent lattice of object `x`, of type e.g. `LatticeSlice`, `Hamiltoni
 ## Keywords
 
 - `bravais`: a collection of one or more Bravais vectors of type NTuple{E} or SVector{E}. It can also be an `AbstractMatrix` of dimension `E×L`. The default `bravais = ()` corresponds to a bounded lattice with no Bravais vectors.
-- `names`: a collection of Symbols. Can be used to rename `sublats`. Any repeated names will be replaced if necessary by `:A`, `:B` etc. to ensure that all sublattice names are unique.
+- `names`: a collection of Symbols. Can be used to rename `sublats`. Any `:unassigned` names will be replaced if necessary by `:A`, `:B` etc.
 
 ## Indexing
 
@@ -423,8 +431,6 @@ translate
     combine(lats::Lattice...)
 
 If all `lats` have compatible Bravais vectors, combine them into a single lattice.
-If necessary, sublattice names are renamed to remain unique, but when they are, they will be
-marked as equivalent, so that selectors treat them as the same sublattice.
 
     combine(hams::Hamiltonians...; coupling = TighbindingModel())
 
@@ -433,9 +439,7 @@ lattices, and optionally by adding a coupling between them, given by the hopping
 `coupling`.
 
 Note that the `coupling` model will be applied to the combined lattice. However, only
-hopping terms between different `hams` blocks will be applied. When sublattice are renamed
-in the combined lattice, they will be marked as equivalent, so that sublattice selectors in
-`coupling` need not be changed.
+hopping terms between different `hams` blocks will be applied.
 
 ## Limitations
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -14,7 +14,7 @@ end
 
 ############################################################################################
 # lattice
-#   Here unitcell_kws = (; merged_sublats = false, reserved_names = ()), that specify how to
+#   Here unitcell_kws = (; merge_sublats = false, reserved_names = ()), that specify how to
 #   deal with repeated sublattice names. See types.jl for details.
 #region
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -14,6 +14,8 @@ end
 
 ############################################################################################
 # lattice
+#   Here unitcell_kws = (; merged_sublats = false, reserved_names = ()), that specify how to
+#   deal with repeated sublattice names. See types.jl for details.
 #region
 
 lattice(s::Sublat, ss::Sublat...; kw...) = _lattice(promote(s, ss...)...; kw...)
@@ -27,25 +29,26 @@ _lattice(ss::Sublat{T,E}...;
     bravais = (),
     dim = Val(E),
     type::Type{T´} = T,
-    names = sublatname.(ss)) where {T,E,T´} =
-    _lattice(ss, bravais, dim, type, names)
+    names = sublatname.(ss), unitcell_kws...) where {T,E,T´} =
+    _lattice(ss, bravais, dim, type, names; unitcell_kws...)
 
 _lattice(ss::AbstractVector{S};
     bravais = (),
     dim = Val(E),
     type::Type{T´} = T,
-    names = sublatname.(ss)) where {T,E,T´,S<:Sublat{T,E}} =
-    _lattice(ss, bravais, dim, type, names)
+    names = sublatname.(ss), unitcell_kws...) where {T,E,T´,S<:Sublat{T,E}} =
+    _lattice(ss, bravais, dim, type, names; unitcell_kws...)
 
-_lattice(ss, bravais, dim, type, names) =
-    Lattice(Bravais(type, dim, bravais), unitcell(ss, names, postype(dim, type)))
+_lattice(ss, bravais, dim, type, names; unitcell_kws...) =
+    Lattice(Bravais(type, dim, bravais), unitcell(ss, names, postype(dim, type); unitcell_kws...))
 
 function lattice(lat::Lattice{T,E};
                  bravais = bravais_matrix(lat),
                  dim = Val(E),
                  type::Type{T´} = T,
-                 names = sublatnames(lat)) where {T,E,T´}
-    u = unitcell(unitcell(lat), names, postype(dim, type))
+                 names = sublatnames(lat),
+                 unitcell_kws...) where {T,E,T´}
+    u = unitcell(unitcell(lat), names, postype(dim, type); unitcell_kws...)
     b = Bravais(type, dim, bravais)
     return Lattice(b, u)
 end
@@ -53,7 +56,7 @@ end
 postype(dim, type) = SVector{dim,type}
 postype(::Val{E}, type) where {E} = SVector{E,type}
 
-function unitcell(sublats, names, postype::Type{S}) where {S<:SVector}
+function unitcell(sublats, names, postype::Type{S}; unitcell_kws...) where {S<:SVector}
     sites´ = S[]
     offsets´ = [0]  # length(offsets) == length(sublats) + 1
     for s in eachindex(sublats)
@@ -62,23 +65,23 @@ function unitcell(sublats, names, postype::Type{S}) where {S<:SVector}
         end
         push!(offsets´, length(sites´))
     end
-    return Unitcell(sites´, names, offsets´)
+    return Unitcell(sites´, names, offsets´; unitcell_kws...)
 end
 
-function unitcell(u::Unitcell{T´,E´}, names, postype::Type{S}) where {T´,E´,S<:SVector}
+function unitcell(u::Unitcell{T´,E´}, names, postype::Type{S}; unitcell_kws...) where {T´,E´,S<:SVector}
     sites´ = sanitize_SVector.(S, sites(u))
     offsets´ = offsets(u)
-    Unitcell(sites´, names, offsets´)
+    Unitcell(sites´, names, offsets´; unitcell_kws...)
 end
 
 # with simple rename, don't copy sites
-unitcell(u::Unitcell{T,E}, names, postype::Type{S})  where {T,E,S<:SVector{E,T}} =
-    Unitcell(sites(u), names, offsets(u))
+unitcell(u::Unitcell{T,E}, names, postype::Type{S}; unitcell_kws...)  where {T,E,S<:SVector{E,T}} =
+    Unitcell(sites(u), names, offsets(u); unitcell_kws...)
 
 #endregion
 
 ############################################################################################
-# combine lattices - combine sublats, rename if equal name
+# combine lattices - combine sublats, rename if equal name but keep merged
 #region
 
 function combine(lats::Lattice{T,E,L}...) where {T,E,L}
@@ -97,7 +100,7 @@ function combine(ucells::Unitcell...)
     names´ = vcat(sublatnames.(ucells)...)
     sites´ = vcat(sites.(ucells)...)
     offsets´ = combined_offsets(offsets.(ucells)...)
-    return Unitcell(sites´, names´, offsets´)
+    return Unitcell(sites´, names´, offsets´; merge_sublats = true)
 end
 
 isapprox_modulo_shuffle() = true

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -2,10 +2,10 @@
 # sublat
 #region
 
-sublat(sites::Union{Number,Tuple,SVector,AbstractVector{<:Number}}...; name = :A) =
+sublat(sites::Union{Number,Tuple,SVector,AbstractVector{<:Number}}...; name = :unassigned) =
     Sublat([float.(promote(sanitize_SVector.(sites)...))...], Symbol(name))
 
-function sublat(sites::AbstractVector; name = :A)
+function sublat(sites::AbstractVector; name = :unassigned)
     T = foldl((x, y) -> promote_type(x, eltype(sanitize_SVector(y))), sites; init = Bool)
     return Sublat(sanitize_SVector.(float(T), sites), Symbol(name))
 end
@@ -14,8 +14,6 @@ end
 
 ############################################################################################
 # lattice
-#   Here unitcell_kws = (; merge_sublats = false, reserved_names = ()), that specify how to
-#   deal with repeated sublattice names. See types.jl for details.
 #region
 
 lattice(s::Sublat, ss::Sublat...; kw...) = _lattice(promote(s, ss...)...; kw...)
@@ -29,26 +27,26 @@ _lattice(ss::Sublat{T,E}...;
     bravais = (),
     dim = Val(E),
     type::Type{T´} = T,
-    names = sublatname.(ss), unitcell_kws...) where {T,E,T´} =
-    _lattice(ss, bravais, dim, type, names; unitcell_kws...)
+    names = sublatname.(ss)) where {T,E,T´} =
+    _lattice(ss, bravais, dim, type, names)
 
 _lattice(ss::AbstractVector{S};
     bravais = (),
     dim = Val(E),
     type::Type{T´} = T,
-    names = sublatname.(ss), unitcell_kws...) where {T,E,T´,S<:Sublat{T,E}} =
-    _lattice(ss, bravais, dim, type, names; unitcell_kws...)
+    names = sublatname.(ss)) where {T,E,T´,S<:Sublat{T,E}} =
+    _lattice(ss, bravais, dim, type, names)
 
-_lattice(ss, bravais, dim, type, names; unitcell_kws...) =
-    Lattice(Bravais(type, dim, bravais), unitcell(ss, names, postype(dim, type); unitcell_kws...))
+_lattice(ss, bravais, dim, type, names) =
+    Lattice(Bravais(type, dim, bravais), unitcell(ss, names, postype(dim, type)))
 
 function lattice(lat::Lattice{T,E};
                  bravais = bravais_matrix(lat),
                  dim = Val(E),
                  type::Type{T´} = T,
                  names = sublatnames(lat),
-                 unitcell_kws...) where {T,E,T´}
-    u = unitcell(unitcell(lat), names, postype(dim, type); unitcell_kws...)
+            ) where {T,E,T´}
+    u = unitcell(unitcell(lat), names, postype(dim, type))
     b = Bravais(type, dim, bravais)
     return Lattice(b, u)
 end
@@ -56,7 +54,7 @@ end
 postype(dim, type) = SVector{dim,type}
 postype(::Val{E}, type) where {E} = SVector{E,type}
 
-function unitcell(sublats, names, postype::Type{S}; unitcell_kws...) where {S<:SVector}
+function unitcell(sublats, names, postype::Type{S}) where {S<:SVector}
     sites´ = S[]
     offsets´ = [0]  # length(offsets) == length(sublats) + 1
     for s in eachindex(sublats)
@@ -65,18 +63,18 @@ function unitcell(sublats, names, postype::Type{S}; unitcell_kws...) where {S<:S
         end
         push!(offsets´, length(sites´))
     end
-    return Unitcell(sites´, names, offsets´; unitcell_kws...)
+    return Unitcell(sites´, names, offsets´)
 end
 
-function unitcell(u::Unitcell{T´,E´}, names, postype::Type{S}; unitcell_kws...) where {T´,E´,S<:SVector}
+function unitcell(u::Unitcell{T´,E´}, names, postype::Type{S}) where {T´,E´,S<:SVector}
     sites´ = sanitize_SVector.(S, sites(u))
     offsets´ = offsets(u)
-    Unitcell(sites´, names, offsets´; unitcell_kws...)
+    Unitcell(sites´, names, offsets´)
 end
 
 # with simple rename, don't copy sites
-unitcell(u::Unitcell{T,E}, names, postype::Type{S}; unitcell_kws...)  where {T,E,S<:SVector{E,T}} =
-    Unitcell(sites(u), names, offsets(u); unitcell_kws...)
+unitcell(u::Unitcell{T,E}, names, postype::Type{S})  where {T,E,S<:SVector{E,T}} =
+    Unitcell(sites(u), names, offsets(u))
 
 #endregion
 
@@ -100,7 +98,7 @@ function combine(ucells::Unitcell...)
     names´ = vcat(sublatnames.(ucells)...)
     sites´ = vcat(sites.(ucells)...)
     offsets´ = combined_offsets(offsets.(ucells)...)
-    return Unitcell(sites´, names´, offsets´; merge_sublats = true)
+    return Unitcell(sites´, names´, offsets´)
 end
 
 isapprox_modulo_shuffle() = true

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -60,7 +60,6 @@ translate!(h::AbstractHamiltonian, δr) = (translate!(lattice(h), δr); h)
 #region
 
 function combine(hams::AbstractHamiltonian...; coupling::AbstractModel=TightbindingModel())
-    check_unique_names(coupling, hams...)
     lat = combine(lattice.(hams)...)
     builder = IJVBuilder(lat, hams...)
     interblockmodel = interblock(coupling, hams...)
@@ -68,21 +67,6 @@ function combine(hams::AbstractHamiltonian...; coupling::AbstractModel=Tightbind
     model´, block´ = parent(interblockmodel), block(interblockmodel)
     add!(builder´, model´, block´)
     return hamiltonian(builder´)
-end
-
-# No need to have unique names if nothing is parametric
-check_unique_names(::TightbindingModel, ::Hamiltonian...) = nothing
-
-function check_unique_names(::AbstractModel, hs::AbstractHamiltonian...)
-    names = tupleflatten(sublatnames.(lattice.(hs))...)
-    allunique(names) || argerror("Cannot combine ParametricHamiltonians with non-unique sublattice names, since modifiers could be tied to the original names. Assign unique names on construction.")
-    return nothing
-end
-
-function check_unique_names(::AbstractModel, hs::Hamiltonian...)
-    names = tupleflatten(sublatnames.(lattice.(hs))...)
-    allunique(names) || argerror("Cannot combine Hamiltonians with non-unique sublattice names using a ParametricModel, since modifiers could be tied to the original names. Assign unique names on construction.")
-    return nothing
 end
 
 maybe_add_modifiers(b, ::ParametricModel) = IJVBuilderWithModifiers(b)

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,21 +7,22 @@ struct Sublat{T<:AbstractFloat,E}
     name::Symbol
 end
 
-#   merged_sublats specifies whether sublattices with repeated names should be consider the
+#   merge_sublats specifies whether sublattices with repeated names should be consider the
 #   same by selectors. reserved_names specifies a list of sublattice names that should not
 #   be used for sublattice renaming.
 struct Unitcell{T<:AbstractFloat,E}
     sites::Vector{SVector{E,T}}
     names::Vector{Symbol}
-    offsets::Vector{Int}            # Linear site number offsets for each sublat
-    merged_sublats::Matrix{Bool}    # merged_sublats[i,j] = true if sublats i and j should be considered the same by selectors
-    function Unitcell{T,E}(sites, names, offsets; merge_sublats = false, reserved_names = ()) where {T<:AbstractFloat,E}
-        names´ = uniquenames!(sanitize_Vector_of_Symbols(names); reserved_names)
-        length(names´) == length(offsets) - 1 ||
-            argerror("Incorrect number of sublattice names, got $(length(names´)), expected $(length(offsets) - 1)")
-        merged_sublats = Matrix{Bool}(I, length(names), length(names))  # no equivalences by default
-        merge_sublats && merge_sublats!(merged_sublats, names)          # record repeated names into merged_sublats
-        return new(sites, names´, offsets, merged_sublats)
+    offsets::Vector{Int}                # Linear site number offsets for each sublat
+    equivalent_sublats::Matrix{Bool}    # equivalent_sublats[i,j] = true if sublats i and j should be considered the same by selectors
+    function Unitcell{T,E}(sites, names_unsanitized, offsets; merge_sublats = false, reserved_names = ()) where {T<:AbstractFloat,E}
+        names = sanitize_Vector_of_Symbols(names_unsanitized)
+        equivalent_sublats = Matrix{Bool}(I, length(names), length(names))  # no equivalences by default
+        merge_sublats && merge_sublats!(equivalent_sublats, names)          # record repeated names into equivalent_sublats
+        uniquenames!(names; reserved_names)
+        length(names) == length(offsets) - 1 ||
+            argerror("Incorrect number of sublattice names, got $(length(names)), expected $(length(offsets) - 1)")
+        return new(sites, names, offsets, equivalent_sublats)
     end
 end
 
@@ -80,20 +81,10 @@ function uniquename(assigned_names, names, i = 1)
     return newname
 end
 
-# Injects M[i,j] = true for i != j if the i, j sublattices had originally the same name.
+# Injects M[i,j] = true if the i, j sublattices had originally the same name.
 function merge_sublats!(M, names)
-    nmerged = 0
-    for j in axes(M, 2)
-        isrepeated = false
-        for i in axes(M, 1)
-            i == j && continue
-            if names[i] == names[j]
-                M[i,j] = true
-                isrepeated = true
-            end
-        end
-        isrepeated && (nmerged += 1)
-    end
+    M .= reshape(names, 1, :) .== names
+    nmerged = count(col -> sum(col) > 1, eachcol(M))
     iszero(nmerged) || @warn "Found $nmerged sublattices with repeated names, which were merged with their duplicates."
     return M
 end
@@ -134,8 +125,8 @@ function sublatindex_or_error(u, s)
     return i
 end
 
-merged_sublats(l::Lattice) = merged_sublats(l.unitcell)
-merged_sublats(u::Unitcell) = u.merged_sublats
+equivalent_sublats(l::Lattice) = equivalent_sublats(l.unitcell)
+equivalent_sublats(u::Unitcell) = u.equivalent_sublats
 
 nsublats(l::Lattice) = nsublats(l.unitcell)
 nsublats(u::Unitcell) = length(u.names)
@@ -206,7 +197,7 @@ Base.copy(b::Bravais{T,E,L}) where {T,E,L} = Bravais{T,E,L}(copy(b.matrix))
 
 function Base.copy(u::Unitcell{T,E}) where {T,E}
     u´ = Unitcell{T,E}(copy(u.sites), copy(u.names), copy(u.offsets))
-    u´.merged_sublats .= u.merged_sublats
+    equivalent_sublats(u´) .= equivalent_sublats(u)
     return u´
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,15 +7,21 @@ struct Sublat{T<:AbstractFloat,E}
     name::Symbol
 end
 
+#   merged_sublats specifies whether sublattices with repeated names should be consider the
+#   same by selectors. reserved_names specifies a list of sublattice names that should not
+#   be used for sublattice renaming.
 struct Unitcell{T<:AbstractFloat,E}
     sites::Vector{SVector{E,T}}
     names::Vector{Symbol}
-    offsets::Vector{Int}        # Linear site number offsets for each sublat
-    function Unitcell{T,E}(sites, names, offsets) where {T<:AbstractFloat,E}
-        names´ = uniquenames!(sanitize_Vector_of_Symbols(names))
+    offsets::Vector{Int}            # Linear site number offsets for each sublat
+    merged_sublats::Matrix{Bool}    # merged_sublats[i,j] = true if sublats i and j should be considered the same by selectors
+    function Unitcell{T,E}(sites, names, offsets; merge_sublats = false, reserved_names = ()) where {T<:AbstractFloat,E}
+        names´ = uniquenames!(sanitize_Vector_of_Symbols(names); reserved_names)
         length(names´) == length(offsets) - 1 ||
             argerror("Incorrect number of sublattice names, got $(length(names´)), expected $(length(offsets) - 1)")
-        return new(sites, names´, offsets)
+        merged_sublats = Matrix{Bool}(I, length(names), length(names))  # no equivalences by default
+        merge_sublats && merge_sublats!(merged_sublats, names)          # record repeated names into merged_sublats
+        return new(sites, names´, offsets, merged_sublats)
     end
 end
 
@@ -51,27 +57,46 @@ Bravais(::Type{T}, ::Val{E}, m::AbstractMatrix) where {T,E} =
 Bravais(::Type{T}, ::Val{E}, m::AbstractVector) where {T,E} =
     Bravais{T,E,1}(sanitize_Matrix(T, E, hcat(m)))
 
-Unitcell(sites::Vector{SVector{E,T}}, names, offsets) where {E,T} =
-    Unitcell{T,E}(sites, names, offsets)
+Unitcell(sites::Vector{SVector{E,T}}, names, offsets; kw...) where {E,T} =
+    Unitcell{T,E}(sites, names, offsets; kw...)
 
-function uniquenames!(names::Vector{Symbol})
-    allnames = Symbol[:_]
+function uniquenames!(names::Vector{Symbol}; reserved_names = ())
+    assigned_names = append!(Symbol[:_], reserved_names)
     for (i, name) in enumerate(names)
-        if name in allnames
-            names[i] = uniquename(allnames, name, i)
+        if name in assigned_names
+            names[i] = uniquename(assigned_names, names, i)
             @warn "Renamed repeated sublattice :$name to :$(names[i])"
         end
-        push!(allnames, names[i])
+        push!(assigned_names, names[i])
     end
     return names
 end
 
-function uniquename(allnames, name, i)
-    newname = Symbol(Char(64+i)) # Lexicographic, starting from Char(65) = 'A'
-    newname = newname in allnames ? uniquename(allnames, name, i + 1) : newname
+# recursively look for the first letter from the i-th, that is not in assigned_names or names
+function uniquename(assigned_names, names, i = 1)
+    newname = Symbol(Char(64+i)) # Lexicographic, starting from Char(65) = 'A' if i = 1
+    newname = newname in assigned_names || newname in names ?
+        uniquename(assigned_names, names, i + 1) : newname
     return newname
 end
 
+# Injects M[i,j] = true for i != j if the i, j sublattices had originally the same name.
+function merge_sublats!(M, names)
+    nmerged = 0
+    for j in axes(M, 2)
+        isrepeated = false
+        for i in axes(M, 1)
+            i == j && continue
+            if names[i] == names[j]
+                M[i,j] = true
+                isrepeated = true
+            end
+        end
+        isrepeated && (nmerged += 1)
+    end
+    iszero(nmerged) || @warn "Found $nmerged sublattices with repeated names, which were merged with their duplicates."
+    return M
+end
 
 #endregion
 
@@ -108,6 +133,9 @@ function sublatindex_or_error(u, s)
     i === nothing && boundserror(u, string(s))
     return i
 end
+
+merged_sublats(l::Lattice) = merged_sublats(l.unitcell)
+merged_sublats(u::Unitcell) = u.merged_sublats
 
 nsublats(l::Lattice) = nsublats(l.unitcell)
 nsublats(u::Unitcell) = length(u.names)
@@ -175,11 +203,16 @@ Base.length(l::Lattice) = nsites(l)
 
 Base.copy(l::Lattice) = Lattice(copy(l.bravais), copy(l.unitcell), copy(l.nranges))
 Base.copy(b::Bravais{T,E,L}) where {T,E,L} = Bravais{T,E,L}(copy(b.matrix))
-Base.copy(u::Unitcell{T,E}) where {T,E} = Unitcell{T,E}(copy(u.sites), copy(u.names), copy(u.offsets))
+
+function Base.copy(u::Unitcell{T,E}) where {T,E}
+    u´ = Unitcell{T,E}(copy(u.sites), copy(u.names), copy(u.offsets))
+    u´.merged_sublats .= u.merged_sublats
+    return u´
+end
 
 Base.:(==)(l::Lattice, l´::Lattice) = l.bravais == l´.bravais && l.unitcell == l´.unitcell
 Base.:(==)(b::Bravais, b´::Bravais) = b.matrix == b´.matrix
-# we do not demand equal names for unitcells to be equal
+# we do not demand equal names for unitcells to be equal, or the same set of merged sublats
 Base.:(==)(u::Unitcell, u´::Unitcell) = u.sites == u´.sites && u.offsets == u´.offsets
 
 #endregion

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,11 +11,12 @@ struct Unitcell{T<:AbstractFloat,E}
     sites::Vector{SVector{E,T}}
     names::Vector{Symbol}
     offsets::Vector{Int}                # Linear site number offsets for each sublat
-    equivalent_sublats::Matrix{Bool}    # equivalent_sublats[i,j] = true if sublats i and j should be considered the same by selectors
+    equivalent_sublats::Matrix{Bool}    # equivalent_sublats[i,j] = true if sublats i and j
+                                        # have the same name (they are equivalent for selectors)
     function Unitcell{T,E}(sites, names_unsanitized, offsets) where {T<:AbstractFloat,E}
         names = sanitize_Vector_of_Symbols(names_unsanitized)
         assign_names!(names)  # give unique names to :unassigned sublats
-        equivalent_sublats = equivalent_sublats_matrix(names)
+        equivalent_sublats = reshape(names, 1, :) .== names
         length(names) == length(offsets) - 1 ||
             argerror("Incorrect number of sublattice names, got $(length(names)), expected $(length(offsets) - 1)")
         return new(sites, names, offsets, equivalent_sublats)
@@ -75,13 +76,6 @@ function uniquename(assigned_names, names, i = 1)
     return newname
 end
 
-# Injects M[i,j] = true if the i, j sublattices had originally the same name.
-function equivalent_sublats_matrix(names)
-    M = reshape(names, 1, :) .== names
-    nmerged = count(col -> sum(col) > 1, eachcol(M))
-    iszero(nmerged) || @warn "Found $nmerged sublattices with repeated names, which will be merged with their duplicates."
-    return M
-end
 
 #endregion
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,19 +7,15 @@ struct Sublat{T<:AbstractFloat,E}
     name::Symbol
 end
 
-#   merge_sublats specifies whether sublattices with repeated names should be consider the
-#   same by selectors. reserved_names specifies a list of sublattice names that should not
-#   be used for sublattice renaming.
 struct Unitcell{T<:AbstractFloat,E}
     sites::Vector{SVector{E,T}}
     names::Vector{Symbol}
     offsets::Vector{Int}                # Linear site number offsets for each sublat
     equivalent_sublats::Matrix{Bool}    # equivalent_sublats[i,j] = true if sublats i and j should be considered the same by selectors
-    function Unitcell{T,E}(sites, names_unsanitized, offsets; merge_sublats = false, reserved_names = ()) where {T<:AbstractFloat,E}
+    function Unitcell{T,E}(sites, names_unsanitized, offsets) where {T<:AbstractFloat,E}
         names = sanitize_Vector_of_Symbols(names_unsanitized)
-        equivalent_sublats = Matrix{Bool}(I, length(names), length(names))  # no equivalences by default
-        merge_sublats && merge_sublats!(equivalent_sublats, names)          # record repeated names into equivalent_sublats
-        uniquenames!(names; reserved_names)
+        assign_names!(names)  # give unique names to :unassigned sublats
+        equivalent_sublats = equivalent_sublats_matrix(names)
         length(names) == length(offsets) - 1 ||
             argerror("Incorrect number of sublattice names, got $(length(names)), expected $(length(offsets) - 1)")
         return new(sites, names, offsets, equivalent_sublats)
@@ -58,16 +54,14 @@ Bravais(::Type{T}, ::Val{E}, m::AbstractMatrix) where {T,E} =
 Bravais(::Type{T}, ::Val{E}, m::AbstractVector) where {T,E} =
     Bravais{T,E,1}(sanitize_Matrix(T, E, hcat(m)))
 
-Unitcell(sites::Vector{SVector{E,T}}, names, offsets; kw...) where {E,T} =
-    Unitcell{T,E}(sites, names, offsets; kw...)
+Unitcell(sites::Vector{SVector{E,T}}, names, offsets) where {E,T} =
+    Unitcell{T,E}(sites, names, offsets)
 
-function uniquenames!(names::Vector{Symbol}; reserved_names = ())
-    assigned_names = append!(Symbol[:_], reserved_names)
+function assign_names!(names::Vector{Symbol})
+    assigned_names = Symbol[:_]
     for (i, name) in enumerate(names)
-        if name in assigned_names
-            names[i] = uniquename(assigned_names, names, i)
-            @warn "Renamed repeated sublattice :$name to :$(names[i])"
-        end
+        name == :unassigned || continue
+        names[i] = uniquename(assigned_names, names, i)
         push!(assigned_names, names[i])
     end
     return names
@@ -82,10 +76,10 @@ function uniquename(assigned_names, names, i = 1)
 end
 
 # Injects M[i,j] = true if the i, j sublattices had originally the same name.
-function merge_sublats!(M, names)
-    M .= reshape(names, 1, :) .== names
+function equivalent_sublats_matrix(names)
+    M = reshape(names, 1, :) .== names
     nmerged = count(col -> sum(col) > 1, eachcol(M))
-    iszero(nmerged) || @warn "Found $nmerged sublattices with repeated names, which were merged with their duplicates."
+    iszero(nmerged) || @warn "Found $nmerged sublattices with repeated names, which will be merged with their duplicates."
     return M
 end
 
@@ -114,13 +108,13 @@ sublatname(l::Lattice, s) = sublatname(l.unitcell, s)
 sublatname(u::Unitcell, s) = u.names[s]
 sublatname(s::Sublat) = s.name
 
-sublatindex_or_nothing(l::Lattice, name::Symbol) = sublatindex_or_nothing(l.unitcell, name)
+first_sublatindex_or_nothing(l::Lattice, name::Symbol) = first_sublatindex_or_nothing(l.unitcell, name)
 
 # May return nothing
-sublatindex_or_nothing(u::Unitcell, name::Symbol) = findfirst(==(name), sublatnames(u))
+first_sublatindex_or_nothing(u::Unitcell, name::Symbol) = findfirst(==(name), sublatnames(u))
 
-function sublatindex_or_error(u, s)
-    i = sublatindex_or_nothing(u, s)
+function first_sublatindex_or_error(u, s)
+    i = first_sublatindex_or_nothing(u, s)
     i === nothing && boundserror(u, string(s))
     return i
 end
@@ -145,14 +139,14 @@ sites(u::Unitcell) = u.sites
 sites(u::Unitcell, sublat) = view(u.sites, siterange(u, sublat))
 sites(u::Unitcell, ::Missing) = sites(u)            # to work with QuanticaMakieExt
 sites(l::Lattice, name::Symbol) = sites(unitcell(l), name)
-sites(u::Unitcell, name::Symbol) = sites(u, sublatindex_or_error(u, name))
+sites(u::Unitcell, name::Symbol) = sites(u, first_sublatindex_or_error(u, name))
 
 site(l::Lattice, i) = sites(l)[i]
 site(l::Lattice, i, dn) = site(l, i) + bravais_matrix(l) * dn
 
 siterange(l::Lattice, sublat...) = siterange(l.unitcell, sublat...)
 siterange(u::Unitcell, sublat::Integer) = (1+u.offsets[sublat]):u.offsets[sublat+1]
-siterange(u::Unitcell, name::Symbol) = siterange(u, sublatindex_or_error(u, name))
+siterange(u::Unitcell, name::Symbol) = siterange(u, first_sublatindex_or_error(u, name))
 siterange(u::Unitcell) = 1:last(u.offsets)
 
 sitesublat(lat::Lattice, siteidx) = sitesublat(lat.unitcell.offsets, siteidx)
@@ -195,11 +189,7 @@ Base.length(l::Lattice) = nsites(l)
 Base.copy(l::Lattice) = Lattice(copy(l.bravais), copy(l.unitcell), copy(l.nranges))
 Base.copy(b::Bravais{T,E,L}) where {T,E,L} = Bravais{T,E,L}(copy(b.matrix))
 
-function Base.copy(u::Unitcell{T,E}) where {T,E}
-    u´ = Unitcell{T,E}(copy(u.sites), copy(u.names), copy(u.offsets))
-    equivalent_sublats(u´) .= equivalent_sublats(u)
-    return u´
-end
+Base.copy(u::Unitcell{T,E}) where {T,E} = Unitcell{T,E}(copy(u.sites), copy(u.names), copy(u.offsets))
 
 Base.:(==)(l::Lattice, l´::Lattice) = l.bravais == l´.bravais && l.unitcell == l´.unitcell
 Base.:(==)(b::Bravais, b´::Bravais) = b.matrix == b´.matrix
@@ -1497,7 +1487,7 @@ flatsize(h::AbstractHamiltonian, args...) = flatsize(blockstructure(h), args...)
 flatrange(h::AbstractHamiltonian, iunflat) = flatrange(blockstructure(h), iunflat)
 
 flatrange(h::AbstractHamiltonian, name::Symbol) =
-    sublatorbrange(blockstructure(h), sublatindex_or_error(lattice(h), name))
+    sublatorbrange(blockstructure(h), first_sublatindex_or_error(lattice(h), name))
 
 zerocell(h::AbstractHamiltonian) = zerocell(lattice(h))
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -529,13 +529,13 @@ end
     @test iszero(h((0,0))[1:2, 5:6])
     h = combine(hb, h0, ht; coupling = hopping((r,dr) -> exp(-norm(dr)), range = 2))
     @test !iszero(h((0,0))[1:2, 5:6])
-    # Parametric combine
+    # Non-unique names
     h1 = LP.linear(dim = 2) |> hopping(1)
     h2 = LP.linear(dim = 2) |> hamiltonian(@hopping((; p = 1) -> p*I), orbitals = 2)
     coupling = @hopping((; p = 1) -> im*p*SA[1 0], range = 3, sublats = :B => :A) |> plusadjoint
-    @test_throws ArgumentError combine(h1, h2)  # non-unique names not allowed with parametric
-    @test_throws ArgumentError combine(h1, h2(); coupling)
-    @test combine(h1, h2()) isa Hamiltonian     # non-unique names allowed with hamiltonian
+    @test combine(h1, h2) isa ParametricHamiltonian  # non-unique names are now allowed with parametric
+    @test combine(h1, h2(); coupling) isa ParametricHamiltonian
+    @test combine(h1, h2()) isa Hamiltonian
     h2 = LP.linear(dim = 2, names = :B) |> hamiltonian(@hopping((; p = 1) -> p*I), orbitals = 2)
     @test combine(h1, h2) isa ParametricHamiltonian{Float64,2,1,Quantica.SMatrixView{2,2,ComplexF64,4}}
     # this `combine` exercises #313, because lattice(h1) + lattice(h2) has smaller neighbor distance than lattice(h2)

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -145,6 +145,10 @@ end
     @test LP.linear()[cells = !iszero, region = RP.circle(1)] |> nsites == 2
     h = LP.linear() |> hopping(1; range = 2, dcells = !iszero) |> @hopping!(t->2t; dcells = [[2],[-2]])
     @test only(h()[1]) == only(h()[-1]) == 1 && only(h()[2]) == only(h()[-2]) == 2
+    # Repeated sublattice names (Issue #398)
+    h = lattice(sublat(0, name = :A), sublat(1, name = :B), sublat(2, name = :A), bravais = SA[3]) |>
+        hopping(I, sublats = :A => :A) - onsite(2, sublats = :A) + onsite(2, sublats = :B)
+    @test h(SA[0]) == SA[-2 0 1; 0 2 0; 1 0 -2]
 end
 
 @testset "models" begin
@@ -564,6 +568,18 @@ end
         @test h[1,2] == h[2,1] == h[3,4] == h[4,3] == ifelse(scalarmodel, 1, 2) * one
         @test h[1,3] == h[3,1] == h[2,4] == h[4,2] == ifelse(scalarcoupling, 1, 10) * one
     end
+    # Sublats with same name (Issue #398)
+    lat0 = LatticePresets.honeycomb(dim = 3)
+    lat = combine(lat0, translate(lat0, SA[0,1,1]/sqrt(3)))
+    @test Quantica.sublatnames(lat) == SA[:A,:B,:A,:B]
+    model = hopping(I, sublats = (:A, :B) .=> (:B,:A))
+    h = lat |> model
+    @test h(SA[0,0]) == SA[0 3 0 0; 3 0 1 0; 0 1 0 3; 0 0 3 0]
+    model = hopping(I, sublats = (:A, :B) .=> (:B,:A), range = 1)
+    h1 = lat |> hamiltonian(model, orbitals = 2)
+    h0 = lat0 |> hamiltonian(model, orbitals = 2)
+    h1´ = combine(h0, translate(h0, SA[0,1,1]/sqrt(3)); coupling = model)
+    @test h1 == h1´
 end
 
 @testset "current operator" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -113,7 +113,7 @@ end
     lat1 = transform(LatticePresets.honeycomb(), r -> SA[r[2], -r[1]]) |> supercell((-1,1), (1,1))
     lat2 = combine(lat0, lat1)
     @test lat2 isa typeof(lat0)
-    @test allunique(Quantica.sublatnames(lat2))
+    @test Quantica.sublatnames(lat2) == SA[:A, :B, :A, :B]
     @test Quantica.equivalent_sublats(lat2) == SA[1 0 1 0; 0 1 0 1; 1 0 1 0; 0 1 0 1]
     lat1 = transform(LatticePresets.honeycomb(), r -> SA[r[2], -r[1]]) |> supercell((-3,3), (1,1))
     @test_throws ArgumentError combine(lat0, lat1)

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -198,4 +198,7 @@ end
     ls = lat[region = RP.circle(4)]
     ls´ = ls[cells = n -> !isreal(n[1])]
     @test isempty(ls´)
+    # repeated sublat names
+    lat = lattice(sublat(0, name = :A), sublat(1, name = :B), sublat(2, name = :A))
+    @test lat[sublats = :A] |> sites |> collect |> length == 2
 end

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -70,6 +70,11 @@ end
     @test bravais_matrix(lat2) == SA[1 2; 3 4]
     # dim/type promotion
     @test lattice(sublat(Float16(0), name = :A), sublat(SA[1,2f0], name = :B)) isa Lattice{Float32,2}
+    # unique name assignment
+    lat = lattice(sublat(0, name = :B), sublat(1), sublat(2, name = :B), sublat(3))
+    @test Quantica.sublatnames(lat) == SA[:B,:C,:B,:D]
+    lat = lattice(sublat(0, name = :C), sublat(1), sublat(2), sublat(3))
+    @test Quantica.sublatnames(lat) == SA[:C,:B,:D,:E]
 end
 
 @testset "lattice presets" begin

--- a/test/test_lattice.jl
+++ b/test/test_lattice.jl
@@ -114,6 +114,7 @@ end
     lat2 = combine(lat0, lat1)
     @test lat2 isa typeof(lat0)
     @test allunique(Quantica.sublatnames(lat2))
+    @test Quantica.equivalent_sublats(lat2) == SA[1 0 1 0; 0 1 0 1; 1 0 1 0; 0 1 0 1]
     lat1 = transform(LatticePresets.honeycomb(), r -> SA[r[2], -r[1]]) |> supercell((-3,3), (1,1))
     @test_throws ArgumentError combine(lat0, lat1)
 end


### PR DESCRIPTION
Closes #398 

For the longest time we have imposed unique names to different sublattices, the only true reason being that each corresponds to a distinct, contiguous block in the Hamiltonians built on the lattice. When building models, we apply selectors that include lattice names. An automatic lattice rename, as those that happen when `combine`ing lattices or Hamiltonians, could introduce silent bugs from models or modifiers that refer to the original names.

The solution taken here is radical: sublattices names are no longer unique. They start as `:unassigned` when not specified, and get resolved to unique names when assembling several sublats into a lattice, but only if the user did not specify a name explicitly (i.e. if their name is :unassigned). If she did, there is no renaming ever. Hence, there can be repetitions. Two sublattices with the same name still remain separate internally (they refer to different matrix blocks in a Hamiltonian for example). But thanks to the fact that selectors get resolved to applied selectors early in the call chain, we just have to adapt `apply` to take into account that a given sublattice name can refer to several sublattices, addressed by their index after `apply` has done its job. To track what sublattices are considered the same, we have a new field in Unitcell called `equivalent_sublats::Matrix{Bool}` which is `true` for any pair of lattice indices with the same name, false otherwise.

This is the proposal summarized in #398, but with `merge_sublats = true` always, and with no unique lattice name at all (none needed after the :unassigned changes).

Practical consequences: when one does `combine(h1, h2; coupling)`, the `coupling` model could refer to the lattice names in `h1` and `h2` even if they are the same (which they often are!). Also, when doing `combine(lat1, lat2) |> model`, we are no longer forced to have distinct names in `lat1` and `lat2`, which can simplify `model` considerably.

