### PR TITLE
Make plot radii (sites and hops) scale with nearest neighbor distance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - windows-latest
           - macOS-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
@@ -39,7 +39,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'

--- a/ext/QuanticaMakieExt/docstrings.jl
+++ b/ext/QuanticaMakieExt/docstrings.jl
@@ -82,9 +82,9 @@ inter-site links, and a representation of contacts.
 - `hopcolor = missing`: color of hops, as a index in `hopcolormap`, a named color, a `Makie.Colorant`, a collection of either, or as a hop shader (see below). If `missing`, cycle through `sitecolormap`. If a collection, cycle through that.
 - `hopcolormap = :Spectral_9`: colormap to use for `hopcolor` (see options in https://tinyurl.com/cschemes, or create your own with ColorSchemes.jl)
 - `hopopacity = missing`: opacity of hops, as a real between 0 and 1, or as a hop shader (see below)
-- `hopradius = 0.1`: if `flat = false` radius of hops as a real number, or as a hop shader (see below)
+- `hopradius = 0.03`: if `flat = false` radius of hops as a real number, or as a hop shader (see below)
 - `hoppixels = 6`: if `flat = true` fixed hop linewidth in pixels, or maximum pixel linewidth if `hopradius` is a shader.
-- `minmaxhopradius = (0, 0.2)`: if `hopdradius` is a shader, minimum and maximum hop radius.
+- `minmaxhopradius = (0, 0.1)`: if `hopdradius` is a shader, minimum and maximum hop radius.
 - `hopdarken = 0.85`: darkening factor for hops
 - `neighborscaling = true`: if `true`, all spatial scales above are multiplied by the nearest-neighbor distance of the lattice before plotting.
 - `selector = missing`: an optional `siteselector(; sites...)` to filter which sites are shown (see `siteselector`)

--- a/ext/QuanticaMakieExt/docstrings.jl
+++ b/ext/QuanticaMakieExt/docstrings.jl
@@ -74,7 +74,7 @@ inter-site links, and a representation of contacts.
 - `sitecolor = missing`: color of sites, as a index in `sitecolormap`, a named color, a `Makie.Colorant`, a collection of either, or as a site shader (see below). If `missing`, cycle through `sitecolormap`. If a collection, cycle through that.
 - `sitecolormap = :Spectral_9`: colormap to use for `sitecolor` (see options in https://tinyurl.com/cschemes, or create your own with ColorSchemes.jl)
 - `siteopacity = missing`: opacity of sites, as a real between 0 and 1, or as a site shader (see below). If `missing`, obey `shellopacity`.
-- `siteradius = 0.25`: radius of sites as a real in units of lattice dimensions, or as a site shader (see below)
+- `siteradius = 0.2`: radius of sites as a real number, or as a site shader (see below)
 - `minmaxsiteradius = (0.0, 0.5)`: if `sitedradius` is a shader, minimum and maximum site radius.
 - `siteoutline = 2`: thickness of the outline around flat sites
 - `siteoutlinedarken = 0.6`: darkening factor of the outline around flat sites
@@ -82,10 +82,11 @@ inter-site links, and a representation of contacts.
 - `hopcolor = missing`: color of hops, as a index in `hopcolormap`, a named color, a `Makie.Colorant`, a collection of either, or as a hop shader (see below). If `missing`, cycle through `sitecolormap`. If a collection, cycle through that.
 - `hopcolormap = :Spectral_9`: colormap to use for `hopcolor` (see options in https://tinyurl.com/cschemes, or create your own with ColorSchemes.jl)
 - `hopopacity = missing`: opacity of hops, as a real between 0 and 1, or as a hop shader (see below)
-- `hopradius = 0.03`: radius of hops as a real number in units of lattice dimensions, or as a hop shader (see below)
+- `hopradius = 0.1`: if `flat = false` radius of hops as a real number, or as a hop shader (see below)
 - `hoppixels = 6`: if `flat = true` fixed hop linewidth in pixels, or maximum pixel linewidth if `hopradius` is a shader.
-- `minmaxhopradius = (0, 0.1)`: if `hopdradius` is a shader, minimum and maximum hop radius.
+- `minmaxhopradius = (0, 0.2)`: if `hopdradius` is a shader, minimum and maximum hop radius.
 - `hopdarken = 0.85`: darkening factor for hops
+- `neighborscaling = true`: if `true`, all spatial scales above are multiplied by the nearest-neighbor distance of the lattice before plotting.
 - `selector = missing`: an optional `siteselector(; sites...)` to filter which sites are shown (see `siteselector`)
 - `hide = (:cell,)`: collection of elements to hide, to choose from `(:hops, :sites, :hops, :bravais, :cell, :axes, :shell, :boundary, :contacts, :all)`. It can also be an empty collection or `nothing` to show all elements.
 - `children = missing`: collection of `NamedTuple`s of any of the above keywords to be applied (cyclically) to contacts in GreenFunction plots

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -464,6 +464,13 @@ function Makie.plot!(plot::PlotLattice{Tuple{H,S,S´}}) where {H<:Hamiltonian,S<
     hidebravais = ishidden((:bravais, :all), plot)
     hideshell = ishidden((:shell, :all), plot) || iszero(Quantica.latdim(h))
 
+    if hidesites && hidehops && hidebravais
+        # An empty recipe (no child plots) causes backends to call draw_atomic on the
+        # recipe itself, which has no method. Add a dummy invisible child to prevent this.
+        linesegments!(plot, Point3f[]; visible = false)
+        return plot
+    end
+
     # plot bravais axes
     if !hidebravais
         plotbravais!(plot, lat, latslice)
@@ -491,8 +498,10 @@ function Makie.plot!(plot::PlotLattice{Tuple{H,S,S´}}) where {H<:Hamiltonian,S<
         else
             joint_colors_radii_update!(hp, hp´, plot)
         end
-        retract_hops!(hp, sp, plot)
-        retract_hops!(hp´, sp, plot)
+        if !hidesites
+            retract_hops!(hp, sp, plot)
+            retract_hops!(hp´, sp, plot)
+        end
     end
 
     # plot hops
@@ -566,8 +575,9 @@ function Makie.plot!(plot::PlotLattice{Tuple{G}}) where {G<:Union{GreenFunction,
             Σplottables = Quantica.selfenergy_plottables(Σ)
             for Σp in Σplottables
                 plottables, kws = get_plottables_and_kws(Σp)
+                hide = (hideΣ..., get(kws, :hide, ()))
                 plottables´ = default_plottable.(plottables; params...)
-                plotlattice!(plot, attr, plottables´...; hide = hideΣ, marker = squaremarker, kws..., Σkw...)
+                plotlattice!(plot, attr, plottables´...; marker = squaremarker, kws..., Σkw..., hide)
             end
         end
     end

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -16,14 +16,15 @@
         minmaxsiteradius = (0.0, 0.5),
         siteradius = 0.2,            # accepts (i, r) -> float, IndexableObservable
         siteradiusfactor = 1.0,      # independent multiplier to apply to siteradius
+        neighborscaling = true,      # if true, all sizes are scaled by the minimum distance to nearest neighbor site
         siteoutline = 2,
         siteoutlinedarken = 0.6,
         sitedarken = 0.0,
         sitecolormap = :Spectral_9,
         hopcolor = missing,          # accepts ((i,j), (r,dr)) -> float, IndexableObservable
         hopopacity = missing,        # accepts ((i,j), (r,dr)) -> float, IndexableObservable
-        minmaxhopradius = (0.0, 0.1),
-        hopradius = 0.01,            # accepts ((i,j), (r,dr)) -> float, IndexableObservable
+        minmaxhopradius = (0.0, 0.2),# when hopradius is a function, range of values to scale to
+        hopradius = 0.1,             # accepts ((i,j), (r,dr)) -> float, IndexableObservable
         hopdarken = 0.85,
         hopcolormap = :Spectral_9,
         hoppixels = 2,
@@ -169,6 +170,8 @@ maybe_getindex(v::AbstractVector{<:Number}, i, j) = 0.5*(v[i] + v[j])
 maybe_getindex(m::AbstractMatrix{<:Number}, i, j) = m[i, j]
 maybe_getindex(v, i, j) = v
 
+default_siteradius(::Missing, ls) = 0.2
+
 ## push! ##
 
 # sitecolor here could be a color, a symbol, a vector/tuple of either, a number, a function, or missing
@@ -305,13 +308,17 @@ update_radii!(p, plot) = update_radii!(p, plot, updated_range!(p.radii))
 function update_radii!(p::SitePrimitives, plot, extremarads)
     siteradius = plot[:siteradius][]
     minmaxsiteradius = plot[:minmaxsiteradius][]
-    return update_radii!(p, extremarads, siteradius, minmaxsiteradius)
+    update_radii!(p, extremarads, siteradius, minmaxsiteradius)
+    maybe_scale_radii_to_neighbors!(p, plot)
+    return p
 end
 
 function update_radii!(p::HoppingPrimitives, plot, extremarads)
     hopradius = plot[:hopradius][]
     minmaxhopradius = plot[:minmaxhopradius][]
-    return update_radii!(p, extremarads, hopradius, minmaxhopradius)
+    update_radii!(p, extremarads, hopradius, minmaxhopradius)
+    !plot[:flat][] && maybe_scale_radii_to_neighbors!(p, plot)
+    return p
 end
 
 function update_radii!(p, extremarads, radius, minmaxradius)
@@ -324,25 +331,26 @@ end
 primitive_radius(normr, radius::Number, minmaxradius) = radius
 primitive_radius(normr, radius, (minr, maxr)) = minr + (maxr - minr) * normr
 
+function maybe_scale_radii_to_neighbors!(p, plot)
+    if plot[:neighborscaling][]
+        lat = lattice(to_value(plot[2]))
+        basescale = Quantica.neighbors(1, lat)
+        p.radii.data .*= basescale
+    end
+    return p
+end
+
+
 ## primitive_scales ##
 
 function primitive_scales(p::HoppingPrimitives, plot)
-    hopradius = plot[:hopradius][]
-    minmaxhopradius = plot[:minmaxhopradius][]
     scales = Vec3f[]
     for (r, v) in zip(p.radii.data, p.vectors)
-        push!(scales, primitive_scale(r, v, hopradius, minmaxhopradius))
+        push!(scales, Vec3f(r, r, norm(v)/2))
     end
     return scales
 end
 
-primitive_scale(normr, v, hopradius::Number, minmaxhopradius) =
-    Vec3f(hopradius, hopradius, norm(v)/2)
-
-function primitive_scale(normr, v, hopradius, (minr, maxr))
-    hopradius´ = minr + (maxr - minr) * normr
-    return Vec3f(hopradius´, hopradius´, norm(v)/2)
-end
 
 ## primitive_segments ##
 
@@ -360,16 +368,17 @@ end
 function primitive_linewidths(p::HoppingPrimitives{E}, plot) where {E}
     hoppixels = plot[:hoppixels][]
     hopradius = plot[:hopradius][]
+    maxhopradius = last(plot[:minmaxhopradius][])
     linewidths = Float32[]
     for r in p.radii.data
-        linewidth = primitive_linewidth(r, hopradius, hoppixels)
+        linewidth = primitive_linewidth(r, hopradius, hoppixels, maxhopradius)
         append!(linewidths, (linewidth, linewidth))
     end
     return linewidths
 end
 
-primitive_linewidth(normr, hopradius::Number, hoppixels) = hoppixels
-primitive_linewidth(normr, hopradius, hoppixels) = hoppixels * normr
+primitive_linewidth(normr, hopradius::Number, hoppixels, maxhopradius) = hoppixels
+primitive_linewidth(normr, hopradius, hoppixels, maxhopradius) = hoppixels * normr/maxhopradius
 
 #endregion
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -147,11 +147,13 @@ function hoppingprimitives!(hp, hp´, ls, ls´, h, opts, siteradii)
                 if i´ === nothing   # dst is not in latslice
                     if haskey(sdict´, csi)  # dst is in latslice´
                         opts´ = maybe_getindex.(opts, j´)
-                        push_hopprimitive!(hp´, opts´, lat, (i, j), (ni, nj), siteradius, view(h, csi, csj), false)
+                        is_shell = false
+                        push_hopprimitive!(hp´, opts´, lat, (i, j), (ni, nj), siteradius, view(h, csi, csj), is_shell)
                     end
                 else
                     opts´ = maybe_getindex.(opts, i´, j´)
-                    push_hopprimitive!(hp, opts´, lat, (i, j), (ni, nj), siteradius, view(h, csi, csj), true)
+                    is_shell = true
+                    push_hopprimitive!(hp, opts´, lat, (i, j), (ni, nj), siteradius, view(h, csi, csj), is_shell)
                 end
             end
         end
@@ -209,23 +211,15 @@ push_sitetooltip!(sp, i, r) = push!(sp.tooltips, positionstring(i, r))
 
 # hopcolor here could be a color, a symbol, a vector/tuple of either, a number, a function, or missing
 function push_hopprimitive!(hp, (hopcolor, hopopacity, shellopacity, hopradius, flat), lat, (i, j), (ni, nj), radius, matij, is_shell)
+    # No hop retraction, that is done at the end with retract_hops!
     src, dst = Quantica.site(lat, j, nj), Quantica.site(lat, i, ni)
-    # First we evaluate hop shaders using uncorrected r, dr
+    dst = is_shell ? (src + dst)/2 : dst
     r, dr = (src + dst)/2, (dst - src)
     sj = Quantica.sitesublat(lat, j)
     push_hophue!(hp, hopcolor, (i, j), (r, dr), sj)
     push_hopopacity!(hp, hopopacity, shellopacity, (i, j), (r, dr), is_shell)
     push_hopradius!(hp, hopradius, (i, j), (r, dr))
     push_hoptooltip!(hp, (i, j), matij)
-    hopradius´ = last(hp.radii.data)  # needed below
-    # Now we determine hop position and size
-    # If end site is opaque (not in outer shell), dst is midpoint, since the inverse hop will be plotted too
-    # otherwise it is shifted by radius´ = radius minus hopradius correction if flat = false, and src also
-    radius´ = flat ? radius : sqrt(max(0, radius^2 - hopradius´^2))
-    unitvec = normalize(dst - src)
-    dst = is_shell ? (src + dst)/2 : dst - unitvec * radius´
-    src = src + unitvec * radius´
-    r, dr = (src + dst)/2, (dst - src)
     push!(hp.centers, r)
     push!(hp.vectors, dr)
     push!(hp.indices, (i, j))
@@ -309,7 +303,7 @@ function update_radii!(p::SitePrimitives, plot, extremarads)
     siteradius = plot[:siteradius][]
     minmaxsiteradius = plot[:minmaxsiteradius][]
     update_radii!(p, extremarads, siteradius, minmaxsiteradius)
-    maybe_scale_radii_to_neighbors!(p, plot)
+    plot[:neighborscaling][] && scale_radii_to_neighbors!(p, plot)
     return p
 end
 
@@ -317,7 +311,7 @@ function update_radii!(p::HoppingPrimitives, plot, extremarads)
     hopradius = plot[:hopradius][]
     minmaxhopradius = plot[:minmaxhopradius][]
     update_radii!(p, extremarads, hopradius, minmaxhopradius)
-    !plot[:flat][] && maybe_scale_radii_to_neighbors!(p, plot)
+    !plot[:flat][] && plot[:neighborscaling][] && scale_radii_to_neighbors!(p, plot)
     return p
 end
 
@@ -328,18 +322,31 @@ function update_radii!(p, extremarads, radius, minmaxradius)
     return p
 end
 
-primitive_radius(normr, radius::Number, minmaxradius) = radius
-primitive_radius(normr, radius, (minr, maxr)) = minr + (maxr - minr) * normr
-
-function maybe_scale_radii_to_neighbors!(p, plot)
-    if plot[:neighborscaling][]
-        lat = lattice(to_value(plot[2]))
-        basescale = Quantica.neighbors(1, lat)
-        p.radii.data .*= basescale
-    end
+function scale_radii_to_neighbors!(p, plot)
+    lat = lattice(to_value(plot[2]))
+    basescale = Quantica.neighbors(1, lat)
+    p.radii.data .*= basescale
     return p
 end
 
+primitive_radius(normr, radius::Number, minmaxradius) = radius
+primitive_radius(normr, radius, (minr, maxr)) = minr + (maxr - minr) * normr
+
+## retract_hops! ##
+
+function retract_hops!(hp::HoppingPrimitives, sp::SitePrimitives)
+    for n in eachindex(hp.vectors)
+        r, dr = hp.centers[n], hp.vectors[n]
+        _, j = hp.indices[n]
+        R, Rj = hp.radii.data[n], sp.radii.data[j]
+        dl = sqrt(Rj^2-R^2) * dr/norm(dr)
+        dr´ = dr - dl
+        r´ = r + 0.5 * dl
+        hp.centers[n] = r´
+        hp.vectors[n] = dr´
+    end
+    return hp
+end
 
 ## primitive_scales ##
 
@@ -350,7 +357,6 @@ function primitive_scales(p::HoppingPrimitives, plot)
     end
     return scales
 end
-
 
 ## primitive_segments ##
 
@@ -483,6 +489,10 @@ function Makie.plot!(plot::PlotLattice{Tuple{H,S,S´}}) where {H<:Hamiltonian,S<
             update_radii!(hp, plot)
         else
             joint_colors_radii_update!(hp, hp´, plot)
+        end
+        if !plot[:flat][]
+            retract_hops!(hp, sp)
+            retract_hops!(hp´, sp)
         end
     end
 

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -464,12 +464,8 @@ function Makie.plot!(plot::PlotLattice{Tuple{H,S,S´}}) where {H<:Hamiltonian,S<
     hidebravais = ishidden((:bravais, :all), plot)
     hideshell = ishidden((:shell, :all), plot) || iszero(Quantica.latdim(h))
 
-    if hidesites && hidehops && hidebravais
-        # An empty recipe (no child plots) causes backends to call draw_atomic on the
-        # recipe itself, which has no method. Add a dummy invisible child to prevent this.
-        linesegments!(plot, Point3f[]; visible = false)
-        return plot
-    end
+    # We put an invisible something in the plot to circunvent a Makie bug that breaks when there are no child plots.
+    linesegments!(plot, Point3f[])
 
     # plot bravais axes
     if !hidebravais

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -23,8 +23,8 @@
         sitecolormap = :Spectral_9,
         hopcolor = missing,          # accepts ((i,j), (r,dr)) -> float, IndexableObservable
         hopopacity = missing,        # accepts ((i,j), (r,dr)) -> float, IndexableObservable
-        minmaxhopradius = (0.0, 0.2),# when hopradius is a function, range of values to scale to
-        hopradius = 0.1,             # accepts ((i,j), (r,dr)) -> float, IndexableObservable
+        minmaxhopradius = (0.0, 0.1),# when hopradius is a function, range of values to scale to
+        hopradius = 0.03,            # accepts ((i,j), (r,dr)) -> float, IndexableObservable
         hopdarken = 0.85,
         hopcolormap = :Spectral_9,
         hoppixels = 2,
@@ -334,11 +334,12 @@ primitive_radius(normr, radius, (minr, maxr)) = minr + (maxr - minr) * normr
 
 ## retract_hops! ##
 
-function retract_hops!(hp::HoppingPrimitives, sp::SitePrimitives)
+function retract_hops!(hp::HoppingPrimitives, sp::SitePrimitives, plot)
     for n in eachindex(hp.vectors)
         r, dr = hp.centers[n], hp.vectors[n]
         _, j = hp.indices[n]
         R, Rj = hp.radii.data[n], sp.radii.data[j]
+        plot[:flat][] && (R = zero(R))
         dl = (Rj>R ? sqrt(Rj^2-R^2) : 0.0) * dr/norm(dr)
         dr´ = dr - dl
         r´ = r + 0.5 * dl
@@ -490,10 +491,8 @@ function Makie.plot!(plot::PlotLattice{Tuple{H,S,S´}}) where {H<:Hamiltonian,S<
         else
             joint_colors_radii_update!(hp, hp´, plot)
         end
-        if !plot[:flat][]
-            retract_hops!(hp, sp)
-            retract_hops!(hp´, sp)
-        end
+        retract_hops!(hp, sp, plot)
+        retract_hops!(hp´, sp, plot)
     end
 
     # plot hops
@@ -714,8 +713,9 @@ function plotbravais!(plot::PlotLattice, lat::Lattice{<:Any,E,L}, latslice) wher
     vtot = sum(vs)
     r0 = Point{E,Float32}(Quantica.mean(Quantica.sites(lat))) - 0.5 * vtot
     if !ishidden(:axes, plot)
+        markerscale = maximum(norm, vs) * 0.2
         for (v, color) in zip(vs, (:red, :green, :blue))
-            arrows3d!(plot, [r0], [v]; color, inspectable = false, markerscale = 1)
+            arrows3d!(plot, [r0], [v]; color, inspectable = false, markerscale)
         end
     end
     if !ishidden((:cell, :cells), plot) && L > 1

--- a/ext/QuanticaMakieExt/plotlattice.jl
+++ b/ext/QuanticaMakieExt/plotlattice.jl
@@ -339,7 +339,7 @@ function retract_hops!(hp::HoppingPrimitives, sp::SitePrimitives)
         r, dr = hp.centers[n], hp.vectors[n]
         _, j = hp.indices[n]
         R, Rj = hp.radii.data[n], sp.radii.data[j]
-        dl = sqrt(Rj^2-R^2) * dr/norm(dr)
+        dl = (Rj>R ? sqrt(Rj^2-R^2) : 0.0) * dr/norm(dr)
         dr´ = dr - dl
         r´ = r + 0.5 * dl
         hp.centers[n] = r´

--- a/ext/QuanticaMakieExt/tools.jl
+++ b/ext/QuanticaMakieExt/tools.jl
@@ -19,6 +19,7 @@ dnshell(::Lattice{<:Any,<:Any,L}, span = -1:1) where {L} =
     sort!(vec(SVector.(Iterators.product(ntuple(_ -> span, Val(L))...))), by = norm)
 
 ishidden(s, plot::Union{PlotLattice,PlotBands}) = ishidden(s, plot[:hide][])
+ishidden(s, t::NamedTuple) = ishidden(s, get(t, :hide, nothing))
 ishidden(s, ::Nothing) = false
 ishidden(s, ::Pair) = false     # for cellsites => function
 ishidden(s::Symbol, hide::Symbol) = s === hide


### PR DESCRIPTION
Closes #397 

With the new `plotlattice` option `neighborscaling = true`, all scales are finally normalized to the nearest neighbor distance, so that the plots do not depend on lattice spacing by default