### PR TITLE
Resolve propagating retarded modes in Schur using velocity

### DIFF
--- a/docs/src/tutorial/greenfunctions.md
+++ b/docs/src/tutorial/greenfunctions.md
@@ -87,7 +87,9 @@ The currently implemented `GreenSolvers` (abbreviated as `GS`) are the following
   For 1D (`L == 1`) and 2D (`L == 2`) AbstractHamiltonians with only nearest-cell coupling along `axis`. Default for `L=1`.
 
   Uses a deflating Generalized Schur (QZ) factorization of the generalized eigenvalue 1D problem along `axis` to compute the unit-cell self energies.
-  The Dyson equation then yields the Green function between arbitrary unit cells, which is further dressed using a T-matrix approach if the lead has any attached self-energy. Wavevector along transverse axes in 2D systes are numerically integrated with the QuadGK package using `integrate_options`.
+  The Dyson equation then yields the Green function between arbitrary unit cells, which is further dressed using a T-matrix approach if the lead has any attached self-energy. Wavevector along transverse axes in 2D systems are numerically integrated with the QuadGK package using `integrate_options`.
+
+  Note: In the 2D case, density of states singularities may lead to non-convergent integrals. If this happens, shift `ω` away from the real axis.
 
 - `GS.Bands(bandsargs...; boundary = missing, bandskw...)`
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1790,6 +1790,7 @@ possible keyword arguments are
 - `GS.Schur(; boundary = Inf, axis = 1, integrate_opts...)` : Solver for 1D and 2D Hamiltonians based on a deflated, generalized Schur factorization and (possibly) integration over the Brillouin zone.
     - `boundary` : 1D cell index of a boundary cell, or `Inf` for no boundaries. Equivalent to removing that specific cell from the lattice when computing the Green function.
     - If the system is 2D, the wavevector along the transverse axis (the one different from the 1D `axis` given in the options) is numerically integrated using QuadGK with options given by `integrate_opts`, which is `(; atol = 1e-7)` by default.
+    - In the 2D case, density of states singularities may lead to non-convergent integrals. If this happens, shift `ω` away from the real axis manually.
     - `integrate_opts` can also contain a `callback = f`, where `f` is a function that will be called `f(ϕs..., y)` at each point in the momentum integration. Here `ϕs` is the integration point in the Brillouin zone and `y` is the integrand evaluated at that point. Useful for inspection and debugging, e.g. `callback(x, y) = @show x`. Default: `Returns(nothing)`.
 - `GS.KPM(; order = 100, bandrange = missing, kernel = I)` : Kernel polynomial method solver for 0D Hamiltonians
     - `order` : order of the expansion in Chebyshev polynomials `Tₙ(h)` of the Hamiltonian `h` (lowest possible order is `n = 0`).

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2108,11 +2108,9 @@ Transmission: total transmission between two different contacts
   From contact  : 1
   To contact    : 2
 
-julia> T(0.2) ≈ 3   # The difference from 3 is due to the automatic `im*sqrt(eps(Float64))` added to `ω`
-false
-
-julia> T(0.2 + 1e-10im) ≈ 3
+julia> T(0.2) ≈ 3
 true
+
 ```
 
 # See also

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -50,7 +50,7 @@ call!(g::G, ω; params...) where {T,G<:Union{GreenFunction{T},GreenSlice{T}}} =
     call!(g, real_or_complex_convert(T, ω); params...)
 
 function call!(g::GreenFunction{T}, ω::T; params...) where {T}
-    ω´ = retarded_omega(ω, solver(g))
+    ω´ = retarded_omega(ω, g)
     return call!(g, ω´; params...)
 end
 
@@ -69,7 +69,7 @@ end
 # real frequency -> maybe complex frequency
 # Σ could be precomputed Σblocks, see above
 call!(g::GreenSlice{T}, ω::T, Σ...; kw...) where {T} =
-    call!(g, retarded_omega(ω, solver(parent(g))), Σ...; kw...)
+    call!(g, retarded_omega(ω, parent(g)), Σ...; kw...)
 
 call!(gs::GreenSlice{T}, ω::Complex{T}, Σ...; post = identity, symmetrize = missing, params...) where {T} =
     getindex!(gs, call!(greenfunction(gs), ω, Σ...; params...); post, symmetrize)
@@ -77,11 +77,18 @@ call!(gs::GreenSlice{T}, ω::Complex{T}, Σ...; post = identity, symmetrize = mi
 real_or_complex_convert(::Type{T}, ω::Real) where {T<:Real} = convert(T, ω)
 real_or_complex_convert(::Type{T}, ω::Complex) where {T<:Real} = convert(Complex{T}, ω)
 
-retarded_omega(ω::T, s::AppliedGreenSolver) where {T<:Real} =
-    ω + im * sqrt(eps(float(T))) * needs_omega_shift(s)
+# The default ω shift is the minimal eps(T) since sqrt(eps(T)) introduces unnecessary errors
+retarded_omega(ω::T, g::GreenFunction) where {T<:Real} =
+    ω + im * eps(float(T)) * needs_omega_shift(g)
 
-# fallback, may be overridden
-needs_omega_shift(s::AppliedGreenSolver) = true
+# omega shift need is also determined by leads if present (cannot assume Σ introduces shift)
+needs_omega_shift(g::GreenFunction) =
+        needs_omega_shift(solver(g)) || any(Σ -> needs_omega_shift(solver(Σ)), selfenergies(g))
+# by default a GreenFunction without self-energies doesn't need a retarded shift.
+# Any solver that needs it should implement needs_omega_shift(::AppliedGreenSolver)
+needs_omega_shift(s::AppliedGreenSolver) = false
+# by default a self-energy already has a retarded shift, no need to add one
+needs_omega_shift(s::AbstractSelfEnergySolver) = false
 
 supports_contacts(s::AppliedGreenSolver) = true
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -77,9 +77,9 @@ real_or_complex_convert(::Type{T}, ω::Real) where {T<:Real} = convert(T, ω)
 real_or_complex_convert(::Type{T}, ω::Complex) where {T<:Real} = convert(Complex{T}, ω)
 
 # The default ω shift is a tiny 4*eps(T) since sqrt(eps(T)) introduces unnecessary errors
-# The reason for the 4 is empirical (Schur becomes able to resolve λ degeneracies with this)
+# The reason for the 5 is empirical (Schur becomes able to resolve λ degeneracies with this)
 retarded_omega(ω::T, g::GreenFunction) where {T<:Real} =
-    ω + im * 4*eps(float(T)) * needs_omega_shift(g)
+    ω + im * 5*eps(float(T)) * needs_omega_shift(g)
 
 # omega shift need is also determined by leads if present (cannot assume Σ introduces shift)
 needs_omega_shift(g::GreenFunction) =

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -65,7 +65,6 @@ function call!(g::GreenFunction{T}, ω::Complex{T}, Σblocks; params...) where {
     return GreenSolution(g, slicer, Σblocks, corbs)
 end
 
-
 # real frequency -> maybe complex frequency
 # Σ could be precomputed Σblocks, see above
 call!(g::GreenSlice{T}, ω::T, Σ...; kw...) where {T} =
@@ -77,20 +76,21 @@ call!(gs::GreenSlice{T}, ω::Complex{T}, Σ...; post = identity, symmetrize = mi
 real_or_complex_convert(::Type{T}, ω::Real) where {T<:Real} = convert(T, ω)
 real_or_complex_convert(::Type{T}, ω::Complex) where {T<:Real} = convert(Complex{T}, ω)
 
-# The default ω shift is the minimal eps(T) since sqrt(eps(T)) introduces unnecessary errors
+# The default ω shift is a tiny 4*eps(T) since sqrt(eps(T)) introduces unnecessary errors
+# The reason for the 4 is empirical (Schur becomes able to resolve λ degeneracies with this)
 retarded_omega(ω::T, g::GreenFunction) where {T<:Real} =
-    ω + im * eps(float(T)) * needs_omega_shift(g)
+    ω + im * 4*eps(float(T)) * needs_omega_shift(g)
 
 # omega shift need is also determined by leads if present (cannot assume Σ introduces shift)
 needs_omega_shift(g::GreenFunction) =
         needs_omega_shift(solver(g)) || any(Σ -> needs_omega_shift(solver(Σ)), selfenergies(g))
 # by default a GreenFunction without self-energies doesn't need a retarded shift.
 # Any solver that needs it should implement needs_omega_shift(::AppliedGreenSolver)
-needs_omega_shift(s::AppliedGreenSolver) = false
+needs_omega_shift(::AppliedGreenSolver) = false
 # by default a self-energy already has a retarded shift, no need to add one
-needs_omega_shift(s::AbstractSelfEnergySolver) = false
+needs_omega_shift(::AbstractSelfEnergySolver) = false
 
-supports_contacts(s::AppliedGreenSolver) = true
+supports_contacts(::AppliedGreenSolver) = true
 
 #endregion
 

--- a/src/greenfunction.jl
+++ b/src/greenfunction.jl
@@ -357,6 +357,8 @@ function call!(g::GreenFunction{T,<:Any,<:Any,<:FixedParamGreenSolver}, ω::Comp
     return call!(s.gfixed, ω; s.params...)  # we pass s.params in case they were not applied (e.g. to contacts)
 end
 
+needs_omega_shift(s::FixedParamGreenSolver) = needs_omega_shift(s.gfixed)
+
 function minimal_callsafe_copy(s::FixedParamGreenSolver, parentham, parentcontacts)
     solver´ = minimal_callsafe_copy(solver(s.gfixed), parentham, parentcontacts)
     gfixed = GreenFunction(parentham, solver´, parentcontacts)

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -287,6 +287,21 @@ biascontact(G) = G.j
 
 function (G::Conductance)(ω; params...)
     τe, τz = G.τezdiag
+    GΓGΓτ, gʳⱼᵢ, Γi = GΓGΓτ_gr_Γ(G, τz, ω; params...)
+    # the -Tr{GʳΓⁱτzGᵃΓʲτₑ} term
+    cond = - real(trace_tau(GΓGΓτ, τe))        # simple trace if τe is missing
+    if G.i == G.j
+        # add the Tr(i(Gʳ-Gᵃ)Γⁱτₑ) term
+        gmg = gʳⱼᵢ
+        gᵃᵢⱼ = gʳⱼᵢ'
+        gmg .-= gᵃᵢⱼ
+        iGmGΓ = mul!(GΓGΓτ, gmg, Γi, im, 0)
+        cond += real(trace_tau(iGmGΓ, τe))      # simple trace if τe is missing
+    end
+    return cond
+end
+
+function GΓGΓτ_gr_Γ(G::Conductance, τ, ω; params...)
     gω = call!(G.g, ω; params...)
     gʳⱼᵢ = gω[G.j, G.i]
     gᵃᵢⱼ = gʳⱼᵢ'
@@ -294,18 +309,9 @@ function (G::Conductance)(ω; params...)
     mul!(G.GrΓi, gʳⱼᵢ, Γi)
     Γj = G.i == G.j ? Γi : selfenergy!(G.Γ, gω, G.j; onlyΓ = true)
     mul!(G.GaΓj, gᵃᵢⱼ, Γj)
-    mul_tau!(G.GrΓi, τz)                        # no-op if τz is missing
+    mul_tau!(G.GrΓi, τ)                        # no-op if τ is missing
     mul!(G.GΓGΓ, G.GrΓi, G.GaΓj)
-    # the -Tr{GʳΓⁱτzGᵃΓʲτₑ} term
-    cond = - real(trace_tau(G.GΓGΓ, τe))        # simple trace if τe is missing
-    if G.i == G.j
-        # add the Tr(i(Gʳ-Gᵃ)Γⁱτₑ) term
-        gmg = gʳⱼᵢ
-        gmg .-= gᵃᵢⱼ
-        iGmGΓ = mul!(G.GΓGΓ, gmg, Γi, im, 0)
-        cond += real(trace_tau(iGmGΓ, τe))      # simple trace if τe is missing
-    end
-    return cond
+    return G.GΓGΓ, gʳⱼᵢ, Γi
 end
 
 #endregion
@@ -334,15 +340,8 @@ Base.parent(t::Transmission) = t.conductance
 
 function (T::Transmission)(ω; params...)
     G = T.conductance
-    gω = call!(G.g, ω; params...)
-    gʳⱼᵢ = gω[G.j, G.i]
-    gᵃᵢⱼ = gʳⱼᵢ'
-    Γi = selfenergy!(G.Γ, gω, G.i; onlyΓ = true)
-    mul!(G.GrΓi, gʳⱼᵢ, Γi)
-    Γj = G.i == G.j ? Γi : selfenergy!(G.Γ, gω, G.j; onlyΓ = true)
-    mul!(G.GaΓj, gᵃᵢⱼ, Γj)
-    mul!(G.GΓGΓ, G.GrΓi, G.GaΓj)
-    t = real(tr(G.GΓGΓ))
+    GΓGΓ, _, _ = GΓGΓτ_gr_Γ(G, missing, ω; params...)
+    t = real(tr(GΓGΓ))
     return t
 end
 

--- a/src/solvers/green/bands.jl
+++ b/src/solvers/green/bands.jl
@@ -621,8 +621,6 @@ end
 # Parent hamiltonian needs to be non-parametric, so no need to alias
 minimal_callsafe_copy(s::AppliedBandsGreenSolver, parentham, parentcontacts) = s
 
-needs_omega_shift(s::AppliedBandsGreenSolver) = false
-
 bands(g::GreenFunction{<:Any,<:Any,<:Any,<:AppliedBandsGreenSolver}) = g.solver.subband
 
 boundaries(s::AppliedBandsGreenSolver{Missing}) =  ()

--- a/src/solvers/green/internal.jl
+++ b/src/solvers/green/internal.jl
@@ -37,8 +37,6 @@ function build_slicer(s::AppliedModelGreenSolver, g, ω::C, Σblocks, contactorb
     return slicer
 end
 
-needs_omega_shift(s::AppliedModelGreenSolver) = false
-
 supports_contacts(s::AppliedModelGreenSolver) = false
 
 minimal_callsafe_copy(s::AppliedModelGreenSolver, args...) = s

--- a/src/solvers/green/kpm.jl
+++ b/src/solvers/green/kpm.jl
@@ -143,8 +143,6 @@ moments(s::AppliedKPMGreenSolver) = s.moments
 # Parent ham needs to be non-parametric, so no need to alias
 minimal_callsafe_copy(s::AppliedKPMGreenSolver, parentham, parentcontacts) = s
 
-needs_omega_shift(s::AppliedKPMGreenSolver) = false
-
 #endregion
 
 #region ## apply ##

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -309,6 +309,7 @@ function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSo
     if !success  # retarded and advanced modes could not be resolved (flat-band-like situation)
         # We hit this when more than two propagating modes with the same λ have vk = 0
         # Need to recompute the pencil and Schur with a larger imag(ω) to break the degeneracy
+        @warn "Retarded and advanced modes could not be resolved at ω = $ω. Recomputing with a larger imag(ω) to break degeneracy."
         imω = iszero(imag(ω)) ? tol : 2*imag(ω)
         ω´ = ω + im * imω
         sch´ = schur_pencil!(s, ω´)
@@ -334,8 +335,6 @@ end
 function classify_retarded_propagating!(whichmodes, V´, nprop)
     for k in 1:nprop
         vk = real(V´[k, k])
-        # deal with flat modes (vk == 0). Only the first with a given λ is marked as retarded.
-        # If there are more than two, we get an imbalance => success == false in caller
         whichmodes[k] = vk > 0
         # Apply rank-1 update if we are not on the last element
         if k < nprop

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -309,8 +309,8 @@ function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSo
     if !success  # retarded and advanced modes could not be resolved (flat-band-like situation)
         # We hit this when more than two propagating modes with the same λ have vk = 0
         # Need to recompute the pencil and Schur with a larger imag(ω) to break the degeneracy
-        @warn "Retarded and advanced modes could not be resolved at ω = $ω. Recomputing with a larger imag(ω) to break degeneracy."
         imω = iszero(imag(ω)) ? tol : 2*imag(ω)
+        # @warn "Retarded and advanced modes could not be resolved at ω = $ω. Recomputing with a larger imag(ω) = $imω to break degeneracy."
         ω´ = ω + im * imω
         sch´ = schur_pencil!(s, ω´)
         return ordschur_retarded!(sch´, s, ω´)  # wipes and recomputes whichmodes at ω´

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -820,6 +820,8 @@ end
 
 #region ## API ##
 
+needs_omega_shift(::AppliedSchurGreenSolver2D) = true
+
 function minimal_callsafe_copy(s::AppliedSchurGreenSolver2D, args...)
     h1D´ = minimal_callsafe_copy(s.h1D)
     solver1D´ = minimal_callsafe_copy(s.solver1D, h1D´, missing)

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -293,7 +293,7 @@ minimal_callsafe_copy(s::SchurWorkspace) =
   - For this to work correctly the propagating eigenvalues should come first.
 =#
 
-function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSolver, ω; tol = sqrt(eps(T))) where {T}
+function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSolver, ω; tol = 4*eps(T)) where {T}
     whichmodes, V´, VZ = s.tmp.whichmodes, s.tmp.V1, s.tmp.V2
     @. whichmodes = abs(sch.β)-tol < abs(sch.α) < abs(sch.β)+tol      # propagating
     if any(whichmodes)                                          # classify propagating modes using velocity
@@ -519,6 +519,8 @@ green_type(::H,::S1,::S2) where {T,E,H<:AbstractHamiltonian{T,E},S1,S2} =
 #endregion
 
 #region ## call API ##
+
+needs_omega_shift(::AppliedSchurGreenSolver) = true
 
 function minimal_callsafe_copy(s::AppliedSchurGreenSolver, parentham, _)
     fsolver´ = minimal_callsafe_copy(s.fsolver, parentham)

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -743,10 +743,13 @@ maybe_SMatrix(G, rows, cols) = G
 ############################################################################################
 # schur_eigvals
 #   computes schur_eigenvalues of all lead modes
+# decay_lengths
+#   compute the decay lengths of evanescent modes
 #region
 
+# We don't add an imaginary part to ω here, as decay lengths depend dramatically on its value.
 schur_eigvals(g::GreenFunctionSchurLead1D, ω::Real; params...) =
-    schur_eigvals(g, retarded_omega(ω, g); params...)
+    schur_eigvals(g, complex(ω); params...)
 
 schur_eigvals(g::GreenFunctionSchurLead1D, ω::Complex; params...) =
     schur_eigvals((parent(g), g.solver), ω; params...)

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -222,7 +222,7 @@ function schur_pencil!(s::SchurFactorsSolver, ω)
     A, B = pencilAB!(s)
     sch = schur!(A, B)
     # disallow zeros in deflated α's or β's for real ω
-    tol = 10*eps(real(typeof(ω)))
+    tol = 5*eps(real(typeof(ω)))
     if iszero(imag(ω)) && (any(x->abs(x)<tol, sch.α) || any(x->abs(x)<tol, sch.β))
         # Schur pencil has zero α or β. Recomputing with imag(ω) = tol to avoid singular pencil
         sch = schur_pencil!(s, ω + im * tol)
@@ -293,7 +293,7 @@ minimal_callsafe_copy(s::SchurWorkspace) =
   - For this to work correctly the propagating eigenvalues should come first.
 =#
 
-function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSolver, ω; tol = 4*eps(T)) where {T}
+function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSolver, ω; tol = 5*eps(T)) where {T}
     whichmodes, V´, VZ = s.tmp.whichmodes, s.tmp.V1, s.tmp.V2
     @. whichmodes = abs(sch.β)-tol < abs(sch.α) < abs(sch.β)+tol      # propagating
     if any(whichmodes)                                          # classify propagating modes using velocity

--- a/src/solvers/green/schur.jl
+++ b/src/solvers/green/schur.jl
@@ -20,7 +20,7 @@
 
 ############################################################################################
 # SchurFactorsSolver - see scattering.pdf notes for derivations
-#   Auxiliary functions for AppliedSchurGreenSolverSolver
+#   Auxiliary functions for AppliedSchurGreenSolver
 #   Computes dense factors PR*R*Z21, Z11 and R'*PR'. The retarded self-energy on the open
 #   unitcell surface of a semi-infinite rightward lead reads Σᵣ = PR R Z21 Z11⁻¹ R' PR'
 #   Computes also the leftward PL*L*Z11´, Z21´, L'*PL', with  Σₗ = PL L Z11´ Z21´⁻¹ L' PL'
@@ -33,6 +33,8 @@ struct SchurWorkspace{C}
     RG::Matrix{C}
     A::Matrix{C}
     B::Matrix{C}
+    V1::Matrix{C}
+    V2::Matrix{C}
     Z11::Matrix{C}
     Z21::Matrix{C}
     Z11´::Matrix{C}
@@ -41,6 +43,7 @@ struct SchurWorkspace{C}
     DL::Matrix{C}
     RD::Matrix{C}
     DR::Matrix{C}
+    whichmodes::Vector{Bool}
 end
 
 struct SchurFactorsSolver{T,B}
@@ -84,6 +87,8 @@ function SchurWorkspace{C}((n, d), l, r) where {C}
     RG = Matrix{C}(undef, d, n)
     A = Matrix{C}(undef, 2d, 2d)
     B = Matrix{C}(undef, 2d, 2d)
+    V1 = Matrix{C}(undef, 2d, 2d)
+    V2 = Matrix{C}(undef, 2d, 2d)
     Z11 = Matrix{C}(undef, d, d)
     Z21 = Matrix{C}(undef, d, d)
     Z11´ = Matrix{C}(undef, d, d)
@@ -92,7 +97,8 @@ function SchurWorkspace{C}((n, d), l, r) where {C}
     DL = Matrix{C}(undef, d, l)
     RD = Matrix{C}(undef, r, d)
     DR = Matrix{C}(undef, d, r)
-    return SchurWorkspace(GL, GR, LG, RG, A, B, Z11, Z21, Z11´, Z21´, LD, DL, RD, DR)
+    whichmodes = Vector{Bool}(undef, 2d)
+    return SchurWorkspace(GL, GR, LG, RG, A, B, V1, V2, Z11, Z21, Z11´, Z21´, LD, DL, RD, DR, whichmodes)
 end
 
 function nearest_cell_harmonics(h)
@@ -176,28 +182,23 @@ call!_output(s::SchurFactorsSolver) =
     (s.tmp.RD, s.tmp.Z11, s.tmp.DR), (s.tmp.LD, s.tmp.Z21´, s.tmp.DL)
 
 function call!(s::SchurFactorsSolver, ω)
-    R, Z11, Z21, L, Z11´, Z21´ = s.R, s.tmp.Z11, s.tmp.Z21, s.L, s.tmp.Z11´, s.tmp.Z21´
+    R, Z11, Z21, L, Z11´, Z21´, whichmodes = s.R, s.tmp.Z11, s.tmp.Z21, s.L, s.tmp.Z11´, s.tmp.Z21´, s.tmp.whichmodes
     update_LR!(s)     # We must update L, R in case a parametric parent has been call!-ed
-    update_iG!(s, ω)  # also iG = ω - h0 + iΩP'P
+    d = size(Z11, 1)
 
-    A, B = pencilAB!(s)
-    sch = schur!(A, B)
-    whichmodes = Vector{Bool}(undef, length(sch.α))
-    r = size(A, 1) ÷ 2
+    sch = schur_pencil!(s, ω)  # we ensure no zeros in deflated α's or β's for real ω
 
-    # Retarded modes
-    retarded_modes!(whichmodes, sch)
+    # Retarded modes. This may need to recompute the pencil and Schur in case of a flat band
+    sch = ordschur_retarded!(sch, s, ω)
     checkmodes(whichmodes)
-    ordschur!(sch, whichmodes)
-    copy!(Z11, view(sch.Z, 1:r, 1:sum(whichmodes)))
-    copy!(Z21, view(sch.Z, r+1:2r, 1:sum(whichmodes)))
+    copy!(Z11, view(sch.Z, 1:d, 1:d))
+    copy!(Z21, view(sch.Z, d+1:2d, 1:d))
 
     # Advanced modes
-    advanced_modes!(whichmodes, sch)
-    checkmodes(whichmodes)
+    whichmodes .= 1:2d .> d   # at this point first half is retarded, second half is advanced
     ordschur!(sch, whichmodes)
-    copy!(Z11´, view(sch.Z, 1:r, 1:sum(whichmodes)))
-    copy!(Z21´, view(sch.Z, r+1:2r, 1:sum(whichmodes)))
+    copy!(Z11´, view(sch.Z, 1:d, 1:d))
+    copy!(Z21´, view(sch.Z, d+1:2d, 1:d))
 
     RZ21, LZ11´, LD, DL, RD, DR = s.tmp.GR, s.tmp.GL, s.tmp.LD, s.tmp.DL, s.tmp.RD, s.tmp.DR
     linds, rinds = s.linds, s.rinds
@@ -210,18 +211,23 @@ function call!(s::SchurFactorsSolver, ω)
     PL_L_Z11´ = copy!(LD, view(LZ11´, linds, :))
     L´_PL = copy!(DL, view(L', :, linds))
 
+    # These are analogous to (V', g⁻¹, V) blocks of an ExtendedSelfEnergySolver
+    # and in fact end up as the output of SelfEnergyCouplingSchurSolver
+    # through call!_output(::SchurFactorsSolver) to be assembled as any other extended Σ
     return (PR_R_Z21, Z11, R´_PR), (PL_L_Z11´, Z21´, L´_PL)
 end
 
-# need this barrier for type-stability (sch.α and sch.β are finicky)
-function retarded_modes!(whichmodes, sch)
-    whichmodes .= abs.(sch.α) .< abs.(sch.β)
-    return whichmodes
-end
-
-function advanced_modes!(whichmodes, sch)
-    whichmodes .= abs.(sch.β) .< abs.(sch.α)
-    return whichmodes
+function schur_pencil!(s::SchurFactorsSolver, ω)
+    update_iG!(s, ω)  # iG = ω - h0 + iΩP'P
+    A, B = pencilAB!(s)
+    sch = schur!(A, B)
+    # disallow zeros in deflated α's or β's for real ω
+    tol = 10*eps(real(typeof(ω)))
+    if iszero(imag(ω)) && (any(x->abs(x)<tol, sch.α) || any(x->abs(x)<tol, sch.β))
+        # Schur pencil has zero α or β. Recomputing with imag(ω) = tol to avoid singular pencil
+        sch = schur_pencil!(s, ω + im * tol)
+    end
+    return sch
 end
 
 checkmodes(whichmodes) = sum(whichmodes) == length(whichmodes) ÷ 2 ||
@@ -238,8 +244,112 @@ function minimal_callsafe_copy(s::SchurFactorsSolver, parentham)
 end
 
 minimal_callsafe_copy(s::SchurWorkspace) =
-    SchurWorkspace(copy.((s.GL, s.GR, s.LG, s.RG, s.A, s.B, s.Z11, s.Z21, s.Z11´, s.Z21´,
-    s.LD, s.DL, s.RD, s.DR))...)
+    SchurWorkspace(copy.((s.GL, s.GR, s.LG, s.RG, s.A, s.B, s.V1, s.V2, s.Z11, s.Z21, s.Z11´, s.Z21´,
+    s.LD, s.DL, s.RD, s.DR, s.whichmodes))...)
+
+## ordschur_retarded!
+#=
+  Unpivoted LDL' Factorization for retarded mode classification
+
+  Computes the signs of the expectation values of a Hermitian operator V
+  (Velocity) evaluated for the propagating eigenstates of a QZ pencil (A - λ B), recording
+  positive values into isretarded::Vector{Bool}. If not propagating, isretarded is simply
+  dictated by the condition |λ| < 1.
+
+  Mathematical Context:
+  Let Φ be the eigenstates of the pencil, which take the form Φ = Z * R,
+  where Z is unitary (from the QZ decomposition) and R is an unknown upper
+  triangular matrix.
+  The expectation values of V for these eigenstates form a diagonal matrix D_ex:
+      D_ex = Φ' * V * Φ
+  Substituting Φ = Z * R yields:
+      D_ex = R' * Z' * V * Z * R
+  Defining V´ = Z' * V * Z and rearranging gives:
+      V´ = (R')^{-1} * D_ex * R^{-1}
+  Because R is upper triangular, L_ex = (R')^{-1} is lower triangular. This
+  forms a lower-diagonal-lower factorization of V´. Factoring out the
+  diagonal of L_ex yields a unit lower triangular matrix L and a diagonal D:
+      V´ = L * D * L'
+  The elements of D differ from D_ex only by strictly positive scaling factors
+  (|1/R_kk|^2). Therefore, the signs of the computed D exactly match the signs
+  of the expectation values D_ex.
+
+  Algorithm:
+  The algorithm iteratively computes the Schur complement. At step k:
+  1. The top-left element of the active submatrix is the pivot vk.
+  2. The sign of vk is use to record retarded modes.
+  3. A rank-1 update is applied to the remaining lower-right submatrix:
+         A_{22} = A_{22} - (v * v') / vk
+     where v is the column vector below vk.
+
+  Key Details:
+  - Unpivoted: Standard LAPACK routines use pivoting for stability, which
+    permutes rows/columns and destroys the eigenvalue ordering established
+    by the QZ decomposition. This custom loop enforces a strict unpivoted
+    factorization to maintain the exact correspondence with Φ.
+  - Memory: The matrix V´ is overwritten in-place. The inner loop
+    iterates over rows to ensure contiguous, column-major memory access
+    and is vectorized via @simd.
+  - For this to work correctly the propagating eigenvalues should come first.
+=#
+
+function ordschur_retarded!(sch::GeneralizedSchur{Complex{T}}, s::SchurFactorsSolver, ω; tol = sqrt(eps(T))) where {T}
+    whichmodes, V´, VZ = s.tmp.whichmodes, s.tmp.V1, s.tmp.V2
+    @. whichmodes = abs(sch.β)-tol < abs(sch.α) < abs(sch.β)+tol      # propagating
+    if any(whichmodes)                                          # classify propagating modes using velocity
+        nprop = sum(whichmodes)
+        ordschur!(sch, whichmodes)
+        V´ = build_velocity!(V´, VZ, sch.Z)
+        @. whichmodes = abs(sch.α) <= abs(sch.β) - tol              # evanescent retarded
+        classify_retarded_propagating!(whichmodes,  V´, nprop) # propagating or evanescent retarded
+    else
+        @. whichmodes = abs(sch.α) <= abs(sch.β) - tol              # evanescent retarded
+    end
+    success = sum(whichmodes) == length(whichmodes)/2
+    if !success  # retarded and advanced modes could not be resolved (flat-band-like situation)
+        # We hit this when more than two propagating modes with the same λ have vk = 0
+        # Need to recompute the pencil and Schur with a larger imag(ω) to break the degeneracy
+        imω = iszero(imag(ω)) ? tol : 2*imag(ω)
+        ω´ = ω + im * imω
+        sch´ = schur_pencil!(s, ω´)
+        return ordschur_retarded!(sch´, s, ω´)  # wipes and recomputes whichmodes at ω´
+    end
+    ordschur!(sch, whichmodes)
+    return sch
+end
+
+# V´ = Z'*V*Z where V = [0 im; -im 0] is a 2dx2d matrix over the deflated space.
+# ordering here is all propagating first, then all evanescent
+function build_velocity!(V´, VZ, Z)
+    d = size(Z, 1) ÷ 2
+    view(VZ, 1:d, :) .= im .* view(Z, d+1:2d, :)
+    view(VZ, d+1:2d, :) .= (-im) .* view(Z, 1:d, :)
+    mul!(V´, Z', VZ)
+    return V´
+end
+
+# use the sign of the D diagonal in LDL' factorization of V´ to classify propagating modes
+# as retarded. Only the top nprop x nprop block of V' is needed. V´ includes all modes
+# whichmodes starts as zero for all nprop states.
+function classify_retarded_propagating!(whichmodes, V´, nprop)
+    for k in 1:nprop
+        vk = real(V´[k, k])
+        # deal with flat modes (vk == 0). Only the first with a given λ is marked as retarded.
+        # If there are more than two, we get an imbalance => success == false in caller
+        whichmodes[k] = vk > 0
+        # Apply rank-1 update if we are not on the last element
+        if k < nprop
+            inv_vk = inv(vk)
+            for j in (k+1):nprop
+                fac = conj(V´[j, k]) * inv_vk
+                @simd for i in j:nprop
+                    V´[i, j] -= V´[i, k] * fac
+                end
+            end
+        end
+    end
+    return whichmodes
+end
 
 ## Pencil A - λB ##
 
@@ -635,7 +745,7 @@ maybe_SMatrix(G, rows, cols) = G
 #region
 
 schur_eigvals(g::GreenFunctionSchurLead1D, ω::Real; params...) =
-    schur_eigvals(g, retarded_omega(ω, solver(g)); params...)
+    schur_eigvals(g, retarded_omega(ω, g); params...)
 
 schur_eigvals(g::GreenFunctionSchurLead1D, ω::Complex; params...) =
     schur_eigvals((parent(g), g.solver), ω; params...)

--- a/src/solvers/green/sparselu.jl
+++ b/src/solvers/green/sparselu.jl
@@ -32,6 +32,8 @@ end
 
 #region ## API ##
 
+needs_omega_shift(s::AppliedSparseLUGreenSolver) = true
+
 inverse_green(s::AppliedSparseLUGreenSolver) = s.invgreen
 
 unitcellinds_contacts(s::SparseLUGreenSlicer) = s.unitcinds

--- a/src/solvers/green/sparselu.jl
+++ b/src/solvers/green/sparselu.jl
@@ -32,7 +32,7 @@ end
 
 #region ## API ##
 
-needs_omega_shift(s::AppliedSparseLUGreenSolver) = true
+needs_omega_shift(::AppliedSparseLUGreenSolver) = true
 
 inverse_green(s::AppliedSparseLUGreenSolver) = s.invgreen
 

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -23,6 +23,8 @@ end
 
 #region ## API ##
 
+needs_omega_shift(s::AppliedSpectrumGreenSolver) = true
+
 # Parent ham needs to be non-parametric, so no need to alias
 minimal_callsafe_copy(s::AppliedSpectrumGreenSolver{<:Spectrum}, parentham, parentcontacts) =
     AppliedSpectrumGreenSolver(s.spectrum)

--- a/src/solvers/green/spectrum.jl
+++ b/src/solvers/green/spectrum.jl
@@ -23,7 +23,7 @@ end
 
 #region ## API ##
 
-needs_omega_shift(s::AppliedSpectrumGreenSolver) = true
+needs_omega_shift(::AppliedSpectrumGreenSolver) = true
 
 # Parent ham needs to be non-parametric, so no need to alias
 minimal_callsafe_copy(s::AppliedSpectrumGreenSolver{<:Spectrum}, parentham, parentcontacts) =

--- a/src/solvers/greensolvers.jl
+++ b/src/solvers/greensolvers.jl
@@ -5,7 +5,7 @@
 #   All new s::AppliedGreenSolver must implement (with Σblock a [possibly nested] tuple of MatrixBlock's)
 #      - build_slicer(s, g::GreenFunction, ω, Σblocks, ::ContactOrbitals; params...) -> GreenSlicer
 #      - minimal_callsafe_copy(s, parentham, parentcontacts)  # injects aliases from parent
-#      - optional: needs_omega_shift(s) (has a `true` default fallback)
+#      - optional: needs_omega_shift(s) (has a `false` default fallback)
 #   A gs::GreenSlicer's allows to compute G[gi, gi´]::AbstractMatrix for indices gi
 #   To do this, it must implement contact slicing (unless it relies on TMatrixSlicer)
 #      - view(gs, ::Int, ::Int) -> g(ω; kw...) between specific contacts (has error fallback)
@@ -39,7 +39,7 @@ struct Schur{T<:AbstractFloat,O<:NamedTuple} <: AbstractGreenSolver
 end
 
 Schur(; shift = 1.0, boundary = Inf, axis = 1, atol = 1e-7, integrate_opts...) =
-    Schur(shift, float(boundary), axis, (; atol, integrate_opts...))
+    Schur(float(shift), float(boundary), axis, (; atol, integrate_opts...))
 
 struct KPM{B<:Union{Missing,NTuple{2}},A} <: AbstractGreenSolver
     order::Int

--- a/src/solvers/selfenergy/generic.jl
+++ b/src/solvers/selfenergy/generic.jl
@@ -64,6 +64,8 @@ end
 
 call!_output(s::SelfEnergyGenericSolver) = s.Σ
 
+needs_omega_shift(s::SelfEnergyGenericSolver) = needs_omega_shift(parent(s.gslice))
+
 function minimal_callsafe_copy(s::SelfEnergyGenericSolver)
     hcoupling´ = minimal_callsafe_copy(s.hcoupling)
     s´ = SelfEnergyGenericSolver(

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -1,5 +1,5 @@
 using Quantica: GreenFunction, GreenSlice, GreenSolution, zerocell, CellOrbitals, ncontacts,
-    solver, Diagonal
+    solver, Diagonal, blockeltype
 
 using ArnoldiMethod  # for KPM bandrange
 using LinearAlgebra
@@ -12,6 +12,7 @@ function testgreen(h, s; kw...)
     @test gω isa GreenSolution
     @test g(0) isa GreenSolution # promote Int to AbstractFloat to add eps
     L = Quantica.latdim(lattice(h))
+    T = real(blockeltype(parent(g)))
     z = zero(SVector{L,Int})
     o = Quantica.unitvector(1, SVector{L,Int})
     conts = ntuple(identity, ncontacts(h))
@@ -23,7 +24,8 @@ function testgreen(h, s; kw...)
         gsω = gs(ω; kw...)
         gωs = gω[loc, loc´]
         @test gsω == gωs
-        loc === loc´ && @test all(x->imag(x)<=0, diag(gωs))
+        # need 10*eps(T) here for cases with 32bit precision and imag(ω) == 0 (Schur)
+        loc === loc´ && @test all(x->imag(x)<=10*eps(T), diag(gωs))
     end
     return nothing
 end
@@ -505,6 +507,13 @@ end
     @test iszero(ρ0)        # rows are on boundary
     @test ρ0[sites(1), sites(SA[1], 1)] isa Matrix
     @test size(view(ρ0, sites(1), sites(SA[1], 1))) == (2, 2)
+
+    # Quantized conductance
+    glead = LP.square() |> hopping(1) |> supercell((1,0), region = r->-2<r[2]<2) |> greenfunction(GS.Schur(boundary = 0));
+    g0 = LP.square() |> hopping(1) |> supercell(region = r->-2<r[2]<2 && r[1]≈0) |> attach(glead, reverse = true) |> attach(glead) |> greenfunction;
+    T = transmission(g0[2, 1])
+    @test T(0) ≈ T(0.2) ≈ 3
+    @test T(1) ≈ 2
 
     glead = LP.square() |> hamiltonian(hopping(1)) |> supercell((0,1), region = r -> -1 <= r[1] <= 1) |> attach(nothing; cells = SA[10]) |> greenfunction(GS.Schur(boundary = 0));
     contact1 = r -> r[1] ≈ 5 && -1 <= r[2] <= 1

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -415,13 +415,12 @@ function testcond(g0; nambu = false)
     @test_throws ArgumentError transmission(g0[1])
     @test_throws ArgumentError transmission(g0[1, 1])
     for ω in -3:0.1:3
-        ωc = ω + im*1e-10
-        @test ifelse(nambu, 6.000001, 3.00000001) >= G1(ωc) >= 0
-        @test G1(ωc) ≈ G1(-ωc) ≈ G2(ωc) ≈ G2(-ωc)
-        @test T12(ωc) ≈ T12(-ωc)
-        nambu || @test G1(ωc) ≈ T12(ωc) atol = 0.000001
-        @test G12(ωc) ≈ G12(-ωc) atol = 0.000001
-        nambu || @test G1(ωc) ≈ -G12(ωc) atol = 0.000001
+        @test ifelse(nambu, 6.000001, 3.00000001) >= G1(ω) >= 0
+        @test G1(ω) ≈ G1(-ω) ≈ G2(ω) ≈ G2(-ω)
+        @test T12(ω) ≈ T12(-ω)
+        nambu || @test G1(ω) ≈ T12(ω) atol = 1e-8
+        @test G12(ω) ≈ G12(-ω) atol = 1e-8
+        nambu || @test G1(ω) ≈ -G12(ω) atol = 1e-8
     end
 end
 
@@ -584,7 +583,8 @@ end
     g = LP.square() |> hopping(1) |> supercell(3,1) |> greenfunction(GS.Schur(; axis = 2, atol = 1e-2, callback))
     ρ = densitymatrix(g[])
     @test iszero(ref[])
-    @test all(x->abs(real(x)) < 1e-4, diag(g(0)[]))
+    # LDOS singularity at ω = 0 has zero real part of g. Needs broadening for integral to converge
+    @test all(x->abs(real(x)) < 1e-4, diag(g(0 + 1e-8im)[]))
     @test !iszero(ref[])
     ref = Ref(0.0)
     @test diag(ρ()) ≈ [0.5,0.5,0.5]

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -514,6 +514,9 @@ end
     T = transmission(g0[2, 1])
     @test T(0) ≈ T(0.2) ≈ 3
     @test T(1) ≈ 2
+    # band-edge effects
+    @test T(1.99999999999) ≈ 2
+    @test T(2.00000000001) ≈ 1
 
     glead = LP.square() |> hamiltonian(hopping(1)) |> supercell((0,1), region = r -> -1 <= r[1] <= 1) |> attach(nothing; cells = SA[10]) |> greenfunction(GS.Schur(boundary = 0));
     contact1 = r -> r[1] ≈ 5 && -1 <= r[2] <= 1

--- a/test/test_greenfunction.jl
+++ b/test/test_greenfunction.jl
@@ -24,8 +24,7 @@ function testgreen(h, s; kw...)
         gsω = gs(ω; kw...)
         gωs = gω[loc, loc´]
         @test gsω == gωs
-        # need 10*eps(T) here for cases with 32bit precision and imag(ω) == 0 (Schur)
-        loc === loc´ && @test all(x->imag(x)<=10*eps(T), diag(gωs))
+        loc === loc´ && @test all(x->imag(x)<=0, diag(gωs))
     end
     return nothing
 end


### PR DESCRIPTION
We make complex frequencies unnecessary to resolve retarded and advanced modes in the Schur Green solver. Instead of shifting propagating eigenvalues away from the |λ| = 1 unit circle, we use group velocity to distinguish them. This is efficient and works as long as velocity does not vanish (in flat bands or band edges). In those edge cases we fall back to an imaginary frequency shift.

~~After this PR, only the `GS.SparseLU` and the `GS.Spectrum` Green solvers require imaginary frequency shifts~~  

EDIT: multiply degenerate λ's, as those in spin-degenerate band edges or highly symmetric degenerate band crossings for example, trigger the imaginary shift path. I realized that if I make the default ω shift of the order of eps(T) instead of sqrt(eps(T)), these degeneracies are resolved with no practical loss of precision, so I changed the shift default and restored `needs_omega_shift(::AppliedSchurGreenSolver) = true` (same for `AppliedSchurGreenSolver2D`). Note that, as before, the shift can be overridden simply using `ω::Complex` on input.

EDIT2: the ω ~ eps(T) shift for Schur is also necessary to compute the Green function, not only the Schur factors, because this involves a sparse LU with the extended self-energy of the lead. If ω is forced to be real, this LU can, on rare occasions, also fail due to a singular G⁻¹(ω). 

EDIT3: to be clear, propagating modes are still being classified using their velocity, since the minimal omega shift is enough to break lambda degeneracies, but not enough to move eigenvalues sufficiently away from the unit circle. That's why the omega shift does not produce a loss of precision.